### PR TITLE
Publish a dedicated event just before disposing the context

### DIFF
--- a/src/main/java/org/scijava/Context.java
+++ b/src/main/java/org/scijava/Context.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.scijava.event.ContextDisposingEvent;
 import org.scijava.event.EventHandler;
 import org.scijava.event.EventService;
 import org.scijava.plugin.Parameter;
@@ -309,6 +310,9 @@ public class Context implements Disposable {
 
 	@Override
 	public void dispose() {
+		final EventService eventService = getService(EventService.class);
+		if (eventService != null) eventService.publish(new ContextDisposingEvent());
+
 		// NB: Dispose services in reverse order.
 		// This may or may not actually be necessary, but seems safer, since
 		// dependent services will be disposed *before* their dependencies.

--- a/src/main/java/org/scijava/event/ContextDisposingEvent.java
+++ b/src/main/java/org/scijava/event/ContextDisposingEvent.java
@@ -1,0 +1,39 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2014 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.event;
+
+/**
+ * Event to be published just before disposing a context.
+ * 
+ * @author Johannes Schindein
+ */
+public class ContextDisposingEvent extends SciJavaEvent { }


### PR DESCRIPTION
This is needed for example for GUIs which want to dispose of their
windows before the context goes away.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
