### PR TITLE
ThreadService: add API for backing ExecutorService

### DIFF
--- a/src/main/java/org/scijava/thread/DefaultThreadService.java
+++ b/src/main/java/org/scijava/thread/DefaultThreadService.java
@@ -84,6 +84,16 @@ public final class DefaultThreadService extends AbstractService implements
 	}
 
 	@Override
+	public ExecutorService getExecutorService() {
+		return executor();
+	}
+
+	@Override
+	public void setExecutorService(final ExecutorService executor) {
+		this.executor = executor;
+	}
+
+	@Override
 	public boolean isDispatchThread() {
 		return EventQueue.isDispatchThread();
 	}

--- a/src/main/java/org/scijava/thread/ThreadService.java
+++ b/src/main/java/org/scijava/thread/ThreadService.java
@@ -33,6 +33,7 @@ package org.scijava.thread;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 
@@ -90,6 +91,24 @@ public interface ThreadService extends SciJavaService, ThreadFactory {
 	 *         finished. Call {@link Future#get()} to do so.
 	 */
 	Future<?> run(Runnable code);
+
+	/**
+	 * Gets the {@link ExecutorService} object used when {@link #run} is called.
+	 * 
+	 * @return the {@link ExecutorService}, or null if an {@link ExecutorService}
+	 *         is not used in this {@link ThreadService} implementation.
+	 */
+	ExecutorService getExecutorService();
+
+	/**
+	 * Sets the {@link ExecutorService} object used when {@link #run} is called.
+	 * 
+	 * @param executor The {@link ExecutorService} for this {@link ThreadService}
+	 *          to use internally for {@link #run} calls.
+	 * @throws UnsupportedOperationException if this {@link ThreadService} does
+	 *           not use an {@link ExecutorService} to handle {@link #run} calls.
+	 */
+	void setExecutorService(ExecutorService executor);
 
 	/**
 	 * Gets whether the current thread is a dispatch thread for use with


### PR DESCRIPTION
For some uses cases (particularly for certain calls to ImgLib2 functionality), it is helpful to have access to the ExecutorService being used internally by the ThreadService. And while we're at it, we may as well make the ExecutorService itself configurable.

I have a vague intuition that ExecutorService is probably not applicable to all threading models of all possible sorts of Java runtimes, so I include a caveat in the javadoc that the accessor is allowed to return null, and the mutator is allowed to throw UnsupportedOperationException, if the ThreadService implementation does not use an ExecutorService.