### PR TITLE
Annotation ConcurrentModificationException during compilation

### DIFF
--- a/src/main/java/org/scijava/annotations/AbstractIndexWriter.java
+++ b/src/main/java/org/scijava/annotations/AbstractIndexWriter.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
  * Writes annotations as JSON-formatted files.
@@ -58,7 +59,7 @@ import java.util.TreeMap;
 public abstract class AbstractIndexWriter {
 
 	private final Map<String, Map<String, Object>> map =
-		new TreeMap<String, Map<String, Object>>();
+		new ConcurrentSkipListMap<String, Map<String, Object>>();
 
 	protected synchronized boolean foundAnnotations() {
 		return !map.isEmpty();
@@ -135,7 +136,7 @@ public abstract class AbstractIndexWriter {
 		int changedCount = map.size();
 		boolean hasObsoletes = false;
 
-		final IndexReader reader = new IndexReader(in);
+		final IndexReader reader = new IndexReader(in,annotationName+" from "+in);
 		try {
 			for (;;) {
 				@SuppressWarnings("unchecked")

--- a/src/main/java/org/scijava/annotations/IndexReader.java
+++ b/src/main/java/org/scijava/annotations/IndexReader.java
@@ -64,12 +64,22 @@ import org.scijava.annotations.legacy.LegacyReader;
 class IndexReader {
 
 	private final PushbackInputStream in;
+	private final String originalISName;
 
 	IndexReader(final InputStream in) {
 		this.in =
 			in instanceof PushbackInputStream ? (PushbackInputStream) in
 				: new PushbackInputStream(new BufferedInputStream(in));
+		this.originalISName="";
 	}
+
+	IndexReader(final InputStream in,final String isName) {
+		this.in =
+				in instanceof PushbackInputStream ? (PushbackInputStream) in
+						: new PushbackInputStream(new BufferedInputStream(in));
+		this.originalISName=isName;
+	}
+
 
 	public Object next() throws IOException {
 		int c = in.read();
@@ -155,7 +165,8 @@ class IndexReader {
 		if (c == '"') {
 			return readString();
 		}
-		throw new IOException("Unexpected char: '" + (char) c + "'");
+		throw new IOException("Unexpected char: '" + (char) c + "'"+
+				((originalISName.length()>0) ? " from "+originalISName : ""));
 	}
 
 	public void close() throws IOException {
@@ -206,7 +217,7 @@ class IndexReader {
 			return 1;
 		}
 		throw new IOException("Expected '" + a + "' or '" + b + "', got '" +
-			(char) c + "'");
+			(char) c + "'"+((originalISName.length()>0) ? " from "+originalISName : ""));
 	}
 
 	private void expect(String match) throws IOException {
@@ -217,6 +228,7 @@ class IndexReader {
 
 	private IndexReader() {
 		this.in = null;
+		this.originalISName="";
 	}
 
 	static IndexReader getLegacyReader(final InputStream in) throws IOException {

--- a/src/main/java/org/scijava/annotations/IndexReader.java
+++ b/src/main/java/org/scijava/annotations/IndexReader.java
@@ -73,6 +73,7 @@ class IndexReader {
 
 	public Object next() throws IOException {
 		int c = in.read();
+		while (Character.isWhitespace(c)) c = in.read();
 		if (c < 0) {
 			return null;
 		}


### PR DESCRIPTION
Changed to ConcurrentSkipListMap to avoid compilation issue when using IntelliJ. Also added more debugging information for the AbstractIndexWriter and Reader to show which annotation causes an exception to occur so debugging can be done more easily.