### PR TITLE
Use generic types in the ConvertRequest class

### DIFF
--- a/src/main/java/org/scijava/convert/ConversionRequest.java
+++ b/src/main/java/org/scijava/convert/ConversionRequest.java
@@ -33,6 +33,8 @@ package org.scijava.convert;
 
 import java.lang.reflect.Type;
 
+import org.scijava.util.GenericUtils;
+
 /**
  * Currency for use in {@link Converter} and {@link ConvertService}
  * methods.
@@ -57,45 +59,49 @@ import java.lang.reflect.Type;
  * </p>
  *
  * @author Mark Hiner
+ * @author Curtis Rueden
  */
 public class ConversionRequest {
 
 	// -- Fields --
 
-	private final Class<?> srcClass;
+	private final Type srcType;
+	private final Type destType;
+
 	private Object src;
-	private Class<?> destClass;
-	private Type destType;
 
 	// -- Constructors --
 
-	public ConversionRequest(final Object s, final Class<?> d) {
-		this(s == null ? null : s.getClass(), d);
-		src = s;
+	public ConversionRequest(final Object src, final Type destType) {
+		this(src, src == null ? null : src.getClass(), destType);
 	}
 
-	public ConversionRequest(final Class<?> s, final Class<?> d) {
-		srcClass = s;
-		destClass = d;
+	public ConversionRequest(final Type srcType, final Type destType) {
+		this(null, srcType, destType);
 	}
 
-	public ConversionRequest(final Object s, final Type d) {
-		this(s == null ? null : s.getClass(), d);
-		src = s;
-	}
-
-	public ConversionRequest(final Class<?> s, final Type d) {
-		srcClass = s;
-		destType = d;
+	public ConversionRequest(final Object src, final Type srcType,
+		final Type destType)
+	{
+		this.src = src;
+		this.srcType = srcType;
+		this.destType = destType;
 	}
 
 	// -- Accessors --
 
 	/**
+	 * @return Source type for conversion or lookup.
+	 */
+	public Type sourceType() {
+		return srcType;
+	}
+
+	/**
 	 * @return Source class for conversion or lookup.
 	 */
 	public Class<?> sourceClass() {
-		return srcClass;
+		return GenericUtils.getClass(srcType);
 	}
 
 	/**
@@ -116,7 +122,7 @@ public class ConversionRequest {
 	 * @return Destination class for conversion.
 	 */
 	public Class<?> destClass() {
-		return destClass;
+		return GenericUtils.getClass(destType);
 	}
 
 	// -- Setters --
@@ -128,11 +134,13 @@ public class ConversionRequest {
 	 *           not match {@link #sourceClass()}.
 	 */
 	public void setSourceObject(final Object o) {
-		if (!srcClass.isAssignableFrom(o.getClass())) {
+		// TODO: More careful check against srcType itself.
+		if (!sourceClass().isInstance(o)) {
 			throw new IllegalArgumentException("Object of type: " + o.getClass() +
-				" provided. Expected: " + srcClass);
+				" provided. Expected: " + srcType);
 		}
 
 		src = o;
 	}
+
 }

--- a/src/main/java/org/scijava/convert/ConversionRequest.java
+++ b/src/main/java/org/scijava/convert/ConversionRequest.java
@@ -119,7 +119,7 @@ public class ConversionRequest {
 		return destClass;
 	}
 
-// -- Setters --
+	// -- Setters --
 
 	/**
 	 * Sets the source object for this {@link ConversionRequest}.

--- a/src/main/java/org/scijava/convert/ConversionRequest.java
+++ b/src/main/java/org/scijava/convert/ConversionRequest.java
@@ -63,7 +63,7 @@ public class ConversionRequest {
 	// -- Fields --
 
 	private final Class<?> srcClass;
-	private Object srcObject;
+	private Object src;
 	private Class<?> destClass;
 	private Type destType;
 
@@ -71,7 +71,7 @@ public class ConversionRequest {
 
 	public ConversionRequest(final Object s, final Class<?> d) {
 		this(s == null ? null : s.getClass(), d);
-		srcObject = s;
+		src = s;
 	}
 
 	public ConversionRequest(final Class<?> s, final Class<?> d) {
@@ -81,7 +81,7 @@ public class ConversionRequest {
 
 	public ConversionRequest(final Object s, final Type d) {
 		this(s == null ? null : s.getClass(), d);
-		srcObject = s;
+		src = s;
 	}
 
 	public ConversionRequest(final Class<?> s, final Type d) {
@@ -102,7 +102,7 @@ public class ConversionRequest {
 	 * @return Source object for conversion.
 	 */
 	public Object sourceObject() {
-		return srcObject;
+		return src;
 	}
 
 	/**
@@ -133,6 +133,6 @@ public class ConversionRequest {
 				" provided. Expected: " + srcClass);
 		}
 
-		srcObject = o;
+		src = o;
 	}
 }

--- a/src/main/java/org/scijava/convert/Converter.java
+++ b/src/main/java/org/scijava/convert/Converter.java
@@ -47,8 +47,7 @@ import org.scijava.plugin.Plugin;
  * @see ConversionRequest
  * @author Mark Hiner
  */
-public interface Converter<I, O> extends HandlerPlugin<ConversionRequest>
-{
+public interface Converter<I, O> extends HandlerPlugin<ConversionRequest> {
 
 	/**
 	 * Checks whether a given {@ConversionRequest} can be


### PR DESCRIPTION
A converter may need to verify type compatibility not just at the
Class level, but potentially for any generic type. Generic types are
not available at runtime from object instances, but they are
available in other scenarios; e.g., the ImageJ OPS framework uses the
converter framework to decide type compatibility (i.e., assignability
or convertibility) based on generic types. This is possible (rather
than generics being erased at runtime) because OPS parameters are
declared as instance fields, which can be introspected at runtime.