### PR TITLE
Eclipse Helper: stop early when we know it's not Eclipse

### DIFF
--- a/src/main/java/org/scijava/annotations/EclipseHelper.java
+++ b/src/main/java/org/scijava/annotations/EclipseHelper.java
@@ -121,6 +121,10 @@ public class EclipseHelper extends DirectoryIndexer {
 		}
 		EclipseHelper helper = new EclipseHelper();
 		for (final URL url : ((URLClassLoader) loader).getURLs()) {
+			if (url.toString().endsWith("/./")) {
+				// Eclipse never adds "." to the class path
+				break;
+			}
 			helper.maybeIndex(url, loader);
 		}
 	}


### PR DESCRIPTION
Eclipse would never add the current directory to the class path;
therefore, when we detect that the current directory was added as
'.', we can just as well stop annotating indexes right away.

Incidentally, this fixes the tons of warnings when Fiji is started from
the build directory (because it does not try any longer to load classes
such as `src-plugins.fiji-compat.target.classes.fiji.Main`).

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
