### PR TITLE
Make FileUtils.stripFilenameVersion support jogamp

### DIFF
--- a/src/main/java/org/scijava/util/FileUtils.java
+++ b/src/main/java/org/scijava/util/FileUtils.java
@@ -70,6 +70,9 @@ public final class FileUtils {
 	public static final String SHORTENER_SLASH = "/";
 	public static final String SHORTENER_ELLIPSE = "...";
 
+	/** A regular expression to match filenames containing version information. */
+	private static final Pattern VERSION_PATTERN = buildVersionPattern();
+
 	private FileUtils() {
 		// prevent instantiation of utility class
 	}
@@ -170,13 +173,8 @@ public final class FileUtils {
 		}
 	}
 
-	/** A regular expression to match filenames containing version information. */
-	private final static Pattern versionPattern =
-		Pattern
-			.compile("(.+?)(-\\d+(\\.\\d+|\\d{7})+[a-z]?\\d?(-[A-Za-z0-9.]+?|\\.GA)*?)?((-(swing|swt|shaded|sources|javadoc|native|linux-x86|linux-x86_64|macosx-x86_64|windows-x86|windows-x86_64|android-arm|android-x86))?(\\.jar(-[a-z]*)?))");
-
 	public static String stripFilenameVersion(final String filename) {
-		final Matcher matcher = versionPattern.matcher(filename);
+		final Matcher matcher = VERSION_PATTERN.matcher(filename);
 		if (!matcher.matches()) return filename;
 		return matcher.group(1) + matcher.group(5);
 	}
@@ -191,7 +189,7 @@ public final class FileUtils {
 	public static File[] getAllVersions(final File directory,
 		final String filename)
 	{
-		final Matcher matcher = versionPattern.matcher(filename);
+		final Matcher matcher = VERSION_PATTERN.matcher(filename);
 		if (!matcher.matches()) {
 			final File file = new File(directory, filename);
 			return file.exists() ? new File[] { file } : null;
@@ -203,7 +201,7 @@ public final class FileUtils {
 			@Override
 			public boolean accept(final File dir, final String name) {
 				if (!name.startsWith(baseName)) return false;
-				final Matcher matcher2 = versionPattern.matcher(name);
+				final Matcher matcher2 = VERSION_PATTERN.matcher(name);
 				return matcher2.matches() && baseName.equals(matcher2.group(1)) &&
 						equals(classifier, matcher2.group(6));
 			}
@@ -609,6 +607,43 @@ public final class FileUtils {
 		return result;
 	}
 
+	// -- Helper methods --
+
+	/** Builds the {@link #VERSION_PATTERN} constant. */
+	private static Pattern buildVersionPattern() {
+		final String version =
+			"\\d+(\\.\\d+|\\d{7})+[a-z]?\\d?(-[A-Za-z0-9.]+?|\\.GA)*?";
+		final String suffix = "\\.jar(-[a-z]*)?";
+		return Pattern.compile("(.+?)(-" + version + ")?((-(" + classifiers() +
+			"))?(" + suffix + "))");
+	}
+
+	/** Helper method of {@link #buildVersionPattern()}. */
+	private static String classifiers() {
+		final String[] classifiers = {
+			"swing",
+			"swt",
+			"shaded",
+			"sources",
+			"javadoc",
+			"native",
+			"linux-x86",
+			"linux-x86_64",
+			"macosx-x86_64",
+			"windows-x86",
+			"windows-x86_64",
+			"android-arm",
+			"android-x86",
+		};
+		final StringBuilder sb = new StringBuilder("(");
+		for (final String classifier : classifiers) {
+			if (sb.length() > 1) sb.append("|");
+			sb.append(classifier);
+		}
+		sb.append(")");
+		return sb.toString();
+	}
+
 	// -- Deprecated methods --
 
 	/**
@@ -620,7 +655,7 @@ public final class FileUtils {
 	 */
 	@Deprecated
 	public static Matcher matchVersionedFilename(final String filename) {
-		return versionPattern.matcher(filename);
+		return VERSION_PATTERN.matcher(filename);
 	}
 
 }

--- a/src/main/java/org/scijava/util/FileUtils.java
+++ b/src/main/java/org/scijava/util/FileUtils.java
@@ -627,8 +627,8 @@ public final class FileUtils {
 			"sources",
 			"javadoc",
 			"native",
-			"(android|linux|macosx|windows)-" +
-				"(arm|x86|x86_64)",
+			"(android|linux|macosx|solaris|windows)-" +
+				"(aarch64|amd64|arm|armv6|armv6hf|i586|universal|x86|x86_64)",
 		};
 		final StringBuilder sb = new StringBuilder("(");
 		for (final String classifier : classifiers) {

--- a/src/main/java/org/scijava/util/FileUtils.java
+++ b/src/main/java/org/scijava/util/FileUtils.java
@@ -627,7 +627,7 @@ public final class FileUtils {
 			"sources",
 			"javadoc",
 			"native",
-			"(android|linux|macosx|solaris|windows)-" +
+			"(natives-)?(android|linux|macosx|solaris|windows)-" +
 				"(aarch64|amd64|arm|armv6|armv6hf|i586|universal|x86|x86_64)",
 		};
 		final StringBuilder sb = new StringBuilder("(");

--- a/src/main/java/org/scijava/util/FileUtils.java
+++ b/src/main/java/org/scijava/util/FileUtils.java
@@ -627,13 +627,8 @@ public final class FileUtils {
 			"sources",
 			"javadoc",
 			"native",
-			"linux-x86",
-			"linux-x86_64",
-			"macosx-x86_64",
-			"windows-x86",
-			"windows-x86_64",
-			"android-arm",
-			"android-x86",
+			"(android|linux|macosx|windows)-" +
+				"(arm|x86|x86_64)",
 		};
 		final StringBuilder sb = new StringBuilder("(");
 		for (final String classifier : classifiers) {

--- a/src/test/java/org/scijava/util/FileUtilsTest.java
+++ b/src/test/java/org/scijava/util/FileUtilsTest.java
@@ -299,6 +299,18 @@ public class FileUtilsTest {
 		assertEquals("jars/ffmpeg-android-x86.jar", FileUtils.stripFilenameVersion("jars/ffmpeg-2.6.1-0.11-android-x86.jar"));
 		assertEquals("jars/ffmpeg-android-arm.jar", FileUtils.stripFilenameVersion("jars/ffmpeg-2.6.1-0.11-android-arm.jar"));
 
+		// Test the jogamp style of native binary .jars
+		assertEquals("jars/jogl-all-natives-android-aarch64.jar", FileUtils.stripFilenameVersion("jars/jogl-all-2.3.0-natives-android-aarch64.jar"));
+		assertEquals("jars/jogl-all-natives-android-armv6.jar", FileUtils.stripFilenameVersion("jars/jogl-all-2.3.0-natives-android-armv6.jar"));
+		assertEquals("jars/jogl-all-natives-linux-amd64.jar", FileUtils.stripFilenameVersion("jars/jogl-all-2.3.0-natives-linux-amd64.jar"));
+		assertEquals("jars/jogl-all-natives-linux-armv6.jar", FileUtils.stripFilenameVersion("jars/jogl-all-2.3.0-natives-linux-armv6.jar"));
+		assertEquals("jars/jogl-all-natives-linux-armv6hf.jar", FileUtils.stripFilenameVersion("jars/jogl-all-2.3.0-natives-linux-armv6hf.jar"));
+		assertEquals("jars/jogl-all-natives-linux-i586.jar", FileUtils.stripFilenameVersion("jars/jogl-all-2.3.0-natives-linux-i586.jar"));
+		assertEquals("jars/jogl-all-natives-macosx-universal.jar", FileUtils.stripFilenameVersion("jars/jogl-all-2.3.0-natives-macosx-universal.jar"));
+		assertEquals("jars/jogl-all-natives-solaris-amd64.jar", FileUtils.stripFilenameVersion("jars/jogl-all-2.3.0-natives-solaris-amd64.jar"));
+		assertEquals("jars/jogl-all-natives-solaris-i586.jar", FileUtils.stripFilenameVersion("jars/jogl-all-2.3.0-natives-solaris-i586.jar"));
+		assertEquals("jars/jogl-all-natives-windows-amd64.jar", FileUtils.stripFilenameVersion("jars/jogl-all-2.3.0-natives-windows-amd64.jar"));
+		assertEquals("jars/jogl-all-natives-windows-i586.jar", FileUtils.stripFilenameVersion("jars/jogl-all-2.3.0-natives-windows-i586.jar"));
 	}
 
 	@Test


### PR DESCRIPTION
Actually, it is more general than that: it identifies native platform suffixes more generally now, which will hopefully work with more than just the jogamp platform artifacts.

But we do add a test explicitly for jogamp's jogl-all artifacts, since those are the ones we acutely need to support.

@hinerm Could you please do a quick review?