### PR TITLE
Save reference to the calling thread in each event

### DIFF
--- a/src/main/java/org/scijava/event/DefaultEventService.java
+++ b/src/main/java/org/scijava/event/DefaultEventService.java
@@ -84,12 +84,14 @@ public class DefaultEventService extends AbstractService implements
 	@Override
 	public <E extends SciJavaEvent> void publish(final E e) {
 		e.setContext(getContext());
+		e.setCallingThread(Thread.currentThread());
 		eventBus.publishNow(e);
 	}
 
 	@Override
 	public <E extends SciJavaEvent> void publishLater(final E e) {
 		e.setContext(getContext());
+		e.setCallingThread(Thread.currentThread());
 		eventBus.publishLater(e);
 	}
 

--- a/src/main/java/org/scijava/event/SciJavaEvent.java
+++ b/src/main/java/org/scijava/event/SciJavaEvent.java
@@ -40,7 +40,14 @@ import org.scijava.AbstractContextual;
  */
 public abstract class SciJavaEvent extends AbstractContextual {
 
+	/** Whether the event has been handled already. */
 	private boolean consumed;
+
+	/** The thread which published this event. */
+	private Thread callingThread;
+
+	/** The stack trace of the calling thread when the event was published. */
+	private StackTraceElement[] stackTrace;
 
 	// -- SciJavaEvent methods --
 
@@ -54,6 +61,25 @@ public abstract class SciJavaEvent extends AbstractContextual {
 
 	public void consume() {
 		setConsumed(true);
+	}
+
+	/** Gets the thread that published the event. */
+	public Thread getCallingThread() {
+		return callingThread;
+	}
+
+	/** Sets the thread that published the event. */
+	public void setCallingThread(final Thread callingThread) {
+		this.callingThread = callingThread;
+		stackTrace = callingThread.getStackTrace();
+	}
+
+	/**
+	 * Gets the stack trace of the calling thread when the event was published.
+	 * This method is useful for debugging what triggered an event.
+	 */
+	public StackTraceElement[] getStackTrace() {
+		return stackTrace;
 	}
 
 	// Object methods --


### PR DESCRIPTION
This way, even though publish and publishLater handle the event
notification on the event dispatch thread, the original calling thread
can still be gleaned from the event. This is useful for debugging.

We also take a snapshot of the stack trace, so that it is crystal clear
exactly where in the code the event publication took place.
