### PR TITLE
Handle IllegalArgumentException for invalid URLs

### DIFF
--- a/src/main/java/org/scijava/util/AppUtils.java
+++ b/src/main/java/org/scijava/util/AppUtils.java
@@ -130,7 +130,14 @@ public final class AppUtils {
 		final String baseSubdirectory)
 	{
 		final URL location = ClassUtils.getLocation(c);
-		final File baseFile = FileUtils.urlToFile(location);
+		File baseFile;
+		try {
+			baseFile = FileUtils.urlToFile(location);
+		}
+		catch (final IllegalArgumentException exc) {
+			// URL can't be converted to a file.
+			baseFile = null;
+		}
 		return getBaseDirectory(baseFile, baseSubdirectory);
 	}
 


### PR DESCRIPTION
This is particularly useful for jar-in-jar URLs beginning with rsrc:
which cause FileUtils.urlToFile to throw IllegalArgumentException.
