### PR TITLE
Do proper exception handling when loading classes

### DIFF
--- a/src/main/java/org/scijava/Context.java
+++ b/src/main/java/org/scijava/Context.java
@@ -320,10 +320,7 @@ public class Context implements Disposable {
 	 *           service.
 	 */
 	public Service service(final String className) {
-		final Class<?> c = ClassUtils.loadClass(className);
-		if (c == null) {
-			throw new IllegalArgumentException("No such class: " + className);
-		}
+		final Class<?> c = ClassUtils.loadClass(className, false);
 		if (!Service.class.isAssignableFrom(c)) {
 			throw new IllegalArgumentException("Not a service class: " + c.getName());
 		}

--- a/src/main/java/org/scijava/main/DefaultMainService.java
+++ b/src/main/java/org/scijava/main/DefaultMainService.java
@@ -101,9 +101,12 @@ public class DefaultMainService extends AbstractService implements MainService {
 		@Override
 		public void exec() {
 			try {
-				final Class<?> mainClass = ClassUtils.loadClass(className);
+				final Class<?> mainClass = ClassUtils.loadClass(className, false);
 				final Method main = mainClass.getMethod("main", String[].class);
 				main.invoke(null, new Object[] { args });
+			}
+			catch (final IllegalArgumentException exc) {
+				if (log != null) log.error(exc);
 			}
 			catch (final NoSuchMethodException exc) {
 				if (log != null) {

--- a/src/main/java/org/scijava/menu/ShadowMenu.java
+++ b/src/main/java/org/scijava/menu/ShadowMenu.java
@@ -231,13 +231,20 @@ public class ShadowMenu extends AbstractContextual implements
 			else return null;
 		}
 		final String className = moduleInfo.getDelegateClassName();
-		final Class<?> c = ClassUtils.loadClass(className);
-		if (c == null) return null;
-		final URL iconURL = c.getResource(iconPath);
-		if (iconURL == null) {
-			if (log != null) log.error("Could not load icon: " + iconPath);
+		try {
+			final Class<?> c = ClassUtils.loadClass(className, false);
+			final URL iconURL = c.getResource(iconPath);
+			if (iconURL == null) {
+				if (log != null) log.error("Could not load icon: " + iconPath);
+			}
+			return iconURL;
 		}
-		return iconURL;
+		catch (final IllegalArgumentException exc) {
+			final String message = "Could not load icon for class: " + className;
+			if (log.isDebug()) log.debug(message, exc);
+			else log.error(message);
+			return null;
+		}
 	}
 
 	/**

--- a/src/main/java/org/scijava/plugin/PluginInfo.java
+++ b/src/main/java/org/scijava/plugin/PluginInfo.java
@@ -280,13 +280,15 @@ public class PluginInfo<PT extends SciJavaPlugin> extends AbstractUIDetails
 	@Override
 	public Class<? extends PT> loadClass() throws InstantiableException {
 		if (pluginClass == null) {
-			final Class<?> c = ClassUtils.loadClass(className, classLoader);
-			if (c == null) {
-				throw new InstantiableException("Class not found: " + className);
+			try {
+				final Class<?> c = ClassUtils.loadClass(className, classLoader, false);
+				@SuppressWarnings("unchecked")
+				final Class<? extends PT> typedClass = (Class<? extends PT>) c;
+				pluginClass = typedClass;
 			}
-			@SuppressWarnings("unchecked")
-			final Class<? extends PT> typedClass = (Class<? extends PT>) c;
-			pluginClass = typedClass;
+			catch (final IllegalArgumentException exc) {
+				throw new InstantiableException("Class not found: " + className, exc);
+			}
 		}
 
 		return pluginClass;

--- a/src/main/java/org/scijava/script/DefaultScriptService.java
+++ b/src/main/java/org/scijava/script/DefaultScriptService.java
@@ -255,13 +255,16 @@ public class DefaultScriptService extends
 		final Class<?> type = aliasMap().get(alias);
 		if (type != null) return type;
 
-		final Class<?> c = ClassUtils.loadClass(alias);
-		if (c != null) {
+		try {
+			final Class<?> c = ClassUtils.loadClass(alias, false);
 			aliasMap().put(alias, c);
 			return c;
 		}
-
-		throw new ScriptException("Unknown type: " + alias);
+		catch (final IllegalArgumentException exc) {
+			final ScriptException se = new ScriptException("Unknown type: " + alias);
+			se.initCause(exc);
+			throw se;
+		}
 	}
 
 	// -- PTService methods --

--- a/src/main/java/org/scijava/util/ClassUtils.java
+++ b/src/main/java/org/scijava/util/ClassUtils.java
@@ -93,6 +93,7 @@ public final class ClassUtils {
 	 * Loads the class with the given name, using the current thread's context
 	 * class loader, or null if it cannot be loaded.
 	 *
+	 * @param name The name of the class to load.
 	 * @return The loaded class, or null if the class could not be loaded.
 	 * @see #loadClass(String, ClassLoader)
 	 */

--- a/src/main/java/org/scijava/util/ClassUtils.java
+++ b/src/main/java/org/scijava/util/ClassUtils.java
@@ -95,10 +95,46 @@ public final class ClassUtils {
 	 *
 	 * @param name The name of the class to load.
 	 * @return The loaded class, or null if the class could not be loaded.
-	 * @see #loadClass(String, ClassLoader)
+	 * @see #loadClass(String, ClassLoader, boolean)
 	 */
 	public static Class<?> loadClass(final String name) {
-		return loadClass(name, null);
+		return loadClass(name, null, true);
+	}
+
+	/**
+	 * Loads the class with the given name, using the specified
+	 * {@link ClassLoader}, or null if it cannot be loaded.
+	 *
+	 * @param name The name of the class to load.
+	 * @param classLoader The class loader with which to load the class; if null,
+	 *          the current thread's context class loader will be used.
+	 * @return The loaded class, or null if the class could not be loaded.
+	 * @see #loadClass(String, ClassLoader, boolean)
+	 */
+	public static Class<?> loadClass(final String name,
+		final ClassLoader classLoader)
+	{
+		return loadClass(name, classLoader, true);
+	}
+
+	/**
+	 * Loads the class with the given name, using the current thread's context
+	 * class loader.
+	 *
+	 * @param className the name of the class to load
+	 * @param quietly Whether to return {@code null} (rather than throwing
+	 *          {@link IllegalArgumentException}) if something goes wrong loading
+	 *          the class
+	 * @return The loaded class, or {@code null} if the class could not be loaded
+	 *         and the {@code quietly} flag is set.
+	 * @see #loadClass(String, ClassLoader, boolean)
+	 * @throws IllegalArgumentException If the class cannot be loaded and the
+	 *           {@code quietly} flag is not set.
+	 */
+	public static Class<?> loadClass(final String className,
+		final boolean quietly)
+	{
+		return loadClass(className, null, quietly);
 	}
 
 	/**
@@ -120,10 +156,16 @@ public final class ClassUtils {
 	 * @param name The name of the class to load.
 	 * @param classLoader The class loader with which to load the class; if null,
 	 *          the current thread's context class loader will be used.
-	 * @return The loaded class, or null if the class could not be loaded.
+	 * @param quietly Whether to return {@code null} (rather than throwing
+	 *          {@link IllegalArgumentException}) if something goes wrong loading
+	 *          the class
+	 * @return The loaded class, or {@code null} if the class could not be loaded
+	 *         and the {@code quietly} flag is set.
+	 * @throws IllegalArgumentException If the class cannot be loaded and the
+	 *           {@code quietly} flag is not set.
 	 */
 	public static Class<?> loadClass(final String name,
-		final ClassLoader classLoader)
+		final ClassLoader classLoader, final boolean quietly)
 	{
 		// handle primitive types
 		if (name.equals("Z") || name.equals("boolean")) return boolean.class;
@@ -171,7 +213,8 @@ public final class ClassUtils {
 			// Not ClassNotFoundException.
 			// Not NoClassDefFoundError.
 			// Not UnsupportedClassVersionError!
-			return null;
+			if (quietly) return null;
+			throw new IllegalArgumentException("Cannot load class: " + className, t);
 		}
 	}
 

--- a/src/main/java/org/scijava/util/ClassUtils.java
+++ b/src/main/java/org/scijava/util/ClassUtils.java
@@ -96,8 +96,8 @@ public final class ClassUtils {
 	 * @return The loaded class, or null if the class could not be loaded.
 	 * @see #loadClass(String, ClassLoader)
 	 */
-	public static Class<?> loadClass(final String className) {
-		return loadClass(className, null);
+	public static Class<?> loadClass(final String name) {
+		return loadClass(name, null);
 	}
 
 	/**

--- a/src/test/java/org/scijava/util/ClassUtilsTest.java
+++ b/src/test/java/org/scijava/util/ClassUtilsTest.java
@@ -117,6 +117,16 @@ public class ClassUtilsTest {
 	}
 
 	@Test
+	public void testFailureQuiet() {
+		assertNull(ClassUtils.loadClass("a.non.existent.class"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testFailureLoud() {
+		ClassUtils.loadClass("a.non.existent.class", false);
+	}
+
+	@Test
 	public void testGetArrayClass() {
 		assertSame(boolean[].class, ClassUtils.getArrayClass(boolean.class));
 		assertSame(String[].class, ClassUtils.getArrayClass(String.class));


### PR DESCRIPTION
Several places in SciJava Common call the `ClassUtils.loadClass` routine. Previously, that routine simply returned null without explanation when the class could not be loaded for any reason. Now, by setting the `quietly` flag to false, we can do proper exception handling so that the reason for failure is known and can be passed along to the caller.

So this branch does that in all the places where it makes sense.