### PR TITLE
Add array type aliases to the DefaultScriptService

### DIFF
--- a/src/main/java/org/scijava/script/DefaultScriptService.java
+++ b/src/main/java/org/scijava/script/DefaultScriptService.java
@@ -408,9 +408,17 @@ public class DefaultScriptService extends
 		addAliases(map, Boolean.class, Byte.class, Character.class, Double.class,
 			Float.class, Integer.class, Long.class, Short.class);
 
+		// primitive wrappers arrays
+		addAliases(map, Boolean[].class, Byte[].class, Character[].class, Double[].class,
+			Float[].class, Integer[].class, Long[].class, Short[].class);
+
 		// built-in types
 		addAliases(map, Context.class, BigDecimal.class, BigInteger.class,
 			ColorRGB.class, ColorRGBA.class, File.class, String.class);
+
+		// built-in type arrays
+		addAliases(map, Context[].class, BigDecimal[].class, BigInteger[].class,
+			ColorRGB[].class, ColorRGBA[].class, File[].class, String[].class);
 
 		// gateway types
 		final List<PluginInfo<Gateway>> gatewayPlugins =


### PR DESCRIPTION
This allows script users to easily use arrays with the added java
types, without needing to fully qualify the array type:

``@Integer[] input`` instead of ``@java.lang.Integer[] input``