### PR TITLE
Script values

### DIFF
--- a/src/main/java/org/scijava/module/AbstractModuleItem.java
+++ b/src/main/java/org/scijava/module/AbstractModuleItem.java
@@ -74,6 +74,7 @@ public abstract class AbstractModuleItem<T> extends AbstractBasicDetails
 		sm.append("persistKey", getPersistKey());
 		sm.append("callback", getCallback());
 		sm.append("widgetStyle", getWidgetStyle());
+		sm.append("default", getDefaultValue());
 		sm.append("min", getMinimumValue());
 		sm.append("max", getMaximumValue());
 		sm.append("softMin", getSoftMinimum());
@@ -214,6 +215,11 @@ public abstract class AbstractModuleItem<T> extends AbstractBasicDetails
 
 	@Override
 	public String getWidgetStyle() {
+		return null;
+	}
+
+	@Override
+	public T getDefaultValue() {
 		return null;
 	}
 

--- a/src/main/java/org/scijava/module/AbstractModuleItem.java
+++ b/src/main/java/org/scijava/module/AbstractModuleItem.java
@@ -76,6 +76,8 @@ public abstract class AbstractModuleItem<T> extends AbstractBasicDetails
 		sm.append("widgetStyle", getWidgetStyle());
 		sm.append("min", getMinimumValue());
 		sm.append("max", getMaximumValue());
+		sm.append("softMin", getSoftMinimum());
+		sm.append("softMax", getSoftMaximum());
 		sm.append("stepSize", getStepSize(), NumberUtils.toNumber("1", getType()));
 		sm.append("columnCount", getColumnCount(), 6);
 		sm.append("choices", getChoices());

--- a/src/main/java/org/scijava/module/DefaultModuleService.java
+++ b/src/main/java/org/scijava/module/DefaultModuleService.java
@@ -302,6 +302,8 @@ public class DefaultModuleService extends AbstractService implements
 	
 	@Override
 	public <T> T getDefaultValue(final ModuleItem<T> item) {
+		final T defaultValue = item.getDefaultValue();
+		if (defaultValue != null) return defaultValue;
 		final T min = item.getMinimumValue();
 		if (min != null) return min;
 		final T softMin = item.getSoftMinimum();

--- a/src/main/java/org/scijava/module/DefaultMutableModuleItem.java
+++ b/src/main/java/org/scijava/module/DefaultMutableModuleItem.java
@@ -59,6 +59,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	private String initializer;
 	private String callback;
 	private String widgetStyle;
+	private T defaultValue;
 	private T minimumValue;
 	private T maximumValue;
 	private T softMinimum;
@@ -172,6 +173,11 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	}
 
 	@Override
+	public void setDefaultValue(final T defaultValue) {
+		this.defaultValue = defaultValue;
+	}
+
+	@Override
 	public void setMinimumValue(final T minimumValue) {
 		this.minimumValue = minimumValue;
 	}
@@ -257,6 +263,11 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	@Override
 	public String getWidgetStyle() {
 		return widgetStyle;
+	}
+
+	@Override
+	public T getDefaultValue() {
+		return defaultValue;
 	}
 
 	@Override

--- a/src/main/java/org/scijava/module/ModuleItem.java
+++ b/src/main/java/org/scijava/module/ModuleItem.java
@@ -146,6 +146,9 @@ public interface ModuleItem<T> extends BasicDetails {
 	 */
 	String getWidgetStyle();
 
+	/** Gets the default value. */
+	T getDefaultValue();
+
 	/** Gets the minimum allowed value (if applicable). */
 	T getMinimumValue();
 

--- a/src/main/java/org/scijava/module/MutableModuleItem.java
+++ b/src/main/java/org/scijava/module/MutableModuleItem.java
@@ -60,6 +60,8 @@ public interface MutableModuleItem<T> extends ModuleItem<T> {
 
 	void setWidgetStyle(String widgetStyle);
 
+	void setDefaultValue(T defaultValue);
+
 	void setMinimumValue(T minimumValue);
 
 	void setMaximumValue(T maximumValue);

--- a/src/main/java/org/scijava/module/process/DefaultValuePreprocessor.java
+++ b/src/main/java/org/scijava/module/process/DefaultValuePreprocessor.java
@@ -1,0 +1,78 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.module.process;
+
+import org.scijava.Priority;
+import org.scijava.module.Module;
+import org.scijava.module.ModuleItem;
+import org.scijava.module.ModuleService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * A preprocessor plugin that populates default parameter values.
+ * <p>
+ * Default values are determined using {@link ModuleService#getDefaultValue}.
+ * </p>
+ *
+ * @author Curtis Rueden
+ */
+@Plugin(type = PreprocessorPlugin.class, priority = Priority.VERY_HIGH_PRIORITY)
+public class DefaultValuePreprocessor extends AbstractPreprocessorPlugin {
+
+	@Parameter
+	private ModuleService moduleService;
+
+	// -- ModuleProcessor methods --
+
+	@Override
+	public void process(final Module module) {
+		for (final ModuleItem<?> input : module.getInfo().inputs()) {
+			assignDefaultValue(module, input);
+		}
+		for (final ModuleItem<?> output : module.getInfo().outputs()) {
+			assignDefaultValue(module, output);
+		}
+	}
+
+	// -- Helper methods --
+
+	private <T> void assignDefaultValue(final Module module,
+		final ModuleItem<T> item)
+	{
+		if (module.isResolved(item.getName())) return;
+		final T defaultValue = moduleService.getDefaultValue(item);
+		if (defaultValue == null) return;
+		item.setValue(module, defaultValue);
+	}
+
+}

--- a/src/main/java/org/scijava/script/ScriptInfo.java
+++ b/src/main/java/org/scijava/script/ScriptInfo.java
@@ -461,7 +461,7 @@ public class ScriptInfo extends AbstractModuleInfo implements Contextual {
 			item.setVisibility(convertService.convert(value, ItemVisibility.class));
 		}
 		else if ("value".equalsIgnoreCase(key)) {
-			item.setWidgetStyle(value);
+			item.setDefaultValue(convertService.convert(value, item.getType()));
 		}
 		else {
 			throw new ScriptException("Invalid attribute name: " + key);


### PR DESCRIPTION
This branch makes default values work better:
* It gives the `ModuleItem` a default value property which can be retrieved and (in the case of `MutableModuleItem`) set.
* It uses that property for the default value, via a new `DefaultValuePreprocessor`. This eliminates the inconsistency between default value handling of primitives and their `java.lang` wrapper types.
* It adds a `value` attribute to script parameter parsing, so that you can write e.g. `@int(value=5) sigma` to set a default value for script parameters. (Ideally, we'd support `@int sigma = 5` too, but for the moment that would be more work, so we can punt for now.)