### PR TITLE
Only warn about duplicate menu entries if priorities are equal

### DIFF
--- a/src/main/java/org/scijava/menu/ShadowMenu.java
+++ b/src/main/java/org/scijava/menu/ShadowMenu.java
@@ -530,8 +530,15 @@ public class ShadowMenu extends AbstractContextual implements
 		if (!leaf) child.addChild(info, depth + 1);
 		else if (existingChild != null) {
 			if (log != null) {
-				log.warn("ShadowMenu: menu item already exists:\n\texisting: " +
-					existingChild.getModuleInfo() + "\n\t ignored: " + info);
+				if (info.getPriority() == existingChild.getModuleInfo().getPriority()) {
+					log.warn("ShadowMenu: menu item already exists:\n\texisting: " +
+						existingChild.getModuleInfo() + "\n\t ignored: " + info);
+				}
+				else {
+					log.debug("ShadowMenu: higher-priority menu item already exists:\n" +
+						"\texisting: " + existingChild.getModuleInfo() + "\n\t ignored: " +
+						info);
+				}
 			}
 		}
 		return child;


### PR DESCRIPTION
When we try to add menu items with the same path and their priorities
differ, we should not complain (the higher-priority one was already
added in that case, so we do not have to replace any existing item).

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
