### PR TITLE
Add support for arbitrary parameter attributes

### DIFF
--- a/src/main/java/org/scijava/AbstractBasicDetails.java
+++ b/src/main/java/org/scijava/AbstractBasicDetails.java
@@ -53,7 +53,7 @@ public abstract class AbstractBasicDetails implements BasicDetails {
 	private String description;
 
 	/** Table of extra key/value pairs. */
-	private Map<String, String> values = new HashMap<String, String>();
+	private final Map<String, String> values = new HashMap<String, String>();
 
 	// -- Object methods --
 
@@ -102,7 +102,7 @@ public abstract class AbstractBasicDetails implements BasicDetails {
 	}
 
 	@Override
-	public void set(String key, String value) {
+	public void set(final String key, final String value) {
 		values.put(key, value);
 	}
 

--- a/src/main/java/org/scijava/script/ScriptInfo.java
+++ b/src/main/java/org/scijava/script/ScriptInfo.java
@@ -399,7 +399,7 @@ public class ScriptInfo extends AbstractModuleInfo implements Contextual {
 	}
 
 	private <T> void addItem(final String name, final Class<T> type,
-		final Map<String, Object> attrs) throws ScriptException
+		final Map<String, Object> attrs)
 	{
 		final DefaultMutableModuleItem<T> item =
 			new DefaultMutableModuleItem<T>(this, name, type);
@@ -412,7 +412,7 @@ public class ScriptInfo extends AbstractModuleInfo implements Contextual {
 	}
 
 	private <T> void assignAttribute(final DefaultMutableModuleItem<T> item,
-		final String k, final Object v) throws ScriptException
+		final String k, final Object v)
 	{
 		// CTR: There must be an easier way to do this.
 		// Just compile the thing using javac? Or parse via javascript, maybe?
@@ -435,7 +435,7 @@ public class ScriptInfo extends AbstractModuleInfo implements Contextual {
 		else if (is(k, "style")) item.setWidgetStyle(as(v, String.class));
 		else if (is(k, "visibility")) item.setVisibility(as(v, ItemVisibility.class));
 		else if (is(k, "value")) item.setDefaultValue(as(v, item.getType()));
-		else throw new ScriptException("Invalid attribute name: " + k);
+		else item.set(k, v.toString());
 	}
 
 	/** Super terse comparison helper method. */

--- a/src/test/java/org/scijava/script/ScriptInfoTest.java
+++ b/src/test/java/org/scijava/script/ScriptInfoTest.java
@@ -142,7 +142,7 @@ public class ScriptInfoTest {
 			"% @LogService(required = false) log\n" + //
 			"% @int(label=\"Slider Value\", softMin=5, softMax=15, " + //
 			"stepSize=3, value=11, style=\"slider\") sliderValue\n" + //
-			"% @String(persist = false, " + //
+			"% @String(persist = false, family='Carnivora', " + //
 			"choices={'quick brown fox', 'lazy dog'}) animal\n" + //
 			"% @BOTH java.lang.StringBuilder buffer";
 
@@ -164,6 +164,7 @@ public class ScriptInfoTest {
 			Arrays.asList("quick brown fox", "lazy dog");
 		assertItem("animal", String.class, null, ItemIO.INPUT, true, false,
 			null, null, null, null, null, null, null, null, animalChoices, animal);
+		assertEquals(animal.get("family"), "Carnivora"); // test custom attribute
 
 		final ModuleItem<?> buffer = info.getOutput("buffer");
 		assertItem("buffer", StringBuilder.class, null, ItemIO.BOTH, true, true,


### PR DESCRIPTION
It was not possible to specify `@Attr` key/value pairs in scripts.
With this change, it is now not only possible, but nice and elegant!