### PR TITLE
CommandInfo: Avoid loading delegate classes in incompatible  loaders

### DIFF
--- a/src/main/java/org/scijava/module/AbstractModuleItem.java
+++ b/src/main/java/org/scijava/module/AbstractModuleItem.java
@@ -35,6 +35,8 @@ import java.lang.reflect.Type;
 import java.util.List;
 
 import org.scijava.AbstractBasicDetails;
+import org.scijava.Instantiable;
+import org.scijava.InstantiableException;
 import org.scijava.ItemIO;
 import org.scijava.ItemVisibility;
 import org.scijava.util.ClassUtils;
@@ -266,6 +268,11 @@ public abstract class AbstractModuleItem<T> extends AbstractBasicDetails
 	// -- Internal methods --
 
 	protected Class<?> getDelegateClass() {
+		if (info instanceof Instantiable) try {
+			return ((Instantiable<?>) info).loadClass();
+		} catch (final InstantiableException e) {
+			throw new RuntimeException(e);
+		}
 		return ClassUtils.loadClass(info.getDelegateClassName());
 	}
 


### PR DESCRIPTION
Some PluginInfo instances implement the Instantiable interface. These
instances should be allowed to return the delegate classes in their
favorite form.

A symptom of loading the delegate class in an incompatible class loader
is that gentyref's getExactFieldType() claims that a field is not a
member of its declaring class.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
