### PR TITLE
Better lazy resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>scijava-common</artifactId>
-	<version>2.41.1-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 
 	<name>SciJava Common</name>
 	<description>SciJava Common is a shared library for SciJava software. It provides a plugin framework, with an extensible mechanism for service discovery, backed by its own annotation processor, so that plugins can be loaded dynamically. It is used by both ImageJ and SCIFIO.</description>

--- a/src/main/java/org/scijava/object/LazyObjects.java
+++ b/src/main/java/org/scijava/object/LazyObjects.java
@@ -45,4 +45,11 @@ public interface LazyObjects<T> {
 	/** Gets the collection of objects. */
 	Collection<T> get();
 
+	/**
+	 * The type of the objects which will be resolved from a call to
+	 * {@link #get()}. This information is used to determine whether to resolve
+	 * the objects in response to an {@link ObjectIndex#get(Class)} call.
+	 */
+	Class<?> getType();
+
 }

--- a/src/main/java/org/scijava/platform/DefaultPlatformService.java
+++ b/src/main/java/org/scijava/platform/DefaultPlatformService.java
@@ -134,7 +134,7 @@ public final class DefaultPlatformService extends
 	}
 
 	@Override
-	public List<? extends Platform> filterInstances(final List<Platform> list) {
+	public List<Platform> filterInstances(final List<Platform> list) {
 		final Iterator<Platform> iter = list.iterator();
 		while (iter.hasNext()) {
 			if (!iter.next().isTarget()) {

--- a/src/main/java/org/scijava/plugin/AbstractSingletonService.java
+++ b/src/main/java/org/scijava/plugin/AbstractSingletonService.java
@@ -31,7 +31,6 @@
 
 package org.scijava.plugin;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -58,10 +57,7 @@ public abstract class AbstractSingletonService<PT extends SingletonPlugin>
 	private ObjectService objectService;
 
 	// TODO: Listen for PluginsAddedEvent and PluginsRemovedEvent
-	// and update the list of singletons accordingly.
-
-	/** List of singleton plugin instances. */
-	private List<PT> instances;
+	// and update the map of singletons accordingly.
 
 	private Map<Class<? extends PT>, PT> instanceMap;
 
@@ -69,8 +65,8 @@ public abstract class AbstractSingletonService<PT extends SingletonPlugin>
 
 	@Override
 	public List<PT> getInstances() {
-		if (instances == null) initInstances();
-		return instances;
+		final List<PT> plugins = objectService.getObjects(getPluginType());
+		return Collections.unmodifiableList(plugins);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -89,7 +85,7 @@ public abstract class AbstractSingletonService<PT extends SingletonPlugin>
 
 			@Override
 			public List<PT> get() {
-				return new ArrayList<PT>(getInstances());
+				return createInstances();
 			}
 
 			@Override
@@ -115,15 +111,12 @@ public abstract class AbstractSingletonService<PT extends SingletonPlugin>
 	// -- Helper methods --
 
 	private synchronized void initInstances() {
-		if (instances != null) return;
-
-		final List<PT> list =
-			Collections.unmodifiableList(filterInstances(getPluginService()
-				.createInstancesOfType(getPluginType())));
+		if (instanceMap != null) return;
 
 		final HashMap<Class<? extends PT>, PT> map =
 			new HashMap<Class<? extends PT>, PT>();
 
+		final List<PT> list = getInstances();
 		for (final PT plugin : list) {
 			@SuppressWarnings("unchecked")
 			final Class<? extends PT> ptClass =
@@ -131,11 +124,17 @@ public abstract class AbstractSingletonService<PT extends SingletonPlugin>
 			map.put(ptClass, plugin);
 		}
 
-		log.debug("Found " + list.size() + " " + getPluginType().getSimpleName() +
-			" plugins.");
-
 		instanceMap = map;
-		instances = list;
+	}
+
+	private List<PT> createInstances() {
+		final List<PT> instances =
+			filterInstances(getPluginService().createInstancesOfType(getPluginType()));
+
+		log.info("Found " + instances.size() + " " +
+			getPluginType().getSimpleName() + " plugins.");
+
+		return instances;
 	}
 
 }

--- a/src/main/java/org/scijava/plugin/AbstractSingletonService.java
+++ b/src/main/java/org/scijava/plugin/AbstractSingletonService.java
@@ -88,7 +88,7 @@ public abstract class AbstractSingletonService<PT extends SingletonPlugin>
 		objectService.getIndex().addLater(new LazyObjects<PT>() {
 
 			@Override
-			public ArrayList<PT> get() {
+			public List<PT> get() {
 				return new ArrayList<PT>(getInstances());
 			}
 
@@ -108,7 +108,7 @@ public abstract class AbstractSingletonService<PT extends SingletonPlugin>
 	 * @param list the initial list of instances
 	 * @return the filtered list of instances
 	 */
-	protected List<? extends PT> filterInstances(final List<PT> list) {
+	protected List<PT> filterInstances(final List<PT> list) {
 		return list;
 	}
 

--- a/src/main/java/org/scijava/plugin/AbstractSingletonService.java
+++ b/src/main/java/org/scijava/plugin/AbstractSingletonService.java
@@ -91,6 +91,12 @@ public abstract class AbstractSingletonService<PT extends SingletonPlugin>
 			public ArrayList<PT> get() {
 				return new ArrayList<PT>(getInstances());
 			}
+
+			@Override
+			public Class<?> getType() {
+				return getPluginType();
+			}
+
 		});
 	}
 

--- a/src/main/java/org/scijava/plugin/AbstractSingletonService.java
+++ b/src/main/java/org/scijava/plugin/AbstractSingletonService.java
@@ -85,11 +85,11 @@ public abstract class AbstractSingletonService<PT extends SingletonPlugin>
 	@Override
 	public void initialize() {
 		// add singleton instances to the object index... IN THE FUTURE!
-		objectService.getIndex().addLater(new LazyObjects<Object>() {
+		objectService.getIndex().addLater(new LazyObjects<PT>() {
 
 			@Override
-			public ArrayList<Object> get() {
-				return new ArrayList<Object>(getInstances());
+			public ArrayList<PT> get() {
+				return new ArrayList<PT>(getInstances());
 			}
 		});
 	}

--- a/src/main/java/org/scijava/script/DefaultScriptService.java
+++ b/src/main/java/org/scijava/script/DefaultScriptService.java
@@ -285,6 +285,11 @@ public class DefaultScriptService extends
 				return scripts().values();
 			}
 
+			@Override
+			public Class<?> getType() {
+				return ScriptInfo.class;
+			}
+
 		});
 	}
 

--- a/src/test/java/org/scijava/object/ObjectIndexTest.java
+++ b/src/test/java/org/scijava/object/ObjectIndexTest.java
@@ -71,6 +71,11 @@ public class ObjectIndexTest {
 				return Arrays.asList(o4, o5, o6);
 			}
 
+			@Override
+			public Class<?> getType() {
+				return String.class;
+			}
+
 		});
 
 		final List<Object> all = objectIndex.getAll();

--- a/src/test/java/org/scijava/object/ObjectIndexTest.java
+++ b/src/test/java/org/scijava/object/ObjectIndexTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -241,6 +242,100 @@ public class ObjectIndexTest {
 		final String[] actual =
 			objectIndex.toString().split(System.getProperty("line.separator"));
 		assertArrayEquals(expected, actual);
+	}
+
+	@Test
+	public void testAddLater() {
+		final ObjectIndex<Object> objectIndex =
+			new ObjectIndex<Object>(Object.class);
+		objectIndex.add(new Integer(5));
+		objectIndex.add(new Float(2.5f));
+		objectIndex.add(new Integer(3));
+
+		final LazyThings<Integer> lazyIntegers = new LazyThings<Integer>(9, -7);
+		objectIndex.addLater(lazyIntegers);
+
+		final LazyThings<Float> lazyFloats =
+			new LazyThings<Float>(6.6f, -3.3f, -5.1f, 12.3f);
+		objectIndex.addLater(lazyFloats);
+
+		final LazyThings<BigInteger> lazyBigIntegers =
+			new LazyThings<BigInteger>(BigInteger.ONE, BigInteger.TEN);
+		objectIndex.addLater(lazyBigIntegers);
+
+		// verify that no pending objects have been resolved yet
+		assertFalse(lazyIntegers.wasAccessed());
+		assertFalse(lazyFloats.wasAccessed());
+		assertFalse(lazyBigIntegers.wasAccessed());
+
+		// verify list of Integers; this will resolve the pending ones
+		final List<Object> integerObjects = objectIndex.get(Integer.class);
+		assertEquals(4, integerObjects.size());
+		assertEquals(5, integerObjects.get(0));
+		assertEquals(3, integerObjects.get(1));
+		assertEquals(9, integerObjects.get(2));
+		assertEquals(-7, integerObjects.get(3));
+
+		// verify that pending Integers have now been resolved
+		assertTrue(lazyIntegers.wasAccessed());
+
+		// verify that the other pending objects have still not been resolved
+		assertFalse(lazyFloats.wasAccessed());
+		assertFalse(lazyBigIntegers.wasAccessed());
+
+		// verify list of Floats; this will resolve the pending ones
+		final List<Object> floatObjects = objectIndex.get(Float.class);
+		assertEquals(5, floatObjects.size());
+		assertEquals(2.5f, floatObjects.get(0));
+		assertEquals(6.6f, floatObjects.get(1));
+		assertEquals(-3.3f, floatObjects.get(2));
+		assertEquals(-5.1f, floatObjects.get(3));
+		assertEquals(12.3f, floatObjects.get(4));
+
+		// verify that pending Floats have now been resolved
+		assertTrue(lazyFloats.wasAccessed());
+
+		// verify that pending BigIntegers have still not been resolved
+		assertFalse(lazyBigIntegers.wasAccessed());
+
+		// verify list of BigIntegers; this will resolve the pending ones
+		final List<Object> bigIntegerObjects = objectIndex.get(BigInteger.class);
+		assertEquals(2, bigIntegerObjects.size());
+		assertEquals(BigInteger.ONE, bigIntegerObjects.get(0));
+		assertEquals(BigInteger.TEN, bigIntegerObjects.get(1));
+
+		// verify that pending BigIntegers have finally been resolved
+		assertTrue(lazyBigIntegers.wasAccessed());
+	}
+
+	// -- Helper classes --
+
+	public static class LazyThings<T> implements LazyObjects<T> {
+
+		private Collection<T> objects;
+		private Class<?> type;
+		private boolean accessed;
+
+		public LazyThings(T... objects) {
+			this.objects = Arrays.asList(objects);
+			this.type = objects[0].getClass();
+		}
+
+		@Override
+		public Collection<T> get() {
+			accessed = true;
+			return objects;
+		}
+
+		@Override
+		public Class<?> getType() {
+			return type;
+		}
+
+		public boolean wasAccessed() {
+			return accessed;
+		}
+
 	}
 
 }

--- a/src/test/java/org/scijava/object/ObjectIndexTest.java
+++ b/src/test/java/org/scijava/object/ObjectIndexTest.java
@@ -38,6 +38,8 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -60,11 +62,25 @@ public class ObjectIndexTest {
 		objectIndex.add(o1);
 		objectIndex.add(o2);
 		objectIndex.add(o3);
+
+		final String o4 = "quick", o5 = "brown", o6 = "fox";
+		objectIndex.addLater(new LazyObjects<String>() {
+
+			@Override
+			public Collection<String> get() {
+				return Arrays.asList(o4, o5, o6);
+			}
+
+		});
+
 		final List<Object> all = objectIndex.getAll();
-		assertEquals(3, all.size());
+		assertEquals(6, all.size());
 		assertSame(o1, all.get(0));
 		assertSame(o2, all.get(1));
 		assertSame(o3, all.get(2));
+		assertSame(o4, all.get(3));
+		assertSame(o5, all.get(4));
+		assertSame(o6, all.get(5));
 	}
 
 	@Test


### PR DESCRIPTION
**MERGE ONLY IN CONCERT WITH THE OTHER 3.0.0 BRANCHES.**

This improves the `ObjectIndex` lazy object resolution feature to only resolve objects as needed based on the type. Previously, as soon as `get(Class)` or `getAll()` was called, _all_ pending objects would be resolved. Now we call the new `LazyObjects#getType()` method to see if the type of the `Collection` is even worth bothering about.

See also issue #90.
