### PR TITLE
Asynchronous status reporting - keeps workers from blocking on UI status reporting

### DIFF
--- a/src/main/java/org/scijava/app/DefaultStatusService.java
+++ b/src/main/java/org/scijava/app/DefaultStatusService.java
@@ -62,36 +62,36 @@ public class DefaultStatusService extends AbstractService implements
 
 	@Override
 	public void showProgress(final int value, final int maximum) {
-		eventService.publish(new StatusEvent(value, maximum));
+		publish(new StatusEvent(value, maximum));
 	}
 
 	@Override
 	public void showStatus(final String message) {
-		eventService.publish(new StatusEvent(message));
+		publish(new StatusEvent(message));
 	}
 
 	@Override
 	public void showStatus(final int progress, final int maximum,
 		final String message)
 	{
-		eventService.publish(new StatusEvent(progress, maximum, message));
+		publish(new StatusEvent(progress, maximum, message));
 	}
 
 	@Override
 	public void warn(final String message) {
-		eventService.publish(new StatusEvent(message, true));
+		publish(new StatusEvent(message, true));
 	}
 
 	@Override
 	public void showStatus(final int progress, final int maximum,
 		final String message, final boolean warn)
 	{
-		eventService.publish(new StatusEvent(progress, maximum, message, warn));
+		publish(new StatusEvent(progress, maximum, message, warn));
 	}
 
 	@Override
 	public void clearStatus() {
-		eventService.publish(new StatusEvent(""));
+		publish(new StatusEvent(""));
 	}
 
 	@Override
@@ -101,6 +101,19 @@ public class DefaultStatusService extends AbstractService implements
 		final String message = statusEvent.getStatusMessage();
 		if (!"".equals(message)) return message;
 		return appService.getApp(appName).getInfo(false);
+	}
+	
+	/**
+	 * Publish the status event to the event service.
+	 * The default behavior is to publish status asynchronously.
+	 * You can change this behavior by overriding this method
+	 * in a derived class.
+	 * 
+	 * @param statusEvent the event to send to status listeners.
+	 */
+	protected void publish(final StatusEvent statusEvent)
+	{
+		eventService.publishLater(statusEvent);
 	}
 
 }

--- a/src/test/java/org/scijava/app/DefaultStatusServiceTest.java
+++ b/src/test/java/org/scijava/app/DefaultStatusServiceTest.java
@@ -1,0 +1,151 @@
+package org.scijava.app;
+
+import static org.junit.Assert.*;
+
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.Contextual;
+import org.scijava.app.event.StatusEvent;
+import org.scijava.event.EventHandler;
+import org.scijava.plugin.Parameter;
+
+public class DefaultStatusServiceTest {
+	Context context;
+	StatusListener statusListener;
+	BlockingQueue<StatusEvent> queue;
+	StatusService statusService;
+	class StatusListener implements Contextual {
+		int progress;
+		int maximum;
+		String status;
+		boolean warning;
+		@Parameter
+		StatusService statusService;
+		
+		@Override
+		public Context getContext() {
+			return context;
+		}
+
+		@Override
+		public void setContext(Context context) {
+			context.inject(this);
+		}
+		@EventHandler
+		void eventHandler(StatusEvent e) {
+			try {
+				queue.put(new StatusEvent(
+						e.getProgressValue(),
+						e.getProgressMaximum(),
+						e.getStatusMessage(),
+						e.isWarning()));
+			} catch (InterruptedException e1) {
+				e1.printStackTrace();
+				fail();
+			}
+		}
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		context = new Context();
+		queue = new ArrayBlockingQueue<StatusEvent>(10);
+		statusListener = new StatusListener();
+		statusListener.setContext(context);
+		statusService = statusListener.statusService; 
+	}
+
+	@Test
+	public void testShowProgress() {
+		statusService.showProgress(15, 45);
+		try {
+			final StatusEvent event = queue.poll(10, TimeUnit.SECONDS);
+			assertEquals(event.getProgressValue(), 15);
+			assertEquals(event.getProgressMaximum(), 45);
+			assertFalse(event.isWarning());
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+	@Test
+	public void testShowStatusString() {
+		final String text = "Hello, world";
+		statusService.showStatus(text);
+		try {
+			final StatusEvent event = queue.poll(10, TimeUnit.SECONDS);
+			assertEquals(event.getStatusMessage(), text);
+			assertFalse(event.isWarning());
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+	@Test
+	public void testShowStatusIntIntString() {
+		final String text = "Working...";
+		statusService.showStatus(25, 55, text);
+		try {
+			final StatusEvent event = queue.poll(10, TimeUnit.SECONDS);
+			assertEquals(event.getProgressValue(), 25);
+			assertEquals(event.getProgressMaximum(), 55);
+			assertEquals(event.getStatusMessage(), text);
+			assertFalse(event.isWarning());
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+	@Test
+	public void testWarn() {
+		final String text = "Totally hosed";
+		statusService.warn(text);
+		try {
+			final StatusEvent event = queue.poll(10, TimeUnit.SECONDS);
+			assertEquals(event.getStatusMessage(), text);
+			assertTrue(event.isWarning());
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+	@Test
+	public void testShowStatusIntIntStringBoolean() {
+		final String text = "Working and hosed...";
+		statusService.showStatus(33, 44, text, true);
+		try {
+			final StatusEvent event = queue.poll(10, TimeUnit.SECONDS);
+			assertEquals(event.getStatusMessage(), text);
+			assertEquals(event.getProgressValue(), 33);
+			assertEquals(event.getProgressMaximum(), 44);
+			assertTrue(event.isWarning());
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+	@Test
+	public void testClearStatus() {
+		statusService.clearStatus();
+		try {
+			final StatusEvent event = queue.poll(10, TimeUnit.SECONDS);
+			assertEquals(event.getStatusMessage(), "");
+			assertFalse(event.isWarning());
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+}


### PR DESCRIPTION
Hi all, this is a proposed change that makes the default status service use asynchronous messaging for status events. I experienced a deadlock when a worker thread reported a status after grabbing a lock while the UI thread was repainting. The UI thread blocked when it tried to get the worker thread's locked object and ImageJ deadlocked because the worker thread blocked while waiting for the status event to be handled by the UI thread.

This limits the problem somewhat.
