### PR TITLE
Fix ignore step size

### DIFF
--- a/src/main/java/org/scijava/command/CommandModuleItem.java
+++ b/src/main/java/org/scijava/command/CommandModuleItem.java
@@ -145,7 +145,14 @@ public class CommandModuleItem<T> extends AbstractModuleItem<T> {
 
 	@Override
 	public Number getStepSize() {
-		return tValue(getParameter().stepSize(), Number.class);
+		final String value = getParameter().stepSize();
+		try {
+			final double stepSize = Double.parseDouble(value);
+			return stepSize;
+		}
+		catch (final NumberFormatException exc) {
+			return tValue(value, Number.class);
+		}
 	}
 
 	@Override

--- a/src/test/java/org/scijava/command/InvalidCommandTest.java
+++ b/src/test/java/org/scijava/command/InvalidCommandTest.java
@@ -71,6 +71,10 @@ public class InvalidCommandTest {
 		final List<ValidityProblem> problems = info.getProblems();
 		assertNotNull(problems);
 		assertEquals(0, problems.size());
+		
+		final Number stepSize = info.getInput("x").getStepSize();
+		assertNotNull(stepSize);
+		assertEquals(10, stepSize.intValue());
 	}
 
 	@Test
@@ -101,7 +105,7 @@ public class InvalidCommandTest {
 	@Plugin(type = Command.class)
 	public static class ValidCommand implements Command {
 
-		@Parameter
+		@Parameter(stepSize = "10")
 		private double x;
 
 		@Parameter(type = ItemIO.OUTPUT)


### PR DESCRIPTION
The step size attribute of a parameter is always ignored because there
is no converter that converts String to Number. The bug is fixed by
parsing the String to double. Similar bug exists in the script editor
and has been fixed.

See also:
c0ffe39
#205