### PR TITLE
DefaultModuleService: change persisting of items

### DIFF
--- a/src/main/java/org/scijava/ItemPersistence.java
+++ b/src/main/java/org/scijava/ItemPersistence.java
@@ -29,52 +29,32 @@
  * #L%
  */
 
-package org.scijava.module;
+package org.scijava;
 
-import java.util.List;
-
-import org.scijava.ItemIO;
-import org.scijava.ItemPersistence;
-import org.scijava.ItemVisibility;
+import org.scijava.plugin.Parameter;
 
 /**
- * {@link ModuleItem} extension allowing manipulation of its metadata.
+ * Defines the persistence setting of a parameter.
  * 
- * @author Curtis Rueden
- * @see org.scijava.command.DynamicCommand
+ * @author Stefan Helfrich
  */
-public interface MutableModuleItem<T> extends ModuleItem<T> {
+public enum ItemPersistence {
 
-	void setIOType(ItemIO ioType);
+	/**
+	 * Item is persisted in any case.
+	 */
+	YES,
 
-	void setVisibility(ItemVisibility visibility);
+	/**
+	 * Item is never persisted.
+	 */
+	NO,
 
-	void setRequired(boolean required);
-
-	void setPersistence(ItemPersistence persistence);
-
-	void setPersistKey(String persistKey);
-
-	void setInitializer(String initializer);
-
-	void setCallback(String callback);
-
-	void setWidgetStyle(String widgetStyle);
-
-	void setDefaultValue(T defaultValue);
-
-	void setMinimumValue(T minimumValue);
-
-	void setMaximumValue(T maximumValue);
-
-	void setSoftMinimum(T softMinimum);
-
-	void setSoftMaximum(T softMaximum);
-
-	void setStepSize(Number stepSize);
-
-	void setColumnCount(int columnCount);
-
-	void setChoices(List<? extends T> choices);
+	/**
+	 * Item is persisted unless an additional {@link Parameter#initializer()
+	 * initializer()} method is defined or the value to persist is the defined
+	 * default value.
+	 */
+	DEFAULT
 
 }

--- a/src/main/java/org/scijava/command/CommandModuleItem.java
+++ b/src/main/java/org/scijava/command/CommandModuleItem.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.scijava.ItemIO;
+import org.scijava.ItemPersistence;
 import org.scijava.ItemVisibility;
 import org.scijava.Optional;
 import org.scijava.module.AbstractModuleItem;
@@ -109,7 +110,7 @@ public class CommandModuleItem<T> extends AbstractModuleItem<T> {
 	}
 
 	@Override
-	public boolean isPersisted() {
+	public ItemPersistence getPersistence() {
 		return getParameter().persist();
 	}
 

--- a/src/main/java/org/scijava/module/AbstractModuleItem.java
+++ b/src/main/java/org/scijava/module/AbstractModuleItem.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import org.scijava.AbstractBasicDetails;
 import org.scijava.ItemIO;
+import org.scijava.ItemPersistence;
 import org.scijava.ItemVisibility;
 import org.scijava.util.ClassUtils;
 import org.scijava.util.ConversionUtils;
@@ -71,7 +72,7 @@ public abstract class AbstractModuleItem<T> extends AbstractBasicDetails
 		sm.append("description", getDescription());
 		sm.append("visibility", getVisibility(), ItemVisibility.NORMAL);
 		sm.append("required", isRequired());
-		sm.append("persisted", isPersisted());
+		sm.append("persisted", getPersistence());
 		sm.append("persistKey", getPersistKey());
 		sm.append("callback", getCallback());
 		sm.append("widgetStyle", getWidgetStyle());
@@ -131,8 +132,8 @@ public abstract class AbstractModuleItem<T> extends AbstractBasicDetails
 	}
 
 	@Override
-	public boolean isPersisted() {
-		return true;
+	public ItemPersistence getPersistence() {
+		return ItemPersistence.DEFAULT;
 	}
 
 	@Override
@@ -149,7 +150,7 @@ public abstract class AbstractModuleItem<T> extends AbstractBasicDetails
 	@Deprecated
 	public T loadValue() {
 		// if there is nothing to load from persistence return nothing
-		if (!isPersisted()) return null;
+		if (getPersistence() == ItemPersistence.NO) return null;
 
 		final String sValue;
 		final String persistKey = getPersistKey();
@@ -169,7 +170,7 @@ public abstract class AbstractModuleItem<T> extends AbstractBasicDetails
 	@Override
 	@Deprecated
 	public void saveValue(final T value) {
-		if (!isPersisted()) return;
+		if (getPersistence() == ItemPersistence.NO) return;
 
 		final String sValue = value == null ? "" : value.toString();
 

--- a/src/main/java/org/scijava/module/DefaultModuleService.java
+++ b/src/main/java/org/scijava/module/DefaultModuleService.java
@@ -291,6 +291,9 @@ public class DefaultModuleService extends AbstractService implements
 	public <T> void save(final ModuleItem<T> item, final T value) {
 		if (!item.isPersisted()) return;
 
+		// NB: Do not persist values which are computed via an initializer.
+		if (item.getInitializer() != null && !item.getInitializer().isEmpty()) return;
+
 		if (MiscUtils.equal(item.getDefaultValue(), value)) {
 			// NB: Do not persist the value if it is the default.
 			// This is nice if the default value might change later,

--- a/src/main/java/org/scijava/module/DefaultModuleService.java
+++ b/src/main/java/org/scijava/module/DefaultModuleService.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import org.scijava.Identifiable;
+import org.scijava.ItemPersistence;
 import org.scijava.MenuPath;
 import org.scijava.Priority;
 import org.scijava.convert.ConvertService;
@@ -289,12 +290,16 @@ public class DefaultModuleService extends AbstractService implements
 
 	@Override
 	public <T> void save(final ModuleItem<T> item, final T value) {
-		if (!item.isPersisted()) return;
+		ItemPersistence persistence = item.getPersistence();
+
+		if (persistence == ItemPersistence.NO) return;
 
 		// NB: Do not persist values which are computed via an initializer.
-		if (item.getInitializer() != null && !item.getInitializer().isEmpty()) return;
+		if (item.getInitializer() != null && !item.getInitializer().isEmpty() &&
+			persistence == ItemPersistence.DEFAULT) return;
 
-		if (MiscUtils.equal(item.getDefaultValue(), value)) {
+		if (MiscUtils.equal(item.getDefaultValue(), value) &&
+			persistence == ItemPersistence.DEFAULT) {
 			// NB: Do not persist the value if it is the default.
 			// This is nice if the default value might change later,
 			// such as when iteratively developing a script.
@@ -318,7 +323,7 @@ public class DefaultModuleService extends AbstractService implements
 	@Override
 	public <T> T load(final ModuleItem<T> item) {
 		// if there is nothing to load from persistence return nothing
-		if (!item.isPersisted()) return null;
+		if (item.getPersistence() == ItemPersistence.NO) return null;
 
 		final String sValue;
 		final String persistKey = item.getPersistKey();

--- a/src/main/java/org/scijava/module/DefaultMutableModuleItem.java
+++ b/src/main/java/org/scijava/module/DefaultMutableModuleItem.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.scijava.ItemIO;
+import org.scijava.ItemPersistence;
 import org.scijava.ItemVisibility;
 
 /**
@@ -54,7 +55,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	private ItemIO ioType;
 	private ItemVisibility visibility;
 	private boolean required;
-	private boolean persisted;
+	private ItemPersistence persistence;
 	private String persistKey;
 	private String initializer;
 	private String callback;
@@ -87,7 +88,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 		ioType = super.getIOType();
 		visibility = super.getVisibility();
 		required = super.isRequired();
-		persisted = super.isPersisted();
+		persistence = super.getPersistence();
 		persistKey = super.getPersistKey();
 		initializer = super.getInitializer();
 		callback = super.getCallback();
@@ -113,7 +114,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 		ioType = item.getIOType();
 		visibility = item.getVisibility();
 		required = item.isRequired();
-		persisted = item.isPersisted();
+		persistence = item.getPersistence();
 		persistKey = item.getPersistKey();
 		initializer = item.getInitializer();
 		callback = item.getCallback();
@@ -148,8 +149,8 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	}
 
 	@Override
-	public void setPersisted(final boolean persisted) {
-		this.persisted = persisted;
+	public void setPersistence(final ItemPersistence persistence) {
+		this.persistence = persistence;
 	}
 
 	@Override
@@ -241,8 +242,8 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	}
 
 	@Override
-	public boolean isPersisted() {
-		return persisted;
+	public ItemPersistence getPersistence() {
+		return persistence;
 	}
 
 	@Override

--- a/src/main/java/org/scijava/module/ModuleItem.java
+++ b/src/main/java/org/scijava/module/ModuleItem.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import org.scijava.BasicDetails;
 import org.scijava.ItemIO;
+import org.scijava.ItemPersistence;
 import org.scijava.ItemVisibility;
 
 /**
@@ -84,7 +85,7 @@ public interface ModuleItem<T> extends BasicDetails {
 	boolean isRequired();
 
 	/** Gets whether to remember the most recent value of the parameter. */
-	boolean isPersisted();
+	ItemPersistence getPersistence();
 
 	/** Gets the key to use for saving the value persistently. */
 	String getPersistKey();

--- a/src/main/java/org/scijava/plugin/Parameter.java
+++ b/src/main/java/org/scijava/plugin/Parameter.java
@@ -116,7 +116,11 @@ public @interface Parameter {
 	/** Defines a key to use for saving the value persistently. */
 	String persistKey() default "";
 
-	/** Defines a function that is called to initialize the parameter. */
+	/**
+	 * Defines a function that is called to initialize the parameter. If an
+	 * initializer is defined, it takes precedence over {@link #persist()}, i.e.
+	 * the parameter is not persisted even if {@code persist=true} is set.
+	 */
 	String initializer() default "";
 
 	/**

--- a/src/main/java/org/scijava/plugin/Parameter.java
+++ b/src/main/java/org/scijava/plugin/Parameter.java
@@ -37,6 +37,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.scijava.ItemIO;
+import org.scijava.ItemPersistence;
 import org.scijava.ItemVisibility;
 
 /**
@@ -111,7 +112,7 @@ public @interface Parameter {
 	boolean required() default true;
 
 	/** Defines whether to remember the most recent value of the parameter. */
-	boolean persist() default true;
+	ItemPersistence persist() default ItemPersistence.DEFAULT;
 
 	/** Defines a key to use for saving the value persistently. */
 	String persistKey() default "";
@@ -119,7 +120,8 @@ public @interface Parameter {
 	/**
 	 * Defines a function that is called to initialize the parameter. If an
 	 * initializer is defined, it takes precedence over {@link #persist()}, i.e.
-	 * the parameter is not persisted even if {@code persist=true} is set.
+	 * the parameter is not persisted even if {@link #persist()} returns
+	 * {@link ItemPersistence#YES}.
 	 */
 	String initializer() default "";
 

--- a/src/main/java/org/scijava/script/ScriptInfo.java
+++ b/src/main/java/org/scijava/script/ScriptInfo.java
@@ -49,6 +49,7 @@ import javax.script.ScriptException;
 import org.scijava.Context;
 import org.scijava.Contextual;
 import org.scijava.ItemIO;
+import org.scijava.ItemPersistence;
 import org.scijava.ItemVisibility;
 import org.scijava.NullContextException;
 import org.scijava.command.Command;
@@ -427,7 +428,7 @@ public class ScriptInfo extends AbstractModuleInfo implements Contextual {
 		else if (is(k, "max")) item.setMaximumValue(as(v, item.getType()));
 		else if (is(k, "min")) item.setMinimumValue(as(v, item.getType()));
 		else if (is(k, "name")) item.setName(as(v, String.class));
-		else if (is(k, "persist")) item.setPersisted(as(v, boolean.class));
+		else if (is(k, "persist")) item.setPersistence(as(v, ItemPersistence.class));
 		else if (is(k, "persistKey")) item.setPersistKey(as(v, String.class));
 		else if (is(k, "required")) item.setRequired(as(v, boolean.class));
 		else if (is(k, "softMax")) item.setSoftMaximum(as(v, item.getType()));

--- a/src/test/java/org/scijava/module/ModuleServiceTest.java
+++ b/src/test/java/org/scijava/module/ModuleServiceTest.java
@@ -31,12 +31,10 @@
 
 package org.scijava.module;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
-import java.security.GeneralSecurityException;
-
-import org.junit.Assert;
 import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.prefs.PrefService;
@@ -100,14 +98,14 @@ public class ModuleServiceTest {
 
 		// verify that the item is not persisted
 		String persistKey = doubleItem.getPersistKey();
-		Assert.assertNull(prefService.get(persistKey));
+		assertNull(prefService.get(persistKey));
 
 		// save ModuleItem for which getInitializer() returns null
 		moduleService.save(integerItem, 5);
 
 		// verify that the item is persisted
 		persistKey = integerItem.getPersistKey();
-		Assert.assertEquals(5, prefService.getInt(persistKey, 0));
+		assertEquals(5, prefService.getInt(persistKey, 0));
 	}
 
 	/** A sample module for testing the module service. */

--- a/src/test/java/org/scijava/script/ScriptInfoTest.java
+++ b/src/test/java/org/scijava/script/ScriptInfoTest.java
@@ -56,6 +56,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.ItemIO;
+import org.scijava.ItemPersistence;
 import org.scijava.log.LogService;
 import org.scijava.module.ModuleItem;
 import org.scijava.plugin.Plugin;
@@ -151,27 +152,32 @@ public class ScriptInfoTest {
 		final List<?> noChoices = Collections.emptyList();
 
 		final ModuleItem<?> log = info.getInput("log");
-		assertItem("log", LogService.class, null, ItemIO.INPUT, false, true, null,
-			null, null, null, null, null, null, null, noChoices, log);
+		assertItem("log", LogService.class, null, ItemIO.INPUT, false,
+			ItemPersistence.DEFAULT, null, null, null, null, null, null, null, null,
+			noChoices, log);
 
 		final ModuleItem<?> sliderValue = info.getInput("sliderValue");
 		assertItem("sliderValue", int.class, "Slider Value", ItemIO.INPUT, true,
-			true, null, "slider", 11, null, null, 5, 15, 3.0, noChoices, sliderValue);
+			ItemPersistence.DEFAULT, null, "slider", 11, null, null, 5, 15, 3.0,
+			noChoices, sliderValue);
 
 		final ModuleItem<?> animal = info.getInput("animal");
 		final List<String> animalChoices = //
 			Arrays.asList("quick brown fox", "lazy dog");
-		assertItem("animal", String.class, null, ItemIO.INPUT, true, false,
-			null, null, null, null, null, null, null, null, animalChoices, animal);
+		assertItem("animal", String.class, null, ItemIO.INPUT, true,
+			ItemPersistence.DEFAULT, null, null, null, null, null, null, null, null,
+			animalChoices, animal);
 		assertEquals(animal.get("family"), "Carnivora"); // test custom attribute
 
 		final ModuleItem<?> buffer = info.getOutput("buffer");
-		assertItem("buffer", StringBuilder.class, null, ItemIO.BOTH, true, true,
-			null, null, null, null, null, null, null, null, noChoices, buffer);
+		assertItem("buffer", StringBuilder.class, null, ItemIO.BOTH, true,
+			ItemPersistence.DEFAULT, null, null, null, null, null, null, null, null,
+			noChoices, buffer);
 
 		final ModuleItem<?> result = info.getOutput("result");
-		assertItem("result", Object.class, null, ItemIO.OUTPUT, true, true, null,
-			null, null, null, null, null, null, null, noChoices, result);
+		assertItem("result", Object.class, null, ItemIO.OUTPUT, true,
+			ItemPersistence.DEFAULT, null, null, null, null, null, null, null, null,
+			noChoices, result);
 
 		int inputCount = 0;
 		final ModuleItem<?>[] inputs = { log, sliderValue, animal, buffer };
@@ -188,7 +194,7 @@ public class ScriptInfoTest {
 
 	private void assertItem(final String name, final Class<?> type,
 		final String label, final ItemIO ioType, final boolean required,
-		final boolean persist, final String persistKey, final String style,
+		final ItemPersistence persist, final String persistKey, final String style,
 		final Object value, final Object min, final Object max,
 		final Object softMin, final Object softMax, final Number stepSize,
 		final List<?> choices, final ModuleItem<?> item)
@@ -198,7 +204,7 @@ public class ScriptInfoTest {
 		assertEquals(label, item.getLabel());
 		assertSame(ioType, item.getIOType());
 		assertEquals(required, item.isRequired());
-		assertEquals(persist, item.isPersisted());
+		assertEquals(persist, item.getPersistence());
 		assertEquals(persistKey, item.getPersistKey());
 		assertEquals(style, item.getWidgetStyle());
 		assertEquals(value, item.getDefaultValue());


### PR DESCRIPTION
Disable the persisting of a `ModuleItem`s if an `initialize()` method is set and is not empty. This way, `initialize()` can overwrite the value of a `ModuleItem` even if `persist=true` is assumed implicitly.

See:
- https://github.com/imagej/imagej-legacy/pull/137#issuecomment-200543860
