### PR TITLE
Show the welcome message only once

### DIFF
--- a/src/main/java/org/scijava/welcome/DefaultWelcomeService.java
+++ b/src/main/java/org/scijava/welcome/DefaultWelcomeService.java
@@ -134,6 +134,8 @@ public class DefaultWelcomeService extends AbstractService implements
 		return "firstRun-" + appService.getApp().getVersion();
 	}
 
+	// TODO: move this into TextUtils or some such
+	// see https://github.com/scijava/scijava-common/issues/82
 	// get digest of the file as according to fullPath
 	private String getChecksum(final String text)
 	{


### PR DESCRIPTION
As discussed in imagej/imagej-legacy#38.

We will most likely want to change the particulars of the change, e.g. use a constant for the preference key, and maybe even factor out a `ChecksumService`. But this PR is intended to start the discussion about the intent of the change: not to show the welcome message twice if it has not changed between ImageJ releases.
