### PR TITLE
Let the ConsoleService track stdout and stderr messages

### DIFF
--- a/src/main/java/org/scijava/console/AbstractConsoleArgument.java
+++ b/src/main/java/org/scijava/console/AbstractConsoleArgument.java
@@ -37,7 +37,7 @@ import org.scijava.plugin.AbstractHandlerPlugin;
 
 /**
  * Abstract superclass of {@link ConsoleArgument} implementations.
- * 
+ *
  * @author Curtis Rueden
  */
 public abstract class AbstractConsoleArgument extends

--- a/src/main/java/org/scijava/console/ConsoleArgument.java
+++ b/src/main/java/org/scijava/console/ConsoleArgument.java
@@ -46,7 +46,7 @@ import org.scijava.plugin.Plugin;
  * is encouraged to instead extend {@link AbstractConsoleArgument}, for
  * convenience.
  * </p>
- * 
+ *
  * @author Curtis Rueden
  */
 public interface ConsoleArgument extends HandlerPlugin<LinkedList<String>> {

--- a/src/main/java/org/scijava/console/ConsoleService.java
+++ b/src/main/java/org/scijava/console/ConsoleService.java
@@ -42,7 +42,7 @@ import org.scijava.service.SciJavaService;
  * In particular, this is the service that defines how command line arguments
  * are handled.
  * </p>
- * 
+ *
  * @author Curtis Rueden
  */
 public interface ConsoleService extends

--- a/src/main/java/org/scijava/console/ConsoleService.java
+++ b/src/main/java/org/scijava/console/ConsoleService.java
@@ -40,7 +40,8 @@ import org.scijava.service.SciJavaService;
  * Interface for service that manages interaction with the console.
  * <p>
  * In particular, this is the service that defines how command line arguments
- * are handled.
+ * are handled. It also provides an extension mechanism for {@code stdout} and
+ * {@code stderr} logging.
  * </p>
  *
  * @author Curtis Rueden
@@ -54,5 +55,14 @@ public interface ConsoleService extends
 	 * command line.
 	 */
 	void processArgs(String... args);
+
+	/** Adds a listener for output sent to {@code stdout} or {@code stderr}. */
+	void addOutputListener(OutputListener l);
+
+	/** Removes a listener for output sent to {@code stdout} or {@code stderr}. */
+	void removeOutputListener(OutputListener l);
+
+	/** Notifies listeners of output sent to {@code stdout} or {@code stderr}. */
+	void notifyListeners(OutputEvent event);
 
 }

--- a/src/main/java/org/scijava/console/DefaultConsoleService.java
+++ b/src/main/java/org/scijava/console/DefaultConsoleService.java
@@ -41,7 +41,7 @@ import org.scijava.service.Service;
 
 /**
  * Default service for managing interaction with the console.
- * 
+ *
  * @author Curtis Rueden
  */
 @Plugin(type = Service.class)

--- a/src/main/java/org/scijava/console/DefaultConsoleService.java
+++ b/src/main/java/org/scijava/console/DefaultConsoleService.java
@@ -31,6 +31,8 @@
 
 package org.scijava.console;
 
+import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.LinkedList;
 
 import org.scijava.log.LogService;
@@ -52,6 +54,11 @@ public class DefaultConsoleService extends
 
 	@Parameter
 	private LogService log;
+
+	private MultiPrintStream sysout, syserr;
+
+	/** List of listeners for {@code stdout} and {@code stderr} output. */
+	private ArrayList<OutputListener> listeners;
 
 	// -- ConsoleService methods --
 
@@ -76,6 +83,32 @@ public class DefaultConsoleService extends
 		}
 	}
 
+	@Override
+	public void addOutputListener(final OutputListener l) {
+		if (listeners == null) initListeners();
+		synchronized (listeners) {
+			listeners.add(l);
+		}
+	}
+
+	@Override
+	public void removeOutputListener(final OutputListener l) {
+		if (listeners == null) initListeners();
+		synchronized (listeners) {
+			listeners.remove(l);
+		}
+	}
+
+	@Override
+	public void notifyListeners(final OutputEvent event) {
+		if (listeners == null) initListeners();
+		synchronized (listeners) {
+			for (final OutputListener l : listeners) {
+				l.outputOccurred(event);
+			}
+		}
+	}
+
 	// -- PTService methods --
 
 	@Override
@@ -89,6 +122,27 @@ public class DefaultConsoleService extends
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public Class<LinkedList<String>> getType() {
 		return (Class) LinkedList.class;
+	}
+
+	// -- Helper methods - lazy initialization --
+
+	/** Initializes {@link #listeners} and related data structures. */
+	private synchronized void initListeners() {
+		if (listeners != null) return; // already initialized
+
+		sysout = multiPrintStream(System.out);
+		if (System.out != sysout) System.setOut(sysout);
+		syserr = multiPrintStream(System.err);
+		if (System.err != syserr) System.setErr(syserr);
+
+		listeners = new ArrayList<OutputListener>();
+	}
+
+	// -- Helper methods --
+
+	private MultiPrintStream multiPrintStream(final PrintStream ps) {
+		if (ps instanceof MultiPrintStream) return (MultiPrintStream) ps;
+		return new MultiPrintStream(ps);
 	}
 
 }

--- a/src/main/java/org/scijava/console/MultiOutputStream.java
+++ b/src/main/java/org/scijava/console/MultiOutputStream.java
@@ -1,0 +1,113 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.console;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+
+/**
+ * A {@code MultiOutputStream} is a collection of constituent
+ * {@link OutputStream} objects, to which all output is forwarded.
+ * <p>
+ * Thanks to Ian F. Darwin for <a href=
+ * "http://www.java2s.com/Code/Java/File-Input-Output/TeePrintStreamteesallPrintStreamoperationsintoafileratherliketheUNIXtee1command.htm"
+ * >his implementation of a similar concept</a>.
+ * </p>
+ *
+ * @author Curtis Rueden
+ */
+public class MultiOutputStream extends OutputStream {
+
+	private final ArrayList<OutputStream> streams;
+
+	/**
+	 * Forwards output to a list of output streams.
+	 *
+	 * @param os Output streams which will receive this stream's output.
+	 */
+	public MultiOutputStream(final OutputStream... os) {
+		streams = new ArrayList<OutputStream>(os.length);
+		for (int i = 0; i < os.length; i++) {
+			streams.add(os[i]);
+		}
+	}
+
+	// -- MultiOutputStream methods --
+
+	/** Adds an output stream to those receiving this stream's output. */
+	public void addOutputStream(final OutputStream os) {
+		synchronized (streams) {
+			streams.add(os);
+		}
+	}
+
+	/** Removes an output stream from those receiving this stream's output. */
+	public void removeOutputStream(final OutputStream os) {
+		synchronized (streams) {
+			streams.remove(os);
+		}
+	}
+
+	// -- OutputStream methods --
+
+	@Override
+	public void write(final int b) throws IOException {
+		for (final OutputStream stream : streams)
+			stream.write(b);
+	}
+
+	@Override
+	public void write(final byte[] buf, final int off, final int len)
+		throws IOException
+	{
+		for (final OutputStream stream : streams)
+			stream.write(buf, off, len);
+	}
+
+	// -- Closeable methods --
+
+	@Override
+	public void close() throws IOException {
+		for (final OutputStream stream : streams)
+			stream.close();
+	}
+
+	// -- Flushable methods --
+
+	@Override
+	public void flush() throws IOException {
+		for (final OutputStream stream : streams)
+			stream.flush();
+	}
+
+}

--- a/src/main/java/org/scijava/console/MultiPrintStream.java
+++ b/src/main/java/org/scijava/console/MultiPrintStream.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.console;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+/**
+ * A {@link PrintStream} that wraps a {@link MultiOutputStream}.
+ *
+ * @author Curtis Rueden
+ */
+public class MultiPrintStream extends PrintStream {
+
+	public MultiPrintStream(final OutputStream os) {
+		super(multi(os));
+	}
+
+	// -- MultiPrintStream methods --
+
+	public MultiOutputStream getParent() {
+		return (MultiOutputStream) out;
+	}
+
+	// -- Helper methods --
+
+	private static OutputStream multi(final OutputStream os) {
+		if (os instanceof MultiOutputStream) return os;
+		return new MultiOutputStream(os);
+	}
+
+}

--- a/src/main/java/org/scijava/console/OutputEvent.java
+++ b/src/main/java/org/scijava/console/OutputEvent.java
@@ -1,0 +1,124 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.console;
+
+import org.scijava.Context;
+import org.scijava.event.EventService;
+import org.scijava.event.SciJavaEvent;
+
+/**
+ * An event indicating output occurred on {@code stdout} or {@code stderr}.
+ * <p>
+ * NB: This event is published <em>on the calling thread</em> by
+ * {@link ConsoleService#notifyListeners(OutputEvent)}, <em>not</em> on a
+ * dedicated event dispatch thread by the {@link EventService}. This is done to
+ * avoid the overhead of the event service's synchronized pub/sub
+ * implementation, as well as to avoid potential infinite output loops caused by
+ * debugging output surrounding event publication.
+ * </p>
+ *
+ * @author Curtis Rueden
+ */
+public class OutputEvent extends SciJavaEvent {
+
+	/** Possible output sources. */
+	public enum Source {
+		STDOUT, STDERR
+	}
+
+	/** The source of the output. */
+	private final Source source;
+
+	/** The output string. */
+	private final String output;
+
+	/**
+	 * Whether the output was produced within this specific SciJava
+	 * {@link Context}.
+	 */
+	private final boolean contextual;
+
+	/**
+	 * Creates a new output event.
+	 *
+	 * @param source The source of the output.
+	 * @param output The output string.
+	 * @param contextual Whether the output was produced within this specific
+	 *          SciJava {@link Context}.
+	 */
+	public OutputEvent(final Context context, final Source source,
+		final String output, final boolean contextual)
+	{
+		this.source = source;
+		this.output = output;
+		this.contextual = contextual;
+		setContext(context);
+		setCallingThread(Thread.currentThread());
+	}
+
+	/** Gets the source of the output. */
+	public Source getSource() {
+		return source;
+	}
+
+	/** Gets the output string. */
+	public String getOutput() {
+		return output;
+	}
+
+	/**
+	 * Returns true if the output was produced outside of a specific SciJava
+	 * {@link Context}.
+	 */
+	public boolean isContextual() {
+		return contextual;
+	}
+
+	/** Returns true of the source of the output is {@code stdout}. */
+	public boolean isStdout() {
+		return source == Source.STDOUT;
+	}
+
+	/** Returns true of the source of the output is {@code stderr}. */
+	public boolean isStderr() {
+		return source == Source.STDERR;
+	}
+
+	// -- Object methods --
+
+	@Override
+	public String toString() {
+		return super.toString() + "\n\tsource = " + source + "\n\toutput = " +
+			output + "\n\tcontextual = " + contextual;
+	}
+
+}

--- a/src/main/java/org/scijava/console/OutputListener.java
+++ b/src/main/java/org/scijava/console/OutputListener.java
@@ -1,0 +1,45 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.console;
+
+/**
+ * Listener for output on {@code stdout} or {@code stderr}.
+ *
+ * @author Curtis Rueden
+ * @see ConsoleService
+ */
+public interface OutputListener {
+
+	/** Method called when output occurs on {@code stdout} or {@code stderr}. */
+	void outputOccurred(final OutputEvent event);
+
+}

--- a/src/main/java/org/scijava/plugin/PluginIndex.java
+++ b/src/main/java/org/scijava/plugin/PluginIndex.java
@@ -98,8 +98,8 @@ public class PluginIndex extends SortedObjectIndex<PluginInfo<?>> {
 	// -- PluginIndex methods --
 
 	/**
-	 * Adds all plugins discovered by the attached {@link PluginFinder} to
-	 * this index, or does nothing if the attached PluginFiner is null.
+	 * Adds all plugins discovered by the attached {@link PluginFinder} to this
+	 * index, or does nothing if the attached {@link PluginFinder} is null.
 	 */
 	public void discover() {
 		if (pluginFinder == null) return;

--- a/src/main/java/org/scijava/thread/DefaultThreadService.java
+++ b/src/main/java/org/scijava/thread/DefaultThreadService.java
@@ -57,6 +57,9 @@ public final class DefaultThreadService extends AbstractService implements
 
 	private static final String SCIJAVA_THREAD_PREFIX = "SciJava-";
 
+	private static WeakHashMap<Thread, Thread> parents =
+		new WeakHashMap<Thread, Thread>();
+
 	@Parameter
 	private LogService log;
 
@@ -65,8 +68,6 @@ public final class DefaultThreadService extends AbstractService implements
 	private int nextThread = 0;
 
 	private boolean disposed;
-
-	private WeakHashMap<Thread, Thread> parents = new WeakHashMap<Thread, Thread>();
 
 	// -- ThreadService methods --
 

--- a/src/main/java/org/scijava/thread/DefaultThreadService.java
+++ b/src/main/java/org/scijava/thread/DefaultThreadService.java
@@ -55,6 +55,8 @@ public final class DefaultThreadService extends AbstractService implements
 	ThreadService
 {
 
+	private static final String SCIJAVA_THREAD_PREFIX = "SciJava-";
+
 	@Parameter
 	private LogService log;
 
@@ -121,9 +123,7 @@ public final class DefaultThreadService extends AbstractService implements
 
 	@Override
 	public Thread newThread(final Runnable r) {
-		final String contextHash = Integer.toHexString(context().hashCode());
-		final String threadName =
-			"SciJava-" + contextHash + "-Thread-" + nextThread++;
+		final String threadName = contextThreadPrefix() + nextThread++;
 		return new Thread(r, threadName);
 	}
 
@@ -169,4 +169,10 @@ public final class DefaultThreadService extends AbstractService implements
 			}
 		};
 	}
+
+	private String contextThreadPrefix() {
+		final String contextHash = Integer.toHexString(context().hashCode());
+		return SCIJAVA_THREAD_PREFIX + contextHash + "-Thread-";
+	}
+
 }

--- a/src/main/java/org/scijava/thread/DefaultThreadService.java
+++ b/src/main/java/org/scijava/thread/DefaultThreadService.java
@@ -111,6 +111,22 @@ public final class DefaultThreadService extends AbstractService implements
 		return parents.get(thread != null ? thread : Thread.currentThread());
 	}
 
+	@Override
+	public ThreadContext getThreadContext(final Thread thread) {
+		final String name = thread.getName();
+
+		// check for same context
+		if (name.startsWith(contextThreadPrefix())) return ThreadContext.SAME;
+
+		// check for different context
+		if (name.startsWith(SCIJAVA_THREAD_PREFIX)) return ThreadContext.OTHER;
+
+		// recursively check parent thread
+		final Thread parent = getParent(thread);
+		if (parent == thread || parent == null) return ThreadContext.NONE;
+		return getThreadContext(parent);
+	}
+
 	// -- Disposable methods --
 
 	@Override

--- a/src/main/java/org/scijava/thread/ThreadService.java
+++ b/src/main/java/org/scijava/thread/ThreadService.java
@@ -31,7 +31,6 @@
 
 package org.scijava.thread;
 
-
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -42,7 +41,7 @@ import org.scijava.service.SciJavaService;
 
 /**
  * Interface for the thread handling service.
- * 
+ *
  * @author Curtis Rueden
  */
 public interface ThreadService extends SciJavaService, ThreadFactory {
@@ -72,7 +71,7 @@ public interface ThreadService extends SciJavaService, ThreadFactory {
 	 * thread service. Typically this means that the service allocates a thread
 	 * from its pool, but ultimately the behavior is implementation-dependent.
 	 * This method returns immediately.
-	 * 
+	 *
 	 * @param code The code to execute.
 	 * @return A {@link Future} that will contain the result once the execution
 	 *         has finished. Call {@link Future#get()} to access to the return
@@ -85,7 +84,7 @@ public interface ThreadService extends SciJavaService, ThreadFactory {
 	 * thread service. Typically this means that the service allocates a thread
 	 * from its pool, but ultimately the behavior is implementation-dependent.
 	 * This method returns immediately.
-	 * 
+	 *
 	 * @param code The code to execute.
 	 * @return A {@link Future} that can be used to block until the execution has
 	 *         finished. Call {@link Future#get()} to do so.
@@ -100,7 +99,7 @@ public interface ThreadService extends SciJavaService, ThreadFactory {
 	 * typically the AWT Event Dispatch Thread (EDT). However, ultimately the
 	 * behavior is implementation-dependent.
 	 * </p>
-	 * 
+	 *
 	 * @return True iff the current thread is considered a dispatch thread.
 	 */
 	boolean isDispatchThread();
@@ -113,7 +112,7 @@ public interface ThreadService extends SciJavaService, ThreadFactory {
 	 * typically the AWT Event Dispatch Thread (EDT). However, ultimately the
 	 * behavior is implementation-dependent.
 	 * </p>
-	 * 
+	 *
 	 * @param code The code to execute.
 	 * @throws InterruptedException If the code execution is interrupted.
 	 * @throws InvocationTargetException If an uncaught exception occurs in the
@@ -129,7 +128,7 @@ public interface ThreadService extends SciJavaService, ThreadFactory {
 	 * typically the AWT Event Dispatch Thread (EDT). However, ultimately the
 	 * behavior is implementation-dependent.
 	 * </p>
-	 * 
+	 *
 	 * @param code The code to execute.
 	 */
 	void queue(Runnable code);
@@ -139,9 +138,10 @@ public interface ThreadService extends SciJavaService, ThreadFactory {
 	 * <p>
 	 * This works only on threads which the thread service knows about, of course.
 	 * </p>
-	 * 
+	 *
 	 * @param thread the managed thread, null refers to the current thread
-	 * @return the thread that asked the {@link ThreadService} to spawn the specified thread
+	 * @return the thread that asked the {@link ThreadService} to spawn the
+	 *         specified thread
 	 */
 	Thread getParent(Thread thread);
 

--- a/src/main/java/org/scijava/thread/ThreadService.java
+++ b/src/main/java/org/scijava/thread/ThreadService.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 
+import org.scijava.Context;
 import org.scijava.service.SciJavaService;
 
 /**
@@ -45,6 +46,26 @@ import org.scijava.service.SciJavaService;
  * @author Curtis Rueden
  */
 public interface ThreadService extends SciJavaService, ThreadFactory {
+
+	public enum ThreadContext {
+		/**
+		 * The thread was spawned by this thread service; i.e., it belongs to the
+		 * same {@link Context}.
+		 */
+		SAME,
+
+		/**
+		 * The thread was spawned by a SciJava thread service, but not this one;
+		 * i.e., it belongs to a different {@link Context}.
+		 */
+		OTHER,
+
+		/**
+		 * The thread was not spawned via a SciJava thread service, and its
+		 * {@link Context} is unknown or inapplicable.
+		 */
+		NONE
+	}
 
 	/**
 	 * Asynchronously executes the given code in a new thread, as decided by the
@@ -123,4 +144,22 @@ public interface ThreadService extends SciJavaService, ThreadFactory {
 	 * @return the thread that asked the {@link ThreadService} to spawn the specified thread
 	 */
 	Thread getParent(Thread thread);
+
+	/**
+	 * Analyzes the {@link Context} of the given thread.
+	 *
+	 * @param thread The thread to analyze.
+	 * @return Information about the thread's {@link Context}. Either:
+	 *         <ul>
+	 *         <li>{@link ThreadContext#SAME} - The thread was spawned by this
+	 *         very thread service, and thus shares the same {@link Context}.</li>
+	 *         <li>{@link ThreadContext#OTHER} - The thread was spawned by a
+	 *         different thread service, and thus has a different {@link Context}.
+	 *         </li>
+	 *         <li>{@link ThreadContext#NONE} - It is unknown what spawned the
+	 *         thread, so it is effectively {@link Context}-free.</li>
+	 *         </ul>
+	 */
+	ThreadContext getThreadContext(Thread thread);
+
 }

--- a/src/main/java/org/scijava/thread/ThreadService.java
+++ b/src/main/java/org/scijava/thread/ThreadService.java
@@ -98,7 +98,7 @@ public interface ThreadService extends SciJavaService, ThreadFactory {
 	 * @throws InvocationTargetException If an uncaught exception occurs in the
 	 *           code during execution.
 	 */
-	void invoke(final Runnable code) throws InterruptedException,
+	void invoke(Runnable code) throws InterruptedException,
 		InvocationTargetException;
 
 	/**
@@ -111,7 +111,7 @@ public interface ThreadService extends SciJavaService, ThreadFactory {
 	 * 
 	 * @param code The code to execute.
 	 */
-	void queue(final Runnable code);
+	void queue(Runnable code);
 
 	/**
 	 * Returns the thread that called the specified thread.
@@ -122,5 +122,5 @@ public interface ThreadService extends SciJavaService, ThreadFactory {
 	 * @param thread the managed thread, null refers to the current thread
 	 * @return the thread that asked the {@link ThreadService} to spawn the specified thread
 	 */
-	Thread getParent(final Thread thread);
+	Thread getParent(Thread thread);
 }

--- a/src/main/java/org/scijava/util/ClassUtils.java
+++ b/src/main/java/org/scijava/util/ClassUtils.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/src/test/java/org/scijava/console/ConsoleServiceTest.java
+++ b/src/test/java/org/scijava/console/ConsoleServiceTest.java
@@ -35,14 +35,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedList;
+import java.util.concurrent.ExecutionException;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.Priority;
+import org.scijava.console.OutputEvent.Source;
 import org.scijava.plugin.Plugin;
+import org.scijava.thread.ThreadService;
 
 /**
  * Tests {@link ConsoleService}.
@@ -70,6 +76,129 @@ public class ConsoleServiceTest {
 		assertTrue(consoleService.getInstance(FooArgument.class).argsHandled);
 	}
 
+	/**
+	 * Tests the {@link OutputListener}-related API:
+	 * <ul>
+	 * <li>{@link ConsoleService#addOutputListener(OutputListener)}</li>
+	 * <li>{@link ConsoleService#removeOutputListener(OutputListener)}</li>
+	 * <li>{@link ConsoleService#notifyListeners(OutputEvent)}</li>
+	 * </ul>
+	 */
+	@Test
+	public void testOutputListeners() throws InterruptedException,
+		ExecutionException
+	{
+		final ThreadService threadService =
+			consoleService.context().service(ThreadService.class);
+
+		final String stdoutBefore = "hoc";
+		final String stderrBefore = "us-";
+		final String stdoutGlobal = "poc";
+		final String stderrGlobal = "us-";
+		final String stdoutLocal = "abra";
+		final String stderrLocal = "-cad";
+		final String stdoutAfter = "ave";
+		final String stderrAfter = "rs-";
+
+		final ArrayList<OutputEvent> events = new ArrayList<OutputEvent>();
+		final OutputListener outputListener = new OutputTracker(events);
+
+		final Runnable r = new Printer(stdoutLocal, stderrLocal);
+
+		// This output should _not_ be announced!
+		System.out.print(stdoutBefore);
+		System.err.print(stderrBefore);
+
+		consoleService.addOutputListener(outputListener);
+
+		// This output _should_ be announced!
+		System.out.print(stdoutGlobal);
+		System.err.print(stderrGlobal);
+		threadService.run(r).get();
+
+		consoleService.removeOutputListener(outputListener);
+
+		// This output should _not_ be announced!
+		threadService.run(r).get();
+		System.out.print(stdoutAfter);
+		System.err.print(stderrAfter);
+
+		assertEquals(4, events.size());
+
+		assertOutputEvent(Source.STDOUT, stdoutGlobal, false, events.get(0));
+		assertOutputEvent(Source.STDERR, stderrGlobal, false, events.get(1));
+		assertOutputEvent(Source.STDOUT, stdoutLocal, true, events.get(2));
+		assertOutputEvent(Source.STDERR, stderrLocal, true, events.get(3));
+	}
+
+	/** Tests multiple simultaneous {@link Context}s listening for output. */
+	@Test
+	public void testMultipleContextOutput() throws InterruptedException,
+		ExecutionException
+	{
+		final Context c1 = consoleService.context();
+		final Context c2 = new Context();
+
+		final ConsoleService cs1 = consoleService;
+		final ConsoleService cs2 = c2.service(ConsoleService.class);
+
+		final ThreadService ts1 = c1.service(ThreadService.class);
+		final ThreadService ts2 = c2.service(ThreadService.class);
+
+		final ArrayList<OutputEvent> events1 = new ArrayList<OutputEvent>();
+		cs1.addOutputListener(new OutputTracker(events1));
+		final ArrayList<OutputEvent> events2 = new ArrayList<OutputEvent>();
+		cs2.addOutputListener(new OutputTracker(events2));
+
+		final String globalOut = "and";
+		final String globalErr = "-zo";
+		final String c1RunOut = "mbi";
+		final String c1RunErr = "es-";
+		final String c2RunOut = "sha";
+		final String c2RunErr = "zam";
+		final String c1InvokeOut = "-cl";
+		final String c1InvokeErr = "eop";
+		final String c2InvokeOut = "atr";
+		final String c2InvokeErr = "a";
+
+		System.out.print(globalOut);
+		System.err.print(globalErr);
+
+		ts1.run(new Printer(c1RunOut, c1RunErr)).get();
+		ts2.run(new Printer(c2RunOut, c2RunErr)).get();
+
+		ts1.run(new EDTPrinter(ts1, c1InvokeOut, c1InvokeErr));
+		ts2.run(new EDTPrinter(ts2, c2InvokeOut, c2InvokeErr));
+
+		c2.dispose();
+
+		assertEquals(6, events1.size());
+		assertOutputEvent(Source.STDOUT, globalOut, false, events1.get(0));
+		assertOutputEvent(Source.STDERR, globalErr, false, events1.get(1));
+		assertOutputEvent(Source.STDOUT, c1RunOut, true, events1.get(2));
+		assertOutputEvent(Source.STDERR, c1RunErr, true, events1.get(3));
+		assertOutputEvent(Source.STDOUT, c1InvokeOut, true, events1.get(4));
+		assertOutputEvent(Source.STDERR, c1InvokeErr, true, events1.get(5));
+
+		assertEquals(6, events2.size());
+		assertOutputEvent(Source.STDOUT, globalOut, false, events2.get(0));
+		assertOutputEvent(Source.STDERR, globalErr, false, events2.get(1));
+		assertOutputEvent(Source.STDOUT, c2RunOut, true, events2.get(2));
+		assertOutputEvent(Source.STDERR, c2RunErr, true, events2.get(3));
+		assertOutputEvent(Source.STDOUT, c2InvokeOut, true, events2.get(4));
+		assertOutputEvent(Source.STDERR, c2InvokeErr, true, events2.get(5));
+	}
+
+	// -- Helper methods --
+
+	private void assertOutputEvent(final Source source, final String output,
+		final boolean contextual, final OutputEvent event)
+	{
+		assertEquals(source, event.getSource());
+		assertEquals(output, event.getOutput());
+		assertEquals(contextual, event.isContextual());
+	}
+
 	// -- Helper classes --
 
 	@Plugin(type = ConsoleArgument.class, priority = Priority.HIGH_PRIORITY)
@@ -85,6 +214,66 @@ public class ConsoleServiceTest {
 			assertEquals("--bar", args.get(1));
 			args.clear();
 			argsHandled = true;
+		}
+
+	}
+
+	private static class OutputTracker implements OutputListener {
+
+		private final Collection<OutputEvent> events;
+
+		private OutputTracker(final Collection<OutputEvent> events) {
+			this.events = events;
+		}
+
+		@Override
+		public void outputOccurred(final OutputEvent event) {
+			events.add(event);
+		}
+
+	}
+
+	private static class Printer implements Runnable {
+
+		private final String out;
+		private final String err;
+
+		private Printer(final String out, final String err) {
+			this.out = out;
+			this.err = err;
+		}
+
+		@Override
+		public void run() {
+			System.out.print(out);
+			System.err.print(err);
+		}
+
+	}
+
+	private static class EDTPrinter implements Runnable {
+
+		private final ThreadService ts;
+		private final Printer p;
+
+		private EDTPrinter(final ThreadService ts, final String out,
+			final String err)
+		{
+			this.ts = ts;
+			p = new Printer(out, err);
+		}
+
+		@Override
+		public void run() {
+			try {
+				ts.invoke(p);
+			}
+			catch (final InvocationTargetException exc) {
+				throw new RuntimeException(exc);
+			}
+			catch (final InterruptedException exc) {
+				throw new RuntimeException(exc);
+			}
 		}
 
 	}

--- a/src/test/java/org/scijava/console/ConsoleServiceTest.java
+++ b/src/test/java/org/scijava/console/ConsoleServiceTest.java
@@ -1,0 +1,92 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.console;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedList;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Tests {@link ConsoleService}.
+ *
+ * @author Curtis Rueden
+ */
+public class ConsoleServiceTest {
+
+	private ConsoleService consoleService;
+
+	@Before
+	public void setUp() {
+		consoleService = new Context().service(ConsoleService.class);
+	}
+
+	@After
+	public void tearDown() {
+		consoleService.context().dispose();
+	}
+
+	/** Tests {@link ConsoleService#processArgs(String...)}. */
+	@Test
+	public void testProcessArgs() {
+		consoleService.processArgs("--foo", "--bar");
+		assertTrue(consoleService.getInstance(FooArgument.class).argsHandled);
+	}
+
+	// -- Helper classes --
+
+	@Plugin(type = ConsoleArgument.class, priority = Priority.HIGH_PRIORITY)
+	public static class FooArgument extends AbstractConsoleArgument {
+
+		private boolean argsHandled;
+
+		@Override
+		public void handle(final LinkedList<String> args) {
+			assertNotNull(args);
+			assertEquals(2, args.size());
+			assertEquals("--foo", args.get(0));
+			assertEquals("--bar", args.get(1));
+			args.clear();
+			argsHandled = true;
+		}
+
+	}
+
+}


### PR DESCRIPTION
This branch adds API so that interested parties can register as listeners for stdout and stderr. But not just _any_ old stdout and stderr messages—only those emitted by threads associated with the relevant SciJava application context. "Pretty snazzy," I hear you say. Well you're darn tootin' it is!