### PR TITLE
Add support for custom main classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>scijava-common</artifactId>
-	<version>2.50.2-SNAPSHOT</version>
+	<version>2.51.0-SNAPSHOT</version>
 
 	<name>SciJava Common</name>
 	<description>SciJava Common is a shared library for SciJava software. It provides a plugin framework, with an extensible mechanism for service discovery, backed by its own annotation processor, so that plugins can be loaded dynamically. It is used by both ImageJ and SCIFIO.</description>

--- a/src/main/java/org/scijava/AbstractGateway.java
+++ b/src/main/java/org/scijava/AbstractGateway.java
@@ -45,6 +45,7 @@ import org.scijava.input.InputService;
 import org.scijava.io.IOService;
 import org.scijava.io.RecentFileService;
 import org.scijava.log.LogService;
+import org.scijava.main.MainService;
 import org.scijava.menu.MenuService;
 import org.scijava.module.ModuleService;
 import org.scijava.object.ObjectService;
@@ -161,6 +162,11 @@ public abstract class AbstractGateway extends AbstractRichPlugin implements
 	@Override
 	public LogService log() {
 		return get(LogService.class);
+	}
+
+	@Override
+	public MainService main() {
+		return get(MainService.class);
 	}
 
 	@Override

--- a/src/main/java/org/scijava/Gateway.java
+++ b/src/main/java/org/scijava/Gateway.java
@@ -43,6 +43,7 @@ import org.scijava.input.InputService;
 import org.scijava.io.IOService;
 import org.scijava.io.RecentFileService;
 import org.scijava.log.LogService;
+import org.scijava.main.MainService;
 import org.scijava.menu.MenuService;
 import org.scijava.module.ModuleService;
 import org.scijava.object.ObjectService;
@@ -225,6 +226,13 @@ public interface Gateway extends RichPlugin, Versioned {
 	 * @return The {@link LogService} of this application context.
 	 */
 	LogService log();
+
+	/**
+	 * Gets this application context's {@link MainService}.
+	 *
+	 * @return The {@link MainService} of this application context.
+	 */
+	MainService main();
 
 	/**
 	 * Gets this application context's {@link MenuService}.

--- a/src/main/java/org/scijava/main/DefaultMainService.java
+++ b/src/main/java/org/scijava/main/DefaultMainService.java
@@ -1,0 +1,122 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.main;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.service.AbstractService;
+import org.scijava.service.Service;
+import org.scijava.util.ClassUtils;
+
+/**
+ * Default implementation of {@link MainService}.
+ * 
+ * @author Curtis Rueden
+ */
+@Plugin(type = Service.class)
+public class DefaultMainService extends AbstractService implements MainService {
+
+	@Parameter(required = false)
+	private LogService log;
+
+	private final List<Main> mains = new ArrayList<Main>();
+
+	@Override
+	public int execMains() {
+		int mainCount = 0;
+		for (final Main main : mains) {
+			main.exec();
+			mainCount++;
+		}
+		return mainCount;
+	}
+
+	@Override
+	public void addMain(final String className, final String... args) {
+		mains.add(new DefaultMain(className, args));
+	}
+
+	@Override
+	public Main[] getMains() {
+		return mains.toArray(new Main[mains.size()]);
+	}
+
+	// -- Helper classes --
+
+	/** Default implementation of {@link MainService.Main}. */
+	private class DefaultMain implements Main {
+		private String className;
+		private String[] args;
+
+		public DefaultMain(final String className, final String... args) {
+			this.className = className;
+			this.args = args.clone();
+		}
+
+		@Override
+		public String className() {
+			return className;
+		}
+
+		@Override
+		public String[] args() {
+			return args;
+		}
+
+		@Override
+		public void exec() {
+			try {
+				final Class<?> mainClass = ClassUtils.loadClass(className);
+				final Method main = mainClass.getMethod("main", String[].class);
+				main.invoke(null, new Object[] { args });
+			}
+			catch (final NoSuchMethodException exc) {
+				if (log != null) {
+					log.error("No main method for class: " + className, exc);
+				}
+			}
+			catch (final IllegalAccessException exc) {
+				if (log != null) log.error(exc);
+			}
+			catch (final InvocationTargetException exc) {
+				if (log != null) log.error(exc);
+			}
+		}
+	}
+
+}

--- a/src/main/java/org/scijava/main/MainService.java
+++ b/src/main/java/org/scijava/main/MainService.java
@@ -1,0 +1,69 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.main;
+
+import org.scijava.service.SciJavaService;
+
+/**
+ * Interface for services which manage dynamic execution of main methods.
+ * 
+ * @author Curtis Rueden
+ */
+public interface MainService extends SciJavaService {
+
+	/**
+	 * Executes registered main classes, in the order they were registered.
+	 * 
+	 * @return The number of main methods which were executed.
+	 */
+	int execMains();
+
+	/** Registers a main class to be executed by {@link #execMains()}. */
+	void addMain(final String className, final String... args);
+
+	/** Gets the registered main classes to execute. */
+	Main[] getMains();
+
+	/** Data structure containing main class and argument values. */
+	interface Main {
+
+		/** Gets the name of the class containing the {@code main} method to run. */
+		String className();
+
+		/** Gets the arguments to pass to the class's {@code main} method. */
+		String[] args();
+
+		/** Runs the {@code main} method with the associated arguments. */
+		void exec();
+	}
+
+}

--- a/src/main/java/org/scijava/main/console/MainArgument.java
+++ b/src/main/java/org/scijava/main/console/MainArgument.java
@@ -1,0 +1,99 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.main.console;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.scijava.console.AbstractConsoleArgument;
+import org.scijava.console.ConsoleArgument;
+import org.scijava.log.LogService;
+import org.scijava.main.MainService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Handles the {@code --main} command line argument, which launches an
+ * alternative main class.
+ * 
+ * @author Curtis Rueden
+ */
+@Plugin(type = ConsoleArgument.class)
+public class MainArgument extends AbstractConsoleArgument {
+
+	@Parameter(required = false)
+	private MainService mainService;
+
+	@Parameter(required = false)
+	private LogService log;
+
+	// -- ConsoleArgument methods --
+
+	@Override
+	public void handle(final LinkedList<String> args) {
+		if (!supports(args)) return;
+
+		args.removeFirst(); // --main / --main-class
+		final String className = args.removeFirst();
+
+		final List<String> argList = new ArrayList<String>();
+		while (!args.isEmpty() && !isMainFlag(args) && !isSeparator(args)) {
+			argList.add(args.removeFirst());
+		}
+		if (isSeparator(args)) args.removeFirst(); // remove the -- separator
+		final String[] mainArgs = argList.toArray(new String[argList.size()]);
+
+		mainService.addMain(className, mainArgs);
+	}
+
+	// -- Typed methods --
+
+	@Override
+	public boolean supports(final LinkedList<String> args) {
+		return mainService != null && isMainFlag(args);
+	}
+
+	// -- Helper methods --
+
+	private boolean isMainFlag(final LinkedList<String> args) {
+		if (args == null || args.isEmpty()) return false;
+		final String arg = args.getFirst();
+		return arg.equals("--main") || arg.equals("--main-class");
+	}
+
+	private boolean isSeparator(final LinkedList<String> args) {
+		if (args == null || args.isEmpty()) return false;
+		return args.getFirst().equals("--");
+	}
+
+}

--- a/src/test/java/org/scijava/console/ConsoleServiceTest.java
+++ b/src/test/java/org/scijava/console/ConsoleServiceTest.java
@@ -220,6 +220,10 @@ public class ConsoleServiceTest {
 			argsHandled = true;
 		}
 
+		@Override
+		public boolean supports(final LinkedList<String> args) {
+			return !args.isEmpty() && args.getFirst().equals("--foo");
+		}
 	}
 
 	private static class OutputTracker implements OutputListener {

--- a/src/test/java/org/scijava/main/MainServiceTest.java
+++ b/src/test/java/org/scijava/main/MainServiceTest.java
@@ -1,0 +1,143 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.main;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.console.ConsoleService;
+import org.scijava.main.console.MainArgument;
+
+/**
+ * Tests {@link MainService}.
+ *
+ * @author Curtis Rueden
+ */
+public class MainServiceTest {
+
+	private MainService mainService;
+
+	@Before
+	public void setUp() {
+		MathMain.resultCount = 0;
+		final Context context = new Context();
+		mainService = context.service(MainService.class);
+	}
+
+	@After
+	public void tearDown() {
+		mainService.context().dispose();
+	}
+
+	/**
+	 * Tests {@link MainService#execMains()},
+	 * {@link MainService#addMain(String, String...)} and
+	 * {@link MainService#getMains()}.
+	 */
+	@Test
+	public void testMainService() {
+		final int mainCount0 = mainService.execMains();
+		assertEquals(0, mainCount0);
+
+		mainService.addMain(MathMain.class.getName(), "12.3", "/", "4.56");
+
+		final int mainCount1 = mainService.execMains();
+		assertEquals(1, mainCount1);
+		assertEquals(System.getProperty(key(0)), "2.697368421052632");
+	}
+
+	/** Tests usage of {@link MainService} via {@code --main} CLI arguments. */
+	@Test
+	public void testConsoleArgs() {
+		assertEquals(0, mainService.getMains().length);
+
+		final ConsoleService consoleService = mainService.context().service(
+			ConsoleService.class);
+		consoleService.processArgs("-Dfoo=bar", //
+			"--main", "org.scijava.main.MainServiceTest$MathMain", "5", "+", "6", //
+			"--", "-Dwhiz=bang", //
+			"--main", "org.scijava.main.MainServiceTest$MathMain", "7", "-", "4");
+
+		final MainService.Main[] m = mainService.getMains();
+		assertEquals(2, m.length);
+		assertEquals("org.scijava.main.MainServiceTest$MathMain", m[0].className());
+		assertArrayEquals(new String[] {"5", "+", "6"}, m[0].args());
+		assertEquals("org.scijava.main.MainServiceTest$MathMain", m[1].className());
+		assertArrayEquals(new String[] {"7", "-", "4"}, m[1].args());
+
+		final int mainCount = mainService.execMains();
+		assertEquals(2, mainCount);
+		assertEquals(System.getProperty(key(0)), "11.0");
+		assertEquals(System.getProperty(key(1)), "3.0");
+
+		assertEquals(System.getProperty("foo"), "bar");
+		assertEquals(System.getProperty("whiz"), "bang");
+	}
+
+	// -- Helper methods --
+
+	private static String key(final int index) {
+		return MathMain.class.getName() + ":" + index;
+	}
+
+	// -- Helper classes --
+
+	private static class MathMain {
+		private static int resultCount = 0;
+		@SuppressWarnings("unused")
+		public static void main(final String[] args) {
+			if (args.length != 3) {
+				throw new IllegalArgumentException("Invalid args: " + args);
+			}
+
+			// compute a result from the arguments
+			final double operand1 = Double.parseDouble(args[0]);
+			final String operator = args[1];
+			final double operand2 = Double.parseDouble(args[2]);
+			final double result;
+			if (operator.equals("+")) result = operand1 + operand2;
+			else if (operator.equals("-")) result = operand1 - operand2;
+			else if (operator.equals("*")) result = operand1 * operand2;
+			else if (operator.equals("/")) result = operand1 / operand2;
+			else throw new IllegalArgumentException("Unknown operator: " + operator);
+
+			// save the result to a system property, for later checking
+			final String key = MathMain.class.getName() + ":" + resultCount++;
+			final String value = "" + result;
+			System.setProperty(key, value);
+		}
+	}
+}


### PR DESCRIPTION
It is nice to be able to override which main class gets executed.
Actually, the plan is not to "override" it per se, but actually for
whichever main application class to have the option to call
mainService.execMains() to run the main classes which have been
registered (via the "--main" CLI argument or otherwise via the API).