### PR TITLE
Only try to load services if required.

### DIFF
--- a/src/main/java/org/scijava/Context.java
+++ b/src/main/java/org/scijava/Context.java
@@ -272,9 +272,11 @@ public class Context implements Disposable {
 
 		setStrict(strict);
 
-		final ServiceHelper serviceHelper =
-			new ServiceHelper(this, serviceClasses, strict);
-		serviceHelper.loadServices();
+		if (!serviceClasses.isEmpty()){
+			final ServiceHelper serviceHelper =
+					new ServiceHelper(this, serviceClasses, strict);
+			serviceHelper.loadServices();
+		}
 	}
 
 	// -- Context methods --


### PR DESCRIPTION
If the serviceClasses Collection is empty, there is no reason to create a ServiceHelper.

This is a source of nullpointers in the ``SubContext`` and a tiny performance improvement when creating lots of ``SubContext`` instances.