### PR TITLE
Update annotation preprocessor to support java8

### DIFF
--- a/src/main/java/org/scijava/annotations/ByteCodeAnalyzer.java
+++ b/src/main/java/org/scijava/annotations/ByteCodeAnalyzer.java
@@ -107,6 +107,8 @@ class ByteCodeAnalyzer {
 			getU4(offset + 5));
 	}
 
+	// See https://en.wikipedia.org/wiki/Java_class_file#The_constant_pool for the 
+	// meaning of the offsets behind these numbers 
 	private void getConstantPoolOffsets() {
 		final int poolCount = getU2(8) - 1;
 		poolOffsets = new int[poolCount];
@@ -115,8 +117,8 @@ class ByteCodeAnalyzer {
 			poolOffsets[i] = offset;
 			final int tag = getU1(offset);
 			if (tag == 7 || tag == 8) offset += 3;
-			else if (tag == 9 || tag == 10 || tag == 11 || tag == 3 || tag == 4 ||
-				tag == 12) offset += 5;
+			else if (tag == 3 || tag == 4 || tag == 9 || tag == 10 
+					|| tag == 11 || tag == 12) offset += 5;
 			else if (tag == 5 || tag == 6) {
 				poolOffsets[++i] = offset;
 				offset += 9;

--- a/src/main/java/org/scijava/annotations/ByteCodeAnalyzer.java
+++ b/src/main/java/org/scijava/annotations/ByteCodeAnalyzer.java
@@ -116,9 +116,10 @@ class ByteCodeAnalyzer {
 		for (int i = 0; i < poolCount; i++) {
 			poolOffsets[i] = offset;
 			final int tag = getU1(offset);
-			if (tag == 7 || tag == 8) offset += 3;
+			if (tag == 7 || tag == 8 || tag == 16) offset += 3;
+			else if (tag == 15) offset += 4;
 			else if (tag == 3 || tag == 4 || tag == 9 || tag == 10 
-					|| tag == 11 || tag == 12) offset += 5;
+					|| tag == 11 || tag == 12 || tag == 18) offset += 5;
 			else if (tag == 5 || tag == 6) {
 				poolOffsets[++i] = offset;
 				offset += 9;

--- a/src/test/java/org/scijava/annotations/AnnotatedD.java
+++ b/src/test/java/org/scijava/annotations/AnnotatedD.java
@@ -1,0 +1,13 @@
+package org.scijava.annotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Simple(string1 = "adfd")
+public class AnnotatedD {
+
+	public AnnotatedD() {
+		List<String> list = new ArrayList<>();
+		list.stream().reduce(String::concat).get();
+	}
+}

--- a/src/test/java/org/scijava/annotations/DirectoryIndexerTest.java
+++ b/src/test/java/org/scijava/annotations/DirectoryIndexerTest.java
@@ -122,7 +122,7 @@ public class DirectoryIndexerTest {
 			assertFalse(seen.contains(name));
 			seen.add(name);
 		}
-		assertEquals(2, seen.size());
+		assertEquals(3, seen.size());
 	}
 
 	public static void

--- a/src/test/java/org/scijava/annotations/EclipseHelperTest.java
+++ b/src/test/java/org/scijava/annotations/EclipseHelperTest.java
@@ -71,7 +71,7 @@ public class EclipseHelperTest {
 	public void testIndexing() throws Exception {
 		final File dir = createTemporaryDirectory("eclipse-test-");
 		copyClasses(dir, Complex.class, Simple.class, Fruit.class,
-			AnnotatedA.class, AnnotatedB.class, AnnotatedC.class);
+			AnnotatedA.class, AnnotatedB.class, AnnotatedC.class, AnnotatedD.class);
 		final File jsonDir = new File(dir, Index.INDEX_PREFIX);
 		for (final Class<?> clazz : new Class<?>[] { Complex.class, Simple.class })
 		{
@@ -104,7 +104,7 @@ public class EclipseHelperTest {
 		// deleted
 		jsonDir.setLastModified(123456789);
 		for (final Class<?> clazz : new Class<?>[] { AnnotatedA.class,
-			AnnotatedB.class, AnnotatedC.class })
+			AnnotatedB.class, AnnotatedC.class, AnnotatedD.class })
 		{
 			assertTrue(new File(dir, DirectoryIndexerTest.getResourcePath(clazz))
 				.delete());


### PR DESCRIPTION
This change allows library users to write SciJava Plugins using java8 language features without getting constant warnings and errors from annotation preprocessor.

The commit with the tests: https://github.com/scijava/scijava-common/commit/a9ba97e40ddc642c182c7f0a0098136795300ea7 can't get merged without scijava-common using java8. Everything else works also with java6.