### PR TITLE
issue #1992 redirect status to log service if threading service has shut down

### DIFF
--- a/src/main/java/org/scijava/app/DefaultStatusService.java
+++ b/src/main/java/org/scijava/app/DefaultStatusService.java
@@ -35,8 +35,11 @@
 
 package org.scijava.app;
 
+import java.util.concurrent.RejectedExecutionException;
+
 import org.scijava.app.event.StatusEvent;
 import org.scijava.event.EventService;
+import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.service.AbstractService;
@@ -57,6 +60,9 @@ public class DefaultStatusService extends AbstractService implements
 
 	@Parameter
 	private AppService appService;
+	
+	@Parameter
+	private LogService logService;
 
 	// -- StatusService methods --
 
@@ -113,7 +119,14 @@ public class DefaultStatusService extends AbstractService implements
 	 */
 	protected void publish(final StatusEvent statusEvent)
 	{
-		eventService.publishLater(statusEvent);
+		try {
+			eventService.publishLater(statusEvent);
+		} catch (RejectedExecutionException e) {
+			// This exception is thrown after the thread service
+			// shuts down and the queue for later operations
+			// is no longer available.
+			logService.info(statusEvent.getStatusMessage());
+		}
 	}
 
 }


### PR DESCRIPTION
This patch catches a RejectedExecutionException that is thrown by the threading service after it has shut down. The StatusService tries to enqueue a status message during shutdown, but the threading service isn't there any more to pass it onto the event thread. I catch the exception and redirect the message to logging - I think that's appropriate at that point since there's no UI to display the status.
