### PR TITLE
Generalize compatibility matches

### DIFF
--- a/src/main/java/org/scijava/convert/AbstractConvertService.java
+++ b/src/main/java/org/scijava/convert/AbstractConvertService.java
@@ -32,6 +32,9 @@
 package org.scijava.convert;
 
 import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.scijava.plugin.AbstractHandlerService;
 import org.scijava.util.ConversionUtils;
@@ -68,10 +71,41 @@ public abstract class AbstractConvertService extends
 		return handler == null ? null : handler.convert(request);
 	}
 
+	@Override
+	public Collection<Class<?>> getCompatibleInputClasses(Class<?> dest) {
+		Set<Class<?>> compatibleClasses = new HashSet<Class<?>>();
+
+		for (Converter<?, ?> converter : getInstances()) {
+			addIfMatches(dest, converter.getOutputType(), converter.getInputType(), compatibleClasses);
+		}
+
+		return compatibleClasses;
+	}
+
+	@Override
+	public Collection<Class<?>> getCompatibleOutputClasses(Class<?> source) {
+		Set<Class<?>> compatibleClasses = new HashSet<Class<?>>();
+
+		for (Converter<?, ?> converter : getInstances()) {
+			addIfMatches(source, converter.getInputType(), converter.getOutputType(), compatibleClasses);
+		}
+
+		return compatibleClasses;
+	}
+
 	// -- Service methods --
 
 	@Override
 	public void initialize() {
 		ConversionUtils.setDelegateService(this, getPriority());
+	}
+
+	// -- Helper methods --
+
+	/**
+	 * Test two classes; if they match, a third class is added to the provided set of classes.
+	 */
+	private void addIfMatches(Class<?> c1, Class<?> c2, Class<?> toAdd, Set<Class<?>> classes) {
+		if (c1 == c2) classes.add(toAdd);
 	}
 }

--- a/src/main/java/org/scijava/convert/AbstractConvertService.java
+++ b/src/main/java/org/scijava/convert/AbstractConvertService.java
@@ -32,31 +32,27 @@
 package org.scijava.convert;
 
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.scijava.plugin.AbstractHandlerService;
 import org.scijava.util.ConversionUtils;
 
 /**
- * Abstract superclass for {@link ConvertService} implementations. Sets
- * this service as the active delegate service in {@link ConversionUtils}.
+ * Abstract superclass for {@link ConvertService} implementations. Sets this
+ * service as the active delegate service in {@link ConversionUtils}.
  *
  * @author Mark Hiner
  */
-public abstract class AbstractConvertService extends
-	AbstractHandlerService<ConversionRequest, Converter<?, ?>> implements
-	ConvertService
-{
+public abstract class AbstractConvertService extends AbstractHandlerService<ConversionRequest, Converter<?, ?>>
+		implements ConvertService {
 
 	// -- ConversionService methods --
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
 	public Class<Converter<?, ?>> getPluginType() {
-		return (Class)Converter.class;
+		return (Class) Converter.class;
 	}
 
 	@Override
@@ -105,8 +101,8 @@ public abstract class AbstractConvertService extends
 	}
 
 	@Override
-	public Collection<Object> getCompatibleInputs(Class<?> dest) {
-		Set<Object> objects = new HashSet<Object>();
+	public Collection<Object> getCompatibleInputs(final Class<?> dest) {
+		final Set<Object> objects = new HashSet<Object>();
 
 		for (final Converter<?, ?> c : getInstances()) {
 			if (dest.isAssignableFrom(c.getOutputType())) {
@@ -118,29 +114,29 @@ public abstract class AbstractConvertService extends
 	}
 
 	@Override
-	public Object convert(Object src, Type dest) {
+	public Object convert(final Object src, final Type dest) {
 		return convert(new ConversionRequest(src, dest));
 	}
 
 	@Override
-	public <T> T convert(Object src, Class<T> dest) {
+	public <T> T convert(final Object src, final Class<T> dest) {
 		// NB: repeated code with convert(ConversionRequest), because the
 		// handler's convert method respects the T provided
-		Converter<?, ?> handler = getHandler(src, dest);
+		final Converter<?, ?> handler = getHandler(src, dest);
 		return handler == null ? null : handler.convert(src, dest);
 	}
 
 	@Override
-	public Object convert(ConversionRequest request) {
-		Converter<?, ?> handler = getHandler(request);
+	public Object convert(final ConversionRequest request) {
+		final Converter<?, ?> handler = getHandler(request);
 		return handler == null ? null : handler.convert(request);
 	}
 
 	@Override
-	public Collection<Class<?>> getCompatibleInputClasses(Class<?> dest) {
-		Set<Class<?>> compatibleClasses = new HashSet<Class<?>>();
+	public Collection<Class<?>> getCompatibleInputClasses(final Class<?> dest) {
+		final Set<Class<?>> compatibleClasses = new HashSet<Class<?>>();
 
-		for (Converter<?, ?> converter : getInstances()) {
+		for (final Converter<?, ?> converter : getInstances()) {
 			addIfMatches(dest, converter.getOutputType(), converter.getInputType(), compatibleClasses);
 		}
 
@@ -148,10 +144,10 @@ public abstract class AbstractConvertService extends
 	}
 
 	@Override
-	public Collection<Class<?>> getCompatibleOutputClasses(Class<?> source) {
-		Set<Class<?>> compatibleClasses = new HashSet<Class<?>>();
+	public Collection<Class<?>> getCompatibleOutputClasses(final Class<?> source) {
+		final Set<Class<?>> compatibleClasses = new HashSet<Class<?>>();
 
-		for (Converter<?, ?> converter : getInstances()) {
+		for (final Converter<?, ?> converter : getInstances()) {
 			addIfMatches(source, converter.getInputType(), converter.getOutputType(), compatibleClasses);
 		}
 
@@ -168,9 +164,11 @@ public abstract class AbstractConvertService extends
 	// -- Helper methods --
 
 	/**
-	 * Test two classes; if they match, a third class is added to the provided set of classes.
+	 * Test two classes; if they match, a third class is added to the provided
+	 * set of classes.
 	 */
-	private void addIfMatches(Class<?> c1, Class<?> c2, Class<?> toAdd, Set<Class<?>> classes) {
-		if (c1 == c2) classes.add(toAdd);
+	private void addIfMatches(final Class<?> c1, final Class<?> c2, final Class<?> toAdd, final Set<Class<?>> classes) {
+		if (c1 == c2)
+			classes.add(toAdd);
 	}
 }

--- a/src/main/java/org/scijava/convert/AbstractConvertService.java
+++ b/src/main/java/org/scijava/convert/AbstractConvertService.java
@@ -106,7 +106,7 @@ public abstract class AbstractConvertService extends
 
 	@Override
 	public Collection<Object> getCompatibleInputs(Class<?> dest) {
-		Set<Object> objects = new LinkedHashSet<Object>();
+		Set<Object> objects = new HashSet<Object>();
 
 		for (final Converter<?, ?> c : getInstances()) {
 			if (dest.isAssignableFrom(c.getOutputType())) {
@@ -114,7 +114,7 @@ public abstract class AbstractConvertService extends
 			}
 		}
 
-		return new ArrayList<Object>(objects);
+		return objects;
 	}
 
 	@Override

--- a/src/main/java/org/scijava/convert/AbstractConvertService.java
+++ b/src/main/java/org/scijava/convert/AbstractConvertService.java
@@ -32,8 +32,10 @@
 package org.scijava.convert;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.scijava.plugin.AbstractHandlerService;
@@ -51,6 +53,69 @@ public abstract class AbstractConvertService extends
 {
 
 	// -- ConversionService methods --
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public Class<Converter<?, ?>> getPluginType() {
+		return (Class)Converter.class;
+	}
+
+	@Override
+	public Class<ConversionRequest> getType() {
+		return ConversionRequest.class;
+	}
+
+	@Override
+	public Converter<?, ?> getHandler(final Object src, final Class<?> dest) {
+		return getHandler(new ConversionRequest(src, dest));
+	}
+
+	@Override
+	public Converter<?, ?> getHandler(final Class<?> src, final Class<?> dest) {
+		return getHandler(new ConversionRequest(src, dest));
+	}
+
+	@Override
+	public Converter<?, ?> getHandler(final Object src, final Type dest) {
+		return getHandler(new ConversionRequest(src, dest));
+	}
+
+	@Override
+	public Converter<?, ?> getHandler(final Class<?> src, final Type dest) {
+		return getHandler(new ConversionRequest(src, dest));
+	}
+
+	@Override
+	public boolean supports(final Object src, final Class<?> dest) {
+		return supports(new ConversionRequest(src, dest));
+	}
+
+	@Override
+	public boolean supports(final Class<?> src, final Class<?> dest) {
+		return supports(new ConversionRequest(src, dest));
+	}
+
+	@Override
+	public boolean supports(final Object src, final Type dest) {
+		return supports(new ConversionRequest(src, dest));
+	}
+
+	@Override
+	public boolean supports(final Class<?> src, final Type dest) {
+		return supports(new ConversionRequest(src, dest));
+	}
+
+	@Override
+	public Collection<Object> getCompatibleInputs(Class<?> dest) {
+		Set<Object> objects = new LinkedHashSet<Object>();
+
+		for (final Converter<?, ?> c : getInstances()) {
+			if (dest.isAssignableFrom(c.getOutputType())) {
+				c.populateInputCandidates(objects);
+			}
+		}
+
+		return new ArrayList<Object>(objects);
+	}
 
 	@Override
 	public Object convert(Object src, Type dest) {

--- a/src/main/java/org/scijava/convert/ConvertService.java
+++ b/src/main/java/org/scijava/convert/ConvertService.java
@@ -83,6 +83,12 @@ public interface ConvertService extends
 	 */
 	boolean supports(Object src, Type dest);
 
+	/**
+	 * @return A collection of instances that could be converted to the
+	 *         specified class.
+	 */
+	Collection<Object> getCompatibleInputs(Class<?> dest);
+
 	// -- Deprecated API --
 
 	/**
@@ -112,6 +118,4 @@ public interface ConvertService extends
 	 */
 	@Deprecated
 	boolean supports(Class<?> src, Type dest);
-
-	Collection<Object> getCompatibleInputs(Class<?> dest);
 }

--- a/src/main/java/org/scijava/convert/ConvertService.java
+++ b/src/main/java/org/scijava/convert/ConvertService.java
@@ -89,6 +89,18 @@ public interface ConvertService extends
 	 */
 	Collection<Object> getCompatibleInputs(Class<?> dest);
 
+	/**
+	 * @return A collection of all classes that could potentially be converted
+	 *         <b>to</b> the specified class.
+	 */
+	Collection<Class<?>> getCompatibleInputClasses(Class<?> dest);
+
+	/**
+	 * @return A collection of all classes that could potentially be converted
+	 *         <b>from</b> the specified class.
+	 */
+	Collection<Class<?>> getCompatibleOutputClasses(Class<?> dest);
+
 	// -- Deprecated API --
 
 	/**

--- a/src/main/java/org/scijava/convert/DefaultConvertService.java
+++ b/src/main/java/org/scijava/convert/DefaultConvertService.java
@@ -31,12 +31,6 @@
 
 package org.scijava.convert;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
 import org.scijava.plugin.Plugin;
 import org.scijava.service.Service;
 
@@ -48,70 +42,5 @@ import org.scijava.service.Service;
 @Plugin(type = Service.class)
 public class DefaultConvertService extends AbstractConvertService
 {
-
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	@Override
-	public Class<Converter<?, ?>> getPluginType() {
-		return (Class)Converter.class;
-	}
-
-	@Override
-	public Class<ConversionRequest> getType() {
-		return ConversionRequest.class;
-	}
-
-	// -- ConversionService methods --
-
-	@Override
-	public Converter<?, ?> getHandler(final Object src, final Class<?> dest) {
-		return getHandler(new ConversionRequest(src, dest));
-	}
-
-	@Override
-	public Converter<?, ?> getHandler(final Class<?> src, final Class<?> dest) {
-		return getHandler(new ConversionRequest(src, dest));
-	}
-
-	@Override
-	public Converter<?, ?> getHandler(final Object src, final Type dest) {
-		return getHandler(new ConversionRequest(src, dest));
-	}
-
-	@Override
-	public Converter<?, ?> getHandler(final Class<?> src, final Type dest) {
-		return getHandler(new ConversionRequest(src, dest));
-	}
-
-	@Override
-	public boolean supports(final Object src, final Class<?> dest) {
-		return supports(new ConversionRequest(src, dest));
-	}
-
-	@Override
-	public boolean supports(final Class<?> src, final Class<?> dest) {
-		return supports(new ConversionRequest(src, dest));
-	}
-
-	@Override
-	public boolean supports(final Object src, final Type dest) {
-		return supports(new ConversionRequest(src, dest));
-	}
-
-	@Override
-	public boolean supports(final Class<?> src, final Type dest) {
-		return supports(new ConversionRequest(src, dest));
-	}
-
-	@Override
-	public Collection<Object> getCompatibleInputs(Class<?> dest) {
-		Set<Object> objects = new LinkedHashSet<Object>();
-
-		for (final Converter<?, ?> c : getInstances()) {
-			if (dest.isAssignableFrom(c.getOutputType())) {
-				c.populateInputCandidates(objects);
-			}
-		}
-
-		return new ArrayList<Object>(objects);
-	}
+	// Trivial implementation
 }

--- a/src/main/java/org/scijava/module/ModuleService.java
+++ b/src/main/java/org/scijava/module/ModuleService.java
@@ -275,6 +275,18 @@ public interface ModuleService extends SciJavaService {
 	<T> ModuleItem<T> getSingleOutput(Module module, Class<T> type);
 
 	/**
+	 * As {@link #getSingleInput(Module, Class)} but will match with a set of
+	 * potential classes, at the cost of generic parameter safety.
+	 */
+	ModuleItem<?> getSingleInput(Module module, Collection<Class<?>> types);
+
+	/**
+	 * As {@link #getSingleOutput(Module, Class)} but will match with a set of
+	 * potential classes, at the cost of generic parameter safety.
+	 */
+	ModuleItem<?> getSingleOutput(Module module, Collection<Class<?>> types);
+
+	/**
 	 * Registers the given value for the given {@link ModuleItem} using the
 	 * {@link PrefService}.
 	 */


### PR DESCRIPTION
Enhance the ModuleService and ConvertServices such that their matching methods (getSingleInput/Output and getCompatibleInputs, respectively) now have an option that accepts or produces a collection of classes, as appropriate.

These changes improve the potential for general plugins, especially module processors.