### PR TITLE
Add empty option for not-required parameter in Widget

### DIFF
--- a/src/main/java/org/scijava/widget/DefaultWidgetModel.java
+++ b/src/main/java/org/scijava/widget/DefaultWidgetModel.java
@@ -83,6 +83,8 @@ public class DefaultWidgetModel extends AbstractContextual implements WidgetMode
 		this.module = module;
 		this.item = item;
 		this.objectPool = objectPool;
+		if (!item.isRequired())
+			this.objectPool.add(0, null);
 		convertedObjects = new WeakHashMap<Object, Object>();
 	}
 
@@ -306,8 +308,10 @@ public class DefaultWidgetModel extends AbstractContextual implements WidgetMode
 
 	/** Ensures the value is on the given list. */
 	private Object ensureValid(final Object value, final List<?> list) {
+		if (value == null)
+			return list.contains(null);
 		for (final Object o : list) {
-			if (o.equals(value)) return value; // value is valid
+			if (value.equals(o)) return value; // value is valid
 			// check if value was converted and cached
 			final Object convertedValue = convertedObjects.get(o);
 			if (convertedValue != null && value.equals(convertedValue)) {


### PR DESCRIPTION
For command parameter that is not required but candidate options exist,
DefaultWidgetModel gave no empty option to be chosen from, which force
the user to use the potentially invalid values.