### PR TITLE
TestUtils: valid calling code locations do not include .jar files

### DIFF
--- a/src/main/java/org/scijava/test/TestUtils.java
+++ b/src/main/java/org/scijava/test/TestUtils.java
@@ -203,6 +203,11 @@ public class TestUtils {
 			final Class<?> clazz;
 			try {
 				clazz = loader.loadClass(element.getClassName());
+				final URL url = clazz.getResource("/" + clazz.getName().replace('.', '/') + ".class");
+				if (url == null || !"file".equals(url.getProtocol())) {
+					// the calling code location must be unpacked; Maven artifacts in $HOME/.m2/ are excluded
+					continue;
+				}
 			}
 			catch (ClassNotFoundException e) {
 				throw new UnsupportedOperationException("Could not load " +


### PR DESCRIPTION
The whole point of the getCallingCodeLocation() method in the TestUtils
class is to be able to determine a unique location for a directory
inside the target/ directory of the current Maven project.

Therefore, code locations in .jar files are not appropriate: there is
no associated target/ directory.

Thanks, Jaspar Jenkins, for running the regression tests so faithfully
and pointing out that the imagej-plugins-uploader-{ssh,webdav} projects
require this change to run their integration tests properly.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
