### PR TITLE
Add API to give explicit file chooser title

### DIFF
--- a/src/main/java/org/scijava/ui/AbstractUserInterface.java
+++ b/src/main/java/org/scijava/ui/AbstractUserInterface.java
@@ -31,6 +31,7 @@
 
 package org.scijava.ui;
 
+import java.io.File;
 import java.util.List;
 
 import org.scijava.app.StatusService;
@@ -47,6 +48,7 @@ import org.scijava.thread.ThreadService;
 import org.scijava.ui.console.ConsolePane;
 import org.scijava.ui.viewer.DisplayViewer;
 import org.scijava.ui.viewer.DisplayWindow;
+import org.scijava.widget.FileWidget;
 
 /**
  * Abstract superclass for {@link UserInterface} implementations.
@@ -187,6 +189,19 @@ public abstract class AbstractUserInterface extends AbstractRichPlugin
 	}
 
 	@Override
+	public File chooseFile(final File file, final String style) {
+		return chooseFile(fileChooserTitle(style), file, style);
+	}
+
+	@Deprecated
+	@Override
+	public File chooseFile(final String title, final File file,
+		final String style)
+	{
+		throw new UnsupportedOperationException("No default implementation.");
+	}
+
+	@Override
 	public void saveLocation() {
 		final ApplicationFrame appFrame = getApplicationFrame();
 		if (appFrame != null) {
@@ -214,6 +229,14 @@ public abstract class AbstractUserInterface extends AbstractRichPlugin
 	 */
 	protected void createUI() {
 		restoreLocation();
+	}
+
+	/** Gets a default file chooser title to use when none is given. */
+	protected String fileChooserTitle(final String style) {
+		if (style.equals(FileWidget.DIRECTORY_STYLE)) return "Choose a directory";
+		if (style.equals(FileWidget.OPEN_STYLE)) return "Open";
+		if (style.equals(FileWidget.SAVE_STYLE)) return "Save";
+		return "Choose a file";
 	}
 
 }

--- a/src/main/java/org/scijava/ui/DefaultUIService.java
+++ b/src/main/java/org/scijava/ui/DefaultUIService.java
@@ -341,6 +341,15 @@ public final class DefaultUIService extends AbstractService implements
 	}
 
 	@Override
+	public File
+		chooseFile(final String title, final File file, final String style)
+	{
+		final UserInterface ui = getDefaultUI();
+		if (ui == null) return null;
+		return ui.chooseFile(title, file, style);
+	}
+
+	@Override
 	public void showContextMenu(final String menuRoot, final Display<?> display,
 		final int x, final int y)
 	{

--- a/src/main/java/org/scijava/ui/UIService.java
+++ b/src/main/java/org/scijava/ui/UIService.java
@@ -277,6 +277,23 @@ public interface UIService extends SciJavaService {
 	File chooseFile(File file, String style);
 
 	/**
+	 * Prompts the user to choose a file.
+	 * <p>
+	 * The prompt is displayed in the default user interface.
+	 * </p>
+	 * 
+	 * @param title Title to use in the file chooser dialog.
+	 * @param file The initial value displayed in the file chooser prompt.
+	 * @param style The style of chooser to use:
+	 *          <ul>
+	 *          <li>{@link FileWidget#OPEN_STYLE}</li>
+	 *          <li>{@link FileWidget#SAVE_STYLE}</li>
+	 *          <li>{@link FileWidget#DIRECTORY_STYLE}</li>
+	 *          </ul>
+	 */
+	File chooseFile(String title, File file, String style);
+
+	/**
 	 * Displays a popup context menu for the given display at the specified
 	 * position.
 	 * <p>

--- a/src/main/java/org/scijava/ui/UserInterface.java
+++ b/src/main/java/org/scijava/ui/UserInterface.java
@@ -134,6 +134,20 @@ public interface UserInterface extends RichPlugin, Disposable {
 	File chooseFile(File file, String style);
 
 	/**
+	 * Prompts the user to choose a file.
+	 * 
+	 * @param title Title to use in the file chooser dialog.
+	 * @param file The initial value displayed in the file chooser prompt.
+	 * @param style The style of chooser to use:
+	 *          <ul>
+	 *          <li>{@link FileWidget#OPEN_STYLE}</li>
+	 *          <li>{@link FileWidget#SAVE_STYLE}</li>
+	 *          <li>{@link FileWidget#DIRECTORY_STYLE}</li>
+	 *          </ul>
+	 */
+	File chooseFile(String title, File file, String style);
+
+	/**
 	 * Displays a popup context menu for the given display at the specified
 	 * position.
 	 */


### PR DESCRIPTION
The method `UserInterface#chooseFile(String, File, String)` is given a deprecated default implementation in `AbstractUserInterface` to avoid requiring a major version bump according to SemVer.