### PR TITLE
Allow filtering instances before they become singletons

### DIFF
--- a/src/main/java/org/scijava/plugin/AbstractSingletonService.java
+++ b/src/main/java/org/scijava/plugin/AbstractSingletonService.java
@@ -99,8 +99,8 @@ public abstract class AbstractSingletonService<PT extends SingletonPlugin>
 
 	private void createInstances() {
 		instances =
-			Collections.unmodifiableList(getPluginService().createInstancesOfType(
-				getPluginType()));
+			Collections.unmodifiableList(filterInstances(getPluginService()
+				.createInstancesOfType(getPluginType())));
 
 		log.info("Found " + instances.size() + " " +
 			getPluginType().getSimpleName() + " plugins.");
@@ -109,6 +109,16 @@ public abstract class AbstractSingletonService<PT extends SingletonPlugin>
 		for (final PT instance : instances) {
 			objectService.addObject(instance);
 		}
+	}
+
+	/**
+	 * Allows subclasses to exclude instances.
+	 * 
+	 * @param list the initial list of instances
+	 * @return the filtered list of instances
+	 */
+	protected List<? extends PT> filterInstances(List<PT> list) {
+		return list;
 	}
 
 }


### PR DESCRIPTION
The DefaultSingletonService used to instantiate all the plugins matching
the given type, but one might want to narrow down what becomes a
singleton even further, e.g. when ImageJ2 is looking for the current
platform: it wants to instantiate all plugins implementing the Platform
class, but then only keep the one that claims that it matches the
current platform.

Therefore, let's introduce the filterInstances(List<PT>) method that
returns the unmodified list of instances by default, but can be
overridden in subclasses.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
