### PR TITLE
Independent Readers in ScriptInfo

### DIFF
--- a/src/test/java/org/scijava/script/ScriptInfoTest.java
+++ b/src/test/java/org/scijava/script/ScriptInfoTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
@@ -122,6 +123,26 @@ public class ScriptInfoTest {
 
 		// clean up the temporary directory
 		FileUtils.deleteRecursively(tmpDir);
+	}
+
+	/**
+	 * Ensures the ScriptInfos Reader can be reused for multiple executions of the
+	 * script.
+	 */
+	@Test
+	public void testReaderSanity() throws Exception {
+		final String script = "" + //
+			"% @LogService log\n" + //
+			"% @OUTPUT Integer output";
+
+		ScriptInfo info = new ScriptInfo(context, "hello.bsizes", new StringReader(
+			script));
+		BufferedReader reader1 = info.getReader();
+		BufferedReader reader2 = info.getReader();
+
+		assertEquals("Readers are not independent.", reader1.read(), reader2
+			.read());
+
 	}
 
 	@Plugin(type = ScriptLanguage.class)


### PR DESCRIPTION
Hi @ctrueden !

here is the pullrequest promised in https://github.com/scijava/scripting-jython/issues/6. My solution changes `ScriptInfo` as follows:

*Instead of `ScriptInfo.getReader()` returning the reader passed onto the constructor of ScriptInfo, the constructor now reads the entire contents of the Reader into a string, so that `ScriptInfo.getReader()` can return a new `StringReader`.*

Greetings, 
Squareys