### PR TITLE
log-slf4j: adjust to new pom-scijava version

### DIFF
--- a/log-slf4j/.factorypath
+++ b/log-slf4j/.factorypath
@@ -1,3 +1,0 @@
-<factorypath>
-    <factorypathentry kind="VARJAR" id="M2_REPO/net/java/sezpoz/sezpoz/1.9-imagej/sezpoz-1.9-imagej.jar" enabled="true" runInBatchMode="true"/>
-</factorypath>

--- a/log-slf4j/.settings/org.eclipse.jdt.apt.core.prefs
+++ b/log-slf4j/.settings/org.eclipse.jdt.apt.core.prefs
@@ -1,5 +1,0 @@
-#Sun Jan 23 14:27:51 CST 2011
-eclipse.preferences.version=1
-org.eclipse.jdt.apt.aptEnabled=true
-org.eclipse.jdt.apt.genSrcDir=target/classes
-org.eclipse.jdt.apt.reconcileEnabled=false

--- a/log-slf4j/pom.xml
+++ b/log-slf4j/pom.xml
@@ -8,8 +8,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>1.78</version>
-		<relativePath/>
+		<version>1.119</version>
 	</parent>
 
 	<artifactId>scijava-log-slf4j</artifactId>


### PR DESCRIPTION
While at it, mention that the pom-scijava project does not live in a
relative path anymore, and remove all of the SezPoz stuff, too.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
