### PR TITLE
Change the default log level to WARN

### DIFF
--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -44,7 +44,7 @@ import org.scijava.service.AbstractService;
  */
 public abstract class AbstractLogService extends AbstractService implements LogService {
 
-	private int currentLevel = System.getenv("DEBUG") == null ? INFO : DEBUG;
+	private int currentLevel = System.getenv("DEBUG") == null ? WARN : DEBUG;
 
 	private Map<String, Integer> classAndPackageLevels =
 		new HashMap<String, Integer>();
@@ -76,8 +76,8 @@ public abstract class AbstractLogService extends AbstractService implements LogS
 		if (level >= 0) setLevel(level);
 
 		if (getLevel() == 0) {
-			// use the default, which is INFO unless the DEBUG env. variable is set
-			setLevel(System.getenv("DEBUG") == null ? INFO : DEBUG);
+			// use the default, which is WARN unless the DEBUG env. variable is set
+			setLevel(System.getenv("DEBUG") == null ? WARN : DEBUG);
 		}
 
 		// populate custom class- and package-specific log level properties


### PR DESCRIPTION
Several people have told me that SciJava applications currently produce
too much logging by default, and I agree. In particular, PTServices tend
to emit the number of plugins of various types that were discovered. I
think this sort of information _does_ make sense at the "INFO" level,
and that the default level should rather be WARN instead.
