### PR TITLE
Set locale to US so that the strings are always formated as expected.

### DIFF
--- a/src/main/java/org/scijava/util/UnitUtils.java
+++ b/src/main/java/org/scijava/util/UnitUtils.java
@@ -31,6 +31,8 @@
 
 package org.scijava.util;
 
+import java.util.Locale;
+
 /**
  * Utility methods for working with units.
  * 
@@ -63,7 +65,7 @@ public final class UnitUtils {
 
 		// format result with 0 decimal places for bytes, or 1 for larger values
 		final String format = pow == 0 ? "%.0f%s" : "%.1f%s";
-		return String.format(format, value, BYTE_UNITS[pow]);
+		return String.format(Locale.US, format, value, BYTE_UNITS[pow]);
 	}
 
 }


### PR DESCRIPTION
In European locales "," is used as decimal seperator instead of ".". String.format(..) automatically converts decimal numbers,
making some unit tests fail on systems with certain European locales.