### PR TITLE
Rich plugin usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>scijava-common</artifactId>
-	<version>2.28.1-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 
 	<name>SciJava Common</name>
 	<description>SciJava Common is a shared library for SciJava software. It provides a plugin framework, with an extensible mechanism for service discovery, backed by its own annotation processor, so that plugins can be loaded dynamically. It is used by both ImageJ and SCIFIO.</description>

--- a/src/main/java/org/scijava/AbstractGateway.java
+++ b/src/main/java/org/scijava/AbstractGateway.java
@@ -93,11 +93,6 @@ public abstract class AbstractGateway extends AbstractRichPlugin implements
 		return context().service(serviceClass);
 	}
 
-	@Override
-	public Service get(final String serviceClassName) {
-		return context().service(serviceClassName);
-	}
-
 	// -- Gateway methods - services --
 
 	@Override

--- a/src/main/java/org/scijava/AbstractGateway.java
+++ b/src/main/java/org/scijava/AbstractGateway.java
@@ -241,13 +241,15 @@ public abstract class AbstractGateway extends AbstractRichPlugin implements
 	}
 
 	@Override
-	public String getVersion() {
-		return getApp().getVersion();
-	}
-
-	@Override
 	public String getInfo(final boolean mem) {
 		return getApp().getInfo(mem);
+	}
+
+	// -- Versioned methods --
+
+	@Override
+	public String getVersion() {
+		return getApp().getVersion();
 	}
 
 }

--- a/src/main/java/org/scijava/Gateway.java
+++ b/src/main/java/org/scijava/Gateway.java
@@ -130,18 +130,6 @@ public interface Gateway extends RichPlugin, Versioned {
 	 */
 	<S extends Service> S get(Class<S> serviceClass);
 
-	/**
-	 * Returns an implementation of the {@link Service} with the given class name,
-	 * if it exists in the underlying {@link Context}.
-	 * 
-	 * @param serviceClassName name of the requested {@link Service}
-	 * @return The singleton instance of the requested {@link Service}
-	 * @throws NullContextException if the application context is not set.
-	 * @throws NoSuchServiceException if there is no service matching
-	 *           {@code serviceClassName}.
-	 */
-	Service get(final String serviceClassName);
-
 	// -- Gateway methods - services --
 
 	AppEventService appEvent();

--- a/src/main/java/org/scijava/Gateway.java
+++ b/src/main/java/org/scijava/Gateway.java
@@ -117,7 +117,7 @@ import org.scijava.widget.WidgetService;
  * @author Mark Hiner
  * @author Curtis Rueden
  */
-public interface Gateway extends RichPlugin, Versioned {
+public interface Gateway extends RichPlugin {
 
 	/**
 	 * Returns an implementation of the requested {@link Service}, if it exists in
@@ -192,11 +192,5 @@ public interface Gateway extends RichPlugin, Versioned {
 
 	/** @see org.scijava.app.App#getInfo(boolean) */
 	String getInfo(boolean mem);
-
-	// -- Versioned methods --
-
-	/** @see org.scijava.app.App#getVersion() */
-	@Override
-	String getVersion();
 
 }

--- a/src/main/java/org/scijava/app/AbstractApp.java
+++ b/src/main/java/org/scijava/app/AbstractApp.java
@@ -51,14 +51,11 @@ public abstract class AbstractApp extends AbstractRichPlugin implements App {
 	/** JAR manifest with metadata about the application. */
 	private Manifest manifest;
 
+	// -- App methods --
+
 	@Override
 	public String getTitle() {
 		return getInfo().getName();
-	}
-
-	@Override
-	public String getVersion() {
-		return getPOM() == null ? "Unknown" : getPOM().getVersion();
 	}
 
 	@Override
@@ -106,6 +103,13 @@ public abstract class AbstractApp extends AbstractRichPlugin implements App {
 	@Override
 	public File getBaseDirectory() {
 		return AppUtils.getBaseDirectory(getSystemProperty(), getClass(), null);
+	}
+
+	// -- Versioned methods --
+
+	@Override
+	public String getVersion() {
+		return getPOM() == null ? "Unknown" : getPOM().getVersion();
 	}
 
 }

--- a/src/main/java/org/scijava/plugin/AbstractHandlerService.java
+++ b/src/main/java/org/scijava/plugin/AbstractHandlerService.java
@@ -47,7 +47,10 @@ public abstract class AbstractHandlerService<DT, PT extends HandlerPlugin<DT>>
 	@Override
 	public PT getHandler(final DT data) {
 		for (final PT handler : getInstances()) {
-			if (handler.supports(data)) return handler;
+			if (handler.supports(data)) {
+				recordUsage(handler);
+				return handler;
+			}
 		}
 		return null;
 	}

--- a/src/main/java/org/scijava/plugin/AbstractPTService.java
+++ b/src/main/java/org/scijava/plugin/AbstractPTService.java
@@ -34,6 +34,7 @@ package org.scijava.plugin;
 import java.util.List;
 
 import org.scijava.service.AbstractService;
+import org.scijava.usage.UsageService;
 
 /**
  * Abstract base class for {@link PTService}s.
@@ -48,6 +49,9 @@ public abstract class AbstractPTService<PT extends SciJavaPlugin> extends
 	@Parameter
 	private PluginService pluginService;
 
+	@Parameter(required = false)
+	private UsageService usageService;
+
 	// -- PTService methods --
 
 	@Override
@@ -58,6 +62,14 @@ public abstract class AbstractPTService<PT extends SciJavaPlugin> extends
 	@Override
 	public List<PluginInfo<PT>> getPlugins() {
 		return pluginService.getPluginsOfType(getPluginType());
+	}
+
+	// -- Internal methods --
+
+	/** Records the usage of a plugin. */
+	protected void recordUsage(final Object plugin) {
+		if (usageService == null) return;
+		usageService.increment(plugin);
 	}
 
 }

--- a/src/main/java/org/scijava/plugin/AbstractRichPlugin.java
+++ b/src/main/java/org/scijava/plugin/AbstractRichPlugin.java
@@ -34,10 +34,12 @@ package org.scijava.plugin;
 import java.net.URL;
 
 import org.scijava.AbstractContextual;
+import org.scijava.BasicDetails;
 import org.scijava.Prioritized;
 import org.scijava.Priority;
 import org.scijava.util.ClassUtils;
 import org.scijava.util.Manifest;
+import org.scijava.util.MiscUtils;
 
 /**
  * Abstract base class for {@link RichPlugin} implementations.
@@ -167,7 +169,16 @@ public abstract class AbstractRichPlugin extends AbstractContextual implements
 		if (priorityCompare != 0) return priorityCompare;
 
 		// compare classes
-		return ClassUtils.compare(getClass(), that.getClass());
+		final int classCompare = ClassUtils.compare(getClass(), that.getClass());
+		if (classCompare != 0) return classCompare;
+
+		if (!(that instanceof BasicDetails)) return 1;
+		final BasicDetails basicDetails = (BasicDetails) that;
+
+		// compare names
+		final String thisName = getName();
+		final String thatName = basicDetails.getName();
+		return MiscUtils.compare(thisName, thatName);
 	}
 
 }

--- a/src/main/java/org/scijava/plugin/AbstractRichPlugin.java
+++ b/src/main/java/org/scijava/plugin/AbstractRichPlugin.java
@@ -31,10 +31,13 @@
 
 package org.scijava.plugin;
 
+import java.net.URL;
+
 import org.scijava.AbstractContextual;
 import org.scijava.Prioritized;
 import org.scijava.Priority;
 import org.scijava.util.ClassUtils;
+import org.scijava.util.Manifest;
 
 /**
  * Abstract base class for {@link RichPlugin} implementations.
@@ -81,6 +84,76 @@ public abstract class AbstractRichPlugin extends AbstractContextual implements
 	@Override
 	public void setInfo(final PluginInfo<?> info) {
 		this.info = info;
+	}
+
+	// -- Identifiable methods --
+
+	@Override
+	public String getIdentifier() {
+		return "plugin:" + getClass().getName();
+	}
+
+	// -- Locatable methods --
+
+	@Override
+	public String getLocation() {
+		final URL location = ClassUtils.getLocation(getClass());
+		return location == null ? null : location.toExternalForm();
+	}
+
+	// -- Versioned methods --
+
+	@Override
+	public String getVersion() {
+		final Manifest m = Manifest.getManifest(getClass());
+		return m == null ? null : m.getImplementationVersion();
+	}
+
+	// -- BasicDetails methods --
+
+	@Override
+	public String getName() {
+		return getInfo().getName();
+	}
+
+	@Override
+	public String getLabel() {
+		return getInfo().getLabel();
+	}
+
+	@Override
+	public String getDescription() {
+		return getInfo().getDescription();
+	}
+
+	@Override
+	public boolean is(String key) {
+		return getInfo().is(key);
+	}
+
+	@Override
+	public String get(String key) {
+		return getInfo().get(key);
+	}
+
+	@Override
+	public void setName(String name) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setLabel(String label) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setDescription(String description) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void set(String key, String value) {
+		throw new UnsupportedOperationException();
 	}
 
 	// -- Comparable methods --

--- a/src/main/java/org/scijava/plugin/AbstractWrapperService.java
+++ b/src/main/java/org/scijava/plugin/AbstractWrapperService.java
@@ -59,6 +59,7 @@ public abstract class AbstractWrapperService<DT, PT extends WrapperPlugin<DT>>
 		@SuppressWarnings("unchecked")
 		final WrapperPlugin<D> typedInstance = (WrapperPlugin<D>) instance;
 		typedInstance.set(data);
+		recordUsage(typedInstance);
 		return typedInstance;
 	}
 

--- a/src/main/java/org/scijava/plugin/RichPlugin.java
+++ b/src/main/java/org/scijava/plugin/RichPlugin.java
@@ -31,8 +31,12 @@
 
 package org.scijava.plugin;
 
+import org.scijava.BasicDetails;
 import org.scijava.Contextual;
+import org.scijava.Identifiable;
+import org.scijava.Locatable;
 import org.scijava.Prioritized;
+import org.scijava.Versioned;
 
 /**
  * Base interface for {@link Contextual}, {@link Prioritized} plugins that
@@ -42,8 +46,8 @@ import org.scijava.Prioritized;
  * 
  * @author Curtis Rueden
  */
-public interface RichPlugin extends Contextual, Prioritized, HasPluginInfo,
-	SciJavaPlugin
+public interface RichPlugin extends SciJavaPlugin, Contextual, Prioritized,
+	HasPluginInfo, Identifiable, Locatable, Versioned, BasicDetails
 {
 	// NB: Marker interface.
 }

--- a/src/main/java/org/scijava/script/ScriptInfo.java
+++ b/src/main/java/org/scijava/script/ScriptInfo.java
@@ -292,6 +292,8 @@ public class ScriptInfo extends AbstractModuleInfo implements Contextual {
 		return new File(path).toURI().normalize().toString();
 	}
 
+	// -- Versioned methods --
+
 	@Override
 	public String getVersion() {
 		final File file = new File(path);


### PR DESCRIPTION
__MERGE ONLY IN CONCERT WITH THE OTHER 3.0.0 BRANCHES.__

This makes all `RichPlugin` types implement the interfaces necessary for tracking their usage, and in particular tracks all uses of "handler" and "wrapper" plugin types.

Unfortunately, to do this, a method had to be removed from the `Gateway` interface, which breaks backwards compatibility. So this PR will be part of SJC3.