### PR TITLE
Added lazy service loading mechanism

### DIFF
--- a/src/main/java/org/scijava/Context.java
+++ b/src/main/java/org/scijava/Context.java
@@ -79,6 +79,9 @@ public class Context implements Disposable {
 
 	/** Index of the application context's services. */
 	private final ServiceIndex serviceIndex;
+	
+	/** Helper class for loading services. */
+	private final ServiceHelper serviceHelper;
 
 	/** Master index of all plugins known to the application context. */
 	private final PluginIndex pluginIndex;
@@ -166,8 +169,7 @@ public class Context implements Disposable {
 		pom = POM.getPOM(Context.class, "org.scijava", "scijava-common");
 		manifest = Manifest.getManifest(Context.class);
 
-		final ServiceHelper serviceHelper =
-			new ServiceHelper(this, serviceClasses);
+		serviceHelper = new ServiceHelper(this, serviceClasses);
 		serviceHelper.loadServices();
 	}
 
@@ -244,7 +246,15 @@ public class Context implements Disposable {
 
 	/** Gets the service of the given class. */
 	public <S extends Service> S getService(final Class<S> c) {
-		return serviceIndex.getService(c);
+		S service = serviceIndex.getService(c);
+		
+		if (service == null && serviceHelper != null &&
+		    serviceHelper.canLoadLazy())
+		{
+		  service = serviceHelper.loadService(c);
+		}
+		  
+		return service;
 	}
 
 	/** Gets the service of the given class name (useful for scripts). */

--- a/src/main/java/org/scijava/plugin/Plugin.java
+++ b/src/main/java/org/scijava/plugin/Plugin.java
@@ -163,6 +163,16 @@ public @interface Plugin {
 	 * </p>
 	 */
 	boolean headless() default false;
+	
+	/**
+	 * When true, if this plugin is an {@link org.scijava.service.Service},
+	 * the context will not try to load this service unless explicitly requested.
+	 * <p>
+	 * NB: Annotating a service field the {@link org.scijava.plugin.Parameter}
+	 * annotation will cause that service to be loaded.
+	 * </p>
+	 */
+	boolean lazy() default false;
 
 	/** Defines a function that is called to initialize the plugin in some way. */
 	String initializer() default "";


### PR DESCRIPTION
Adds the capacity to mark services as lazy so they won't be loaded during context construction, but can be loaded on demand later.

To test:

This is easiest to see with a Service implementation that will fail when loaded .. e.g. https://github.com/hinerm/bioformats/blob/scifio-master/components/scifio/src/loci/formats/services/LuraWaveServiceImpl.java .. but any service will work as long as it's not a parameter of another class (as parameters will be loaded before the parent class, regardless of whether they are lazy or not)
1. Verify the service fails or loads as appropriate when "new Context()" is invoked.
2. add "lazy=true" to the service's Plugin annotation
3. repeat (1) and verify there's no error or success message for the service
4. test that context.getService(service.class) causes the same output as before setting lazy to true.
