### PR TITLE
Adapt instances of AnnotationValue in the annotation processor

### DIFF
--- a/src/main/java/org/scijava/annotations/AbstractIndexWriter.java
+++ b/src/main/java/org/scijava/annotations/AbstractIndexWriter.java
@@ -45,6 +45,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
+import javax.lang.model.element.AnnotationValue;
+
 /**
  * Writes annotations as JSON-formatted files.
  * <p>
@@ -169,6 +171,9 @@ public abstract class AbstractIndexWriter {
 	protected Object adapt(final Object o) {
 		if (o instanceof Annotation) {
 			return adapt((Annotation) o);
+		}
+		else if (o instanceof AnnotationValue) {
+			return adapt(((AnnotationValue) o).getValue());
 		}
 		else if (o instanceof Enum) {
 			return adapt((Enum<?>) o);


### PR DESCRIPTION
Kevin Mader reported that certain @interfaces were not handled gracefully
because the annotation processor would encounter AnnotationValue instances
and not know how to handle them.

This fixes https://github.com/scijava/scijava-common/issues/130.

Without these changes, the example provided below yielded the following
exception:

```
error: java.io.IOException: Cannot handle object of type class com.sun.tools.javac.code.Attribute$Constant
    at org.scijava.annotations.AbstractIndexWriter.writeObject(AbstractIndexWriter.java:252)
    at org.scijava.annotations.AbstractIndexWriter.writeArray(AbstractIndexWriter.java:306)
    at org.scijava.annotations.AbstractIndexWriter.writeObject(AbstractIndexWriter.java:243)
    at org.scijava.annotations.AbstractIndexWriter.writeMap(AbstractIndexWriter.java:288)
    at org.scijava.annotations.AbstractIndexWriter.writeObject(AbstractIndexWriter.java:249)
    at org.scijava.annotations.AbstractIndexWriter.writeMap(AbstractIndexWriter.java:288)
    at org.scijava.annotations.AbstractIndexWriter.writeObject(AbstractIndexWriter.java:249)
    at org.scijava.annotations.AbstractIndexWriter.write(AbstractIndexWriter.java:99)
    at org.scijava.annotations.AnnotationProcessor.process(AnnotationProcessor.java:91)
    at com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor(JavacProcessingEnvironment.java:627)
    ...
```

-- snip BlockIdentity.java --
import java.lang.annotation.ElementType;
import java.lang.annotation.Retention;
import java.lang.annotation.RetentionPolicy;
import java.lang.annotation.Target;

import org.scijava.annotations.Indexable;

@Target(ElementType.TYPE)
@Retention(RetentionPolicy.RUNTIME)
@Indexable
public @interface BlockIdentity {
    String blockName();
    String desc() default "";
    String[] inputNames();
    String[] outputNames();
}
-- snap --

-- snip Test.java --
@BlockIdentity(blockName = "GrowRegionsBlock",
            inputNames= {"labeled image", "mask image"},
            outputNames= {"filled labels", "filled neighborhood"})
public class Test {}
-- snap --

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
