### PR TITLE
Use List instead of Iterable as returntype of ModuleInfo methods.

### DIFF
--- a/src/main/java/org/scijava/command/CommandInfo.java
+++ b/src/main/java/org/scijava/command/CommandInfo.java
@@ -279,13 +279,13 @@ public class CommandInfo extends PluginInfo<Command> implements ModuleInfo {
 	}
 
 	@Override
-	public Iterable<ModuleItem<?>> inputs() {
+	public List<ModuleItem<?>> inputs() {
 		parseParams();
 		return Collections.unmodifiableList(inputList);
 	}
 
 	@Override
-	public Iterable<ModuleItem<?>> outputs() {
+	public List<ModuleItem<?>> outputs() {
 		parseParams();
 		return Collections.unmodifiableList(outputList);
 	}

--- a/src/main/java/org/scijava/module/AbstractModuleInfo.java
+++ b/src/main/java/org/scijava/module/AbstractModuleInfo.java
@@ -99,12 +99,12 @@ public abstract class AbstractModuleInfo extends AbstractUIDetails implements
 	}
 
 	@Override
-	public Iterable<ModuleItem<?>> inputs() {
+	public List<ModuleItem<?>> inputs() {
 		return Collections.unmodifiableList(inputList());
 	}
 
 	@Override
-	public Iterable<ModuleItem<?>> outputs() {
+	public List<ModuleItem<?>> outputs() {
 		return Collections.unmodifiableList(outputList());
 	}
 

--- a/src/main/java/org/scijava/module/ModuleInfo.java
+++ b/src/main/java/org/scijava/module/ModuleInfo.java
@@ -31,6 +31,8 @@
 
 package org.scijava.module;
 
+import java.util.List;
+
 import org.scijava.UIDetails;
 import org.scijava.Validated;
 import org.scijava.event.EventService;
@@ -74,10 +76,10 @@ public interface ModuleInfo extends UIDetails, Validated {
 	<T> ModuleItem<T> getOutput(String name, Class<T> type);
 
 	/** Gets the list of input items. */
-	Iterable<ModuleItem<?>> inputs();
+	List<ModuleItem<?>> inputs();
 
 	/** Gets the list of output items. */
-	Iterable<ModuleItem<?>> outputs();
+	List<ModuleItem<?>> outputs();
 
 	/**
 	 * Gets the fully qualified name of the class containing the module's actual


### PR DESCRIPTION
that return a list of ModuleItems.

``inputs()`` and ``outputs()`` used to return ``Iterable<ModuleItem<?>> ``this made random access on a Module's inputs and outputs painful. This restriction is not needed as the implementations of ModuleInfo already return a List. This change breaks compatibility with custom implementations of ``ModuleInfo``, but not with any calls to the changed methods, as ``List`` is still ``Iterable``.