### PR TITLE
Work around problem with Batik on the class path

### DIFF
--- a/src/main/java/org/scijava/util/XML.java
+++ b/src/main/java/org/scijava/util/XML.java
@@ -144,6 +144,9 @@ public class XML {
 		catch (final XPathExpressionException e) {
 			return null;
 		}
+		catch (NoSuchMethodError e) {
+			// ignore; Some batik version bundle obsolete xalan...
+		}
 		return (NodeList) result;
 	}
 


### PR DESCRIPTION
Batik unfortunately bundles xalan inside the .jar. As if this was not bad
enough, it does so with a real old version, one that is incompatible with
xalan we use. The symptom is a NoSuchMethodError stating that
org.apache.xpath.XPathContext.<init>(Z)V could not be found.

Let's work around that issue by simply ignoring it and continue on the
assumption that we cannot extract anything from the XML.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
