### PR TITLE
CheckSezpoz enhancements

### DIFF
--- a/src/main/java/org/scijava/util/CheckSezpoz.java
+++ b/src/main/java/org/scijava/util/CheckSezpoz.java
@@ -44,7 +44,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.DigestInputStream;
@@ -532,16 +531,6 @@ public final class CheckSezpoz {
 	}
 
 	/**
-	 * Adjusts the mtime of a file to "now".
-	 * 
-	 * @param file the file to touch
-	 * @throws IOException
-	 */
-	private static void touch(final File file) throws IOException {
-		new FileOutputStream(file, true).close();
-	}
-
-	/**
 	 * Makes sure that the given Eclipse project is set up correctly to run
 	 * SezPoz.
 	 * <p>
@@ -708,19 +697,4 @@ public final class CheckSezpoz {
 		}
 	}
 
-	/**
-	 * Writes plain text into a plain file.
-	 * 
-	 * @param file the plain file
-	 * @param contents the plain text
-	 * @throws IOException
-	 * @throws UnsupportedEncodingException
-	 */
-	private static void write(final File file, final String contents)
-		throws IOException, UnsupportedEncodingException
-	{
-		final OutputStream out = new FileOutputStream(file);
-		out.write(contents.getBytes("UTF-8"));
-		out.close();
-	}
 }


### PR DESCRIPTION
This branch improves the `CheckSezpoz` utility class with a few enhancements. In particular, it writes out the `.settings/org.eclipse.jdt.apt.core.prefs` configuration file to leave off the datestamp comment, and include the `eclipse.preferences.version` key, to match the newest releases of Eclipse.

@dscho: Since you wrote `CheckSezpoz`, could you please review and merge if OK? Thanks!
