### PR TITLE
Adds method to get InputWidget from InputPanel

### DIFF
--- a/src/main/java/org/scijava/widget/AbstractInputPanel.java
+++ b/src/main/java/org/scijava/widget/AbstractInputPanel.java
@@ -61,6 +61,11 @@ public abstract class AbstractInputPanel<P, W> implements InputPanel<P, W> {
 	public void addWidget(final InputWidget<?, W> widget) {
 		widgets.put(widget.get().getItem().getName(), widget);
 	}
+	
+	@Override
+	public InputWidget<?, W> getWidget(final String name) {
+		return widgets.get(name);
+	}
 
 	@Override
 	public Object getValue(final String name) {

--- a/src/main/java/org/scijava/widget/InputPanel.java
+++ b/src/main/java/org/scijava/widget/InputPanel.java
@@ -70,5 +70,8 @@ public interface InputPanel<P, W> extends UIComponent<P> {
 
 	/** Gets the type of the UI component housing the panel's widgets. */
 	Class<W> getWidgetComponentType();
+	
+	/** Gets the widget with the provided name. */
+	InputWidget<?, W> getWidget(String name);
 
 }


### PR DESCRIPTION
sometimes one wants to access the `InputWidget` from `InputPanel`s directly. Therefore one can request now the `InputWidget`from an `InputPanel`. However, this breaks backwards compatibility.