### PR TITLE
Fix bug of overwriting pre-assigned values

### DIFF
--- a/src/main/java/org/scijava/module/process/DefaultValuePreprocessor.java
+++ b/src/main/java/org/scijava/module/process/DefaultValuePreprocessor.java
@@ -37,6 +37,8 @@ import org.scijava.module.ModuleItem;
 import org.scijava.module.ModuleService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import org.scijava.util.ConversionUtils;
+import org.scijava.util.MiscUtils;
 
 /**
  * A preprocessor plugin that populates default parameter values.
@@ -70,6 +72,8 @@ public class DefaultValuePreprocessor extends AbstractPreprocessorPlugin {
 		final ModuleItem<T> item)
 	{
 		if (module.isResolved(item.getName())) return;
+		final T nullValue = ConversionUtils.getNullValue(item.getType());
+		if (MiscUtils.equal(item.getValue(module), nullValue)) return;
 		final T defaultValue = moduleService.getDefaultValue(item);
 		if (defaultValue == null) return;
 		item.setValue(module, defaultValue);


### PR DESCRIPTION
The DefaultValuePreprocessor overwrote the value of the module's
corresponding item even if the item is pre-assigned with some value. Now
it checks if the item is primitive or if it is non-null before setting
the default value.

See also:
#207