### PR TITLE
Help SezPoz a little

### DIFF
--- a/src/main/java/org/scijava/plugin/DefaultPluginFinder.java
+++ b/src/main/java/org/scijava/plugin/DefaultPluginFinder.java
@@ -110,7 +110,24 @@ public class DefaultPluginFinder implements PluginFinder {
 
 	private ClassLoader getClassLoader() {
 		if (customClassLoader != null) return customClassLoader;
-		return Thread.currentThread().getContextClassLoader();
+
+		/*
+		 * If not even the current class can be found by the current
+		 * Thread's context class loader, chances are that the plugins
+		 * the caller tries to discover using this plugin finder cannot
+		 * be found, either. Therefore let's use the current class'
+		 * class loader in that case. This is not completely
+		 * fool-proof, but better than nothing.
+		 */
+		final ClassLoader thisLoader = getClass().getClassLoader();
+		final ClassLoader contextLoader =
+			Thread.currentThread().getContextClassLoader();
+		for (ClassLoader loader = contextLoader;
+				loader != null;
+				loader = loader.getParent()) {
+			if (thisLoader == loader) return contextLoader;
+		}
+		return thisLoader;
 	}
 
 }


### PR DESCRIPTION
SezPoz uses the current Thread's context class loader to discover our
plugins. But if the DefaultPluginFinder cannot be loaded by said class
loader, it is safe to assume that SezPoz cannot find the plugins wanted
by the caller, either.

So let's not use the current Thread's context class loader in that case,
but the best we can do in that case: the class loader that found the
DefaultPluginFinder.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
