### PR TITLE
Clarify docs for canConvert(Object, Class)

### DIFF
--- a/src/main/java/org/scijava/util/ConversionUtils.java
+++ b/src/main/java/org/scijava/util/ConversionUtils.java
@@ -257,7 +257,7 @@ public class ConversionUtils {
 	}
 
 	/**
-	 * Checks whether the given object can be converted to the specified type.
+	 * Checks whether the given object's type can be converted to the specified type.
 	 * 
 	 * @see #convert(Object, Class)
 	 */


### PR DESCRIPTION
It was misleading the way it was because I could return true from
canConvert("5.1", int.class) but would get an exception when I actually
tried convert("5.1", int.class). The documentation led me to believe
the check would catch this scenario when it is actually a convenience
method that uses canConvert(Class, Class)
