### PR TITLE
Run EclipseHelper more zealously

### DIFF
--- a/src/main/java/org/scijava/annotations/EclipseHelper.java
+++ b/src/main/java/org/scijava/annotations/EclipseHelper.java
@@ -112,7 +112,9 @@ public class EclipseHelper extends DirectoryIndexer {
 	 * @throws IOException
 	 */
 	public static void updateAnnotationIndex(final ClassLoader loader) {
-		if (!(loader instanceof URLClassLoader)) {
+		if (loader == null || loader == ClassLoader.getSystemClassLoader() ||
+			!(loader instanceof URLClassLoader))
+		{
 			return;
 		}
 		EclipseHelper helper = new EclipseHelper();
@@ -123,6 +125,7 @@ public class EclipseHelper extends DirectoryIndexer {
 			}
 			helper.maybeIndex(url, loader);
 		}
+		updateAnnotationIndex(loader.getParent());
 	}
 
 	private void maybeIndex(final URL url, final ClassLoader loader) {


### PR DESCRIPTION
Recursively look through the parents of the current thread's context
class loader, too.

This is important for tests relating to ij1-patcher because it creates
new class loader hierarchies.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
