### PR TITLE
Reintroduce ModuleInfo List iterators

### DIFF
--- a/src/main/java/org/scijava/command/CommandInfo.java
+++ b/src/main/java/org/scijava/command/CommandInfo.java
@@ -279,13 +279,13 @@ public class CommandInfo extends PluginInfo<Command> implements ModuleInfo {
 	}
 
 	@Override
-	public Iterable<ModuleItem<?>> inputs() {
+	public List<ModuleItem<?>> inputs() {
 		parseParams();
 		return Collections.unmodifiableList(inputList);
 	}
 
 	@Override
-	public Iterable<ModuleItem<?>> outputs() {
+	public List<ModuleItem<?>> outputs() {
 		parseParams();
 		return Collections.unmodifiableList(outputList);
 	}

--- a/src/main/java/org/scijava/module/AbstractModuleInfo.java
+++ b/src/main/java/org/scijava/module/AbstractModuleInfo.java
@@ -99,12 +99,12 @@ public abstract class AbstractModuleInfo extends AbstractUIDetails implements
 	}
 
 	@Override
-	public Iterable<ModuleItem<?>> inputs() {
+	public List<ModuleItem<?>> inputs() {
 		return Collections.unmodifiableList(inputList());
 	}
 
 	@Override
-	public Iterable<ModuleItem<?>> outputs() {
+	public List<ModuleItem<?>> outputs() {
 		return Collections.unmodifiableList(outputList());
 	}
 

--- a/src/main/java/org/scijava/module/ModuleInfo.java
+++ b/src/main/java/org/scijava/module/ModuleInfo.java
@@ -31,6 +31,8 @@
 
 package org.scijava.module;
 
+import java.util.List;
+
 import org.scijava.UIDetails;
 import org.scijava.Validated;
 import org.scijava.event.EventService;
@@ -74,10 +76,10 @@ public interface ModuleInfo extends UIDetails, Validated {
 	<T> ModuleItem<T> getOutput(String name, Class<T> type);
 
 	/** Gets the list of input items. */
-	Iterable<ModuleItem<?>> inputs();
+	List<ModuleItem<?>> inputs();
 
 	/** Gets the list of output items. */
-	Iterable<ModuleItem<?>> outputs();
+	List<ModuleItem<?>> outputs();
 
 	/**
 	 * Gets the fully qualified name of the class containing the module's actual


### PR DESCRIPTION
__INTENDED FOR MERGE WITH OTHER SJC3 WORK__

In 88d3cab189d1fd68b2065e0e109cbb18ef48e0b0, the type of the iterators returned by inputs() and outputs() was narrowed from Iterable to List. Unfortunately, this broke downstream callers, so the change was reverted in edfc7c53815918672ba708daa5fb45b3d80ea404.

This commit reintroduces the patch, for inclusion into SJC3.