### PR TITLE
DirectoryIndexer: Handle SecurityException

### DIFF
--- a/src/main/java/org/scijava/annotations/DirectoryIndexer.java
+++ b/src/main/java/org/scijava/annotations/DirectoryIndexer.java
@@ -97,6 +97,9 @@ public class DirectoryIndexer extends AbstractIndexWriter {
 							+ e.getMessage() + "); skipping");
 				} catch (ClassNotFoundException e) {
 					System.err.println("Warning: could not load class '" + className + "'; skipping");
+				} catch (Throwable e){
+					System.err.println("Warning: could not load class '" + className + "' ("
+							+ e.getMessage() + "); skipping");
 				}
 			}
 		}


### PR DESCRIPTION
Hi there,

@dscho, thanks for the help again! I will test it on Windows these days. On Linux it works, with your example. Anyway: If I want to use the builder in my Eclipse-OSGi Plugin I get the following exception:

Exception in thread "main" java.lang.SecurityException: class "org.eclipse.swt.browser.BrowserInitializer"'s signer information does not match signer information of other classes in the same package

I think this exception occurs, as we try to load another eclipse plugin outside the eclipse enviroment (plugins are signed, but not the classes). If I catch the SecurityException (which is thrown in line 91 in the DirectoryIndexer), and simply skip the classes, it works just fine.

---

This commit skips classes which can't be loaded due to a SecurityException during
the annotation pre-processing using the Eclipse Helper. Reason: Not all
classes of a eclipse-plugin can't be loaded outside the eclipse-enviroment,
i.e. from a "normal" java program. If you try to load them during
annoation-preprocessing using the EclipseHelper, the SecurityException
is thrown.
