### PR TITLE
Add STL format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,10 @@
 			<artifactId>eventbus</artifactId>
 			<version>1.4</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
 
 		<!-- Test scope dependencies -->
 		<dependency>

--- a/src/main/java/org/scijava/stl/AbstractBinarySTLFormat.java
+++ b/src/main/java/org/scijava/stl/AbstractBinarySTLFormat.java
@@ -1,0 +1,75 @@
+
+package org.scijava.stl;
+
+import com.google.common.base.Strings;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.scijava.plugin.AbstractHandlerPlugin;
+import org.scijava.util.FileUtils;
+
+/**
+ * An abstract superclass of binary {@link STLFormat} implementations
+ * <p>
+ * Binary STL formats include the standard and non-standard colour variants
+ * </p>
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+public abstract class AbstractBinarySTLFormat extends
+	AbstractHandlerPlugin<File> implements STLFormat
+{
+
+	public static final int HEADER_BYTES = 80;
+	public static final String HEADER = Strings.padEnd(
+		"Binary STL created with ImageJ", HEADER_BYTES, '.');
+	public static final int COUNT_BYTES = 4;
+	public static final int FACET_START = HEADER_BYTES + COUNT_BYTES;
+	public static final int FACET_BYTES = 50;
+
+	@Override
+	public List<STLFacet> read(final File stlFile) throws IOException {
+		if (stlFile == null) {
+			return Collections.emptyList();
+		}
+
+		final byte[] data = Files.readAllBytes(Paths.get(stlFile
+			.getAbsolutePath()));
+
+		return readFacets(data);
+	}
+
+	@Override
+	public boolean supports(final File file) {
+		final String extension = FileUtils.getExtension(file);
+		if (!EXTENSION.equalsIgnoreCase(extension)) {
+			return false;
+		}
+
+		try (FileInputStream reader = new FileInputStream(file)) {
+			final byte[] dataStart = new byte[5];
+			reader.read(dataStart, 0, 5);
+			// ASCII STL files begin with the line solid <name> whereas binary files
+			// have an arbitrary header
+			return !"solid".equals(Arrays.toString(dataStart));
+		}
+		catch (IOException e) {
+			return false;
+		}
+	}
+
+	@Override
+	public Class<File> getType() {
+		return File.class;
+	}
+
+	public abstract List<STLFacet> readFacets(final byte[] data)
+		throws IOException;
+}

--- a/src/main/java/org/scijava/stl/BinarySTLFormat.java
+++ b/src/main/java/org/scijava/stl/BinarySTLFormat.java
@@ -1,0 +1,98 @@
+
+package org.scijava.stl;
+
+import com.sun.javafx.geom.Vec3f;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The {@link STLFormat} implementation for standard binary STL files
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+public class BinarySTLFormat extends AbstractBinarySTLFormat {
+
+	@Override
+	public List<STLFacet> readFacets(final byte[] data) {
+		final List<STLFacet> facets = new ArrayList<>();
+
+		if (data.length < FACET_START) {
+			return facets;
+		}
+
+		final ByteBuffer buffer = ByteBuffer.wrap(data).order(
+			ByteOrder.LITTLE_ENDIAN);
+		final int facetCount = buffer.getInt(HEADER_BYTES);
+		final int expectedSize = HEADER_BYTES + COUNT_BYTES + facetCount *
+			FACET_BYTES;
+		if (expectedSize != buffer.capacity()) {
+			return facets;
+		}
+
+		buffer.position(FACET_START);
+		for (int offset = FACET_START; offset < buffer.capacity(); offset +=
+			FACET_BYTES)
+		{
+			STLFacet facet = readFacet(buffer);
+			facets.add(facet);
+		}
+
+		return facets;
+	}
+
+	@Override
+	public byte[] write(final List<STLFacet> facets) {
+		final int facetCount = facets == null ? 0 : facets.size();
+		final int bytes = HEADER_BYTES + COUNT_BYTES + facetCount * FACET_BYTES;
+		final ByteBuffer buffer = ByteBuffer.allocate(bytes).order(
+			ByteOrder.LITTLE_ENDIAN);
+
+		buffer.put(HEADER.getBytes());
+		buffer.putInt(facetCount);
+
+		if (facets == null) {
+			return buffer.array();
+		}
+
+		facets.forEach(f -> writeFacet(buffer, f));
+
+		return buffer.array();
+	}
+
+	private static void writeFacet(final ByteBuffer buffer,
+		final STLFacet facet)
+	{
+		writeVector(buffer, facet.normal);
+		writeVector(buffer, facet.vertex0);
+		writeVector(buffer, facet.vertex1);
+		writeVector(buffer, facet.vertex2);
+		buffer.putShort((short) 0); // Attribute byte count
+	}
+
+	private static void writeVector(final ByteBuffer buffer, final Vec3f vector) {
+		buffer.putFloat(vector.x);
+		buffer.putFloat(vector.y);
+		buffer.putFloat(vector.z);
+	}
+
+	private static STLFacet readFacet(final ByteBuffer buffer) {
+		final Vec3f normal = readVector(buffer);
+		final Vec3f vertex0 = readVector(buffer);
+		final Vec3f vertex1 = readVector(buffer);
+		final Vec3f vertex2 = readVector(buffer);
+		final short attributeByteCount = buffer.getShort();
+
+		return new STLFacet(normal, vertex0, vertex1, vertex2, attributeByteCount);
+	}
+
+	private static Vec3f readVector(final ByteBuffer buffer) {
+		final float x = buffer.getFloat();
+		final float y = buffer.getFloat();
+		final float z = buffer.getFloat();
+
+		return new Vec3f(x, y, z);
+	}
+}

--- a/src/main/java/org/scijava/stl/DefaultSTLService.java
+++ b/src/main/java/org/scijava/stl/DefaultSTLService.java
@@ -1,0 +1,52 @@
+
+package org.scijava.stl;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import com.google.common.io.Files;
+import org.scijava.plugin.AbstractHandlerService;
+import org.scijava.plugin.Plugin;
+import org.scijava.service.Service;
+
+/**
+ * Default service for working with STL formats
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+@Plugin(type = Service.class)
+public class DefaultSTLService extends AbstractHandlerService<File, STLFormat>
+	implements STLService
+{
+
+	@Override
+	public List<STLFacet> read(final File file) throws IOException {
+		final STLFormat format = getHandler(file);
+		if (format == null) return null;
+		return format.read(file);
+	}
+
+	@Override
+	public void write(final File file, final List<STLFacet> facets) throws IOException {
+		final STLFormat format = getHandler(file);
+		if (format == null) return;
+		final byte[] bytes = format.write(facets);
+
+		Files.write(bytes, file);
+	}
+
+	// -- PTService methods --
+
+	@Override
+	public Class<STLFormat> getPluginType() {
+		return STLFormat.class;
+	}
+
+	// -- Typed methods --
+
+	@Override
+	public Class<File> getType() {
+		return File.class;
+	}
+}

--- a/src/main/java/org/scijava/stl/STLFacet.java
+++ b/src/main/java/org/scijava/stl/STLFacet.java
@@ -1,0 +1,28 @@
+
+package org.scijava.stl;
+
+import com.sun.javafx.geom.Vec3f;
+
+/**
+ * A helper class to store a facet read from a STL file
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+public final class STLFacet {
+
+	public final Vec3f normal;
+	public final Vec3f vertex0;
+	public final Vec3f vertex1;
+	public final Vec3f vertex2;
+	public final short attributeByteCount;
+
+	public STLFacet(final Vec3f normal, final Vec3f vertex0, final Vec3f vertex1,
+		final Vec3f vertex2, final short attributeByteCount)
+	{
+		this.normal = normal;
+		this.vertex0 = vertex0;
+		this.vertex1 = vertex1;
+		this.vertex2 = vertex2;
+		this.attributeByteCount = attributeByteCount;
+	}
+}

--- a/src/main/java/org/scijava/stl/STLFormat.java
+++ b/src/main/java/org/scijava/stl/STLFormat.java
@@ -1,0 +1,30 @@
+
+package org.scijava.stl;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.scijava.plugin.HandlerPlugin;
+
+/**
+ * {@code STLFormat} plugins provide handling for different kinds of STL files
+ * <p>
+ * STL files can be saved in binary or ascii
+ * </p>
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+public interface STLFormat extends HandlerPlugin<File> {
+
+	String EXTENSION = "stl";
+
+	/**
+	 * Reads the STL facets from the given File which can then be converted into a
+	 * mesh
+	 */
+	List<STLFacet> read(final File stlFile) throws IOException;
+
+	/** Writes the facets into a byte[] that can then be saved into a file */
+	byte[] write(final List<STLFacet> facets) throws IOException;
+}

--- a/src/main/java/org/scijava/stl/STLService.java
+++ b/src/main/java/org/scijava/stl/STLService.java
@@ -1,0 +1,43 @@
+
+package org.scijava.stl;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.scijava.plugin.HandlerService;
+import org.scijava.service.SciJavaService;
+
+/**
+ * Interface for service that works with STL formats.
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+public interface STLService extends HandlerService<File, STLFormat>,
+	SciJavaService
+{
+
+	/** Reads the data from the given file into a string. */
+	List<STLFacet> read(File file) throws IOException;
+
+	/** Writes the facets into the given file */
+	void write(File file, List<STLFacet> facets) throws IOException;
+
+	// -- HandlerService methods --
+
+	/** Gets the STL format which best handles the given file. */
+	@Override
+	STLFormat getHandler(File file);
+
+	// -- SingletonService methods --
+
+	/** Gets the list of available STL formats. */
+	@Override
+	List<STLFormat> getInstances();
+
+	// -- Typed methods --
+
+	/** Gets whether the given file contains STL data in a supported format. */
+	@Override
+	boolean supports(File file);
+}

--- a/src/main/java/org/scijava/stl/io/STLIOPlugin.java
+++ b/src/main/java/org/scijava/stl/io/STLIOPlugin.java
@@ -1,0 +1,50 @@
+
+package org.scijava.stl.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.scijava.Priority;
+import org.scijava.io.AbstractIOPlugin;
+import org.scijava.io.IOPlugin;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.stl.STLFacet;
+import org.scijava.stl.STLService;
+
+/**
+ * {@link IOPlugin} for handling STL files
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ * @see STLService
+ */
+@Plugin(type = IOPlugin.class, priority = Priority.LOW_PRIORITY - 1)
+public class STLIOPlugin extends AbstractIOPlugin<List<STLFacet>> {
+
+	@Parameter(required = false)
+	private STLService stlService;
+
+	@Override
+	public Class<List<STLFacet>> getDataType() {
+		return (Class) List.class;
+	}
+
+	@Override
+	public boolean supportsOpen(final String source) {
+		return stlService != null && stlService.supports(new File(source));
+	}
+
+	@Override
+	public boolean supportsSave(final String destination) {
+		return stlService != null && stlService.supports(new File(destination));
+	}
+
+	@Override
+	public void save(final List<STLFacet> data, final String destination)
+		throws IOException, NullPointerException
+	{
+		stlService.write(new File(destination), data);
+	}
+}

--- a/src/test/java/org/scijava/ContextCreationTest.java
+++ b/src/test/java/org/scijava/ContextCreationTest.java
@@ -108,6 +108,7 @@ public class ContextCreationTest {
 				org.scijava.prefs.DefaultPrefService.class,
 				org.scijava.run.DefaultRunService.class,
 				org.scijava.script.DefaultScriptHeaderService.class,
+				org.scijava.stl.DefaultSTLService.class,
 				org.scijava.text.DefaultTextService.class,
 				org.scijava.thread.DefaultThreadService.class,
 				org.scijava.tool.DefaultToolService.class,

--- a/src/test/java/org/scijava/stl/BinarySTLFormatTest.java
+++ b/src/test/java/org/scijava/stl/BinarySTLFormatTest.java
@@ -1,0 +1,173 @@
+
+package org.scijava.stl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.scijava.stl.AbstractBinarySTLFormat.FACET_BYTES;
+import static org.scijava.stl.BinarySTLFormat.COUNT_BYTES;
+import static org.scijava.stl.BinarySTLFormat.HEADER;
+import static org.scijava.stl.BinarySTLFormat.HEADER_BYTES;
+
+import com.google.common.base.Strings;
+import com.sun.javafx.geom.Vec3f;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link BinarySTLFormat}
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+public class BinarySTLFormatTest {
+
+	private static final BinarySTLFormat format = new BinarySTLFormat();
+
+	@Test
+	public void testWriteNull() throws Exception {
+		final byte[] bytes = format.write(null);
+
+		assertNotNull(bytes);
+		assertEquals(HEADER_BYTES + COUNT_BYTES, bytes.length);
+	}
+
+	@Test
+	public void testWrite() throws Exception {
+		final STLFacet facet = new STLFacet(new Vec3f(0, 0, 1), new Vec3f(1, 0, 0),
+			new Vec3f(0, 1, 0), new Vec3f(0, 0, 0), (short) 0);
+		final STLFacet facet2 = new STLFacet(new Vec3f(-1, 0, 0), new Vec3f(0, 0,
+			1), new Vec3f(0, 1, 0), new Vec3f(0, 0, 0), (short) 0);
+		List<STLFacet> facets = Arrays.asList(facet, facet2);
+		final int expectedSize = HEADER_BYTES + COUNT_BYTES + facets.size() *
+			FACET_BYTES;
+
+		final byte[] data = format.write(facets);
+		final ByteBuffer buffer = ByteBuffer.wrap(data).order(
+			ByteOrder.LITTLE_ENDIAN);
+
+		assertEquals("Size of STL data is incorrect", expectedSize, buffer
+			.capacity());
+
+		byte[] headerBytes = new byte[HEADER_BYTES];
+		buffer.get(headerBytes, 0, HEADER_BYTES);
+		final String header = new String(headerBytes);
+		assertEquals("Header of STL data is incorrect", header, HEADER);
+
+		final int facetCount = buffer.getInt();
+		assertEquals("Wrong number of facets written", facets.size(), facetCount);
+
+		facets.forEach(f -> assertFacet(f, buffer, 1e-12));
+	}
+
+	@Test
+	public void testReadNull() throws Exception {
+		final List<STLFacet> facets = format.read(null);
+
+		assertNotNull(facets);
+		assertEquals(0, facets.size());
+	}
+
+	@Test
+	public void testReadBadSize() throws Exception {
+		final byte[] data = new byte[61];
+		final List<STLFacet> facets = format.readFacets(data);
+
+		assertNotNull(facets);
+		assertEquals(0, facets.size());
+	}
+
+	@Test
+	public void testReadBadFacetCount() throws Exception {
+		final ByteBuffer buffer = ByteBuffer.allocate(HEADER_BYTES + COUNT_BYTES)
+			.order(ByteOrder.LITTLE_ENDIAN);
+		final byte[] header = Strings.padEnd("Header", 80, '.').getBytes();
+		final int facetCount = 2;
+		buffer.put(header);
+		buffer.putInt(facetCount);
+
+		final List<STLFacet> facets = format.readFacets(buffer.array());
+
+		assertNotNull(facets);
+		assertEquals(0, facets.size());
+	}
+
+	@Test
+	public void testReadFacets() throws Exception {
+		final int facetCount = 2;
+		final short attributeByteCount = 0;
+		final List<float[]> facet = Arrays.asList(new float[] { -2.0f, -1.0f,
+			0.0f }, new float[] { 1.0f, 2.0f, 3.0f }, new float[] { 4.0f, 5.0f,
+				6.0f }, new float[] { 7.0f, 8.0f, 9.0f });
+		final List<float[]> facet1 = Arrays.asList(new float[] { 1.0f, 0.0f, 0.0f },
+			new float[] { 1.0f, 0.0f, 0.0f }, new float[] { 1.0f, 0.0f, 0.0f },
+			new float[] { 1.0f, 0.0f, 0.0f });
+		final ByteBuffer buffer = ByteBuffer.allocate(HEADER_BYTES + COUNT_BYTES +
+			facetCount * FACET_BYTES).order(ByteOrder.LITTLE_ENDIAN);
+		final byte[] header = Strings.padEnd("Header", 80, '.').getBytes();
+
+		buffer.put(header);
+		buffer.putInt(facetCount);
+		writeFacet(buffer, facet, attributeByteCount);
+		writeFacet(buffer, facet1, attributeByteCount);
+
+		final List<STLFacet> facets = format.readFacets(buffer.array());
+
+		assertFacet(facets.get(0), facet);
+	}
+
+	private static void assertFacet(final STLFacet expectedFacet,
+		final List<float[]> actualFacet)
+	{
+		assertVector(expectedFacet.normal, actualFacet.get(0));
+		assertVector(expectedFacet.vertex0, actualFacet.get(1));
+		assertVector(expectedFacet.vertex1, actualFacet.get(2));
+		assertVector(expectedFacet.vertex2, actualFacet.get(3));
+	}
+
+	private static void assertVector(final Vec3f expectedVector,
+		final float[] actualVector)
+	{
+		assertEquals(expectedVector.x, actualVector[0], 1e-12);
+		assertEquals(expectedVector.y, actualVector[1], 1e-12);
+		assertEquals(expectedVector.z, actualVector[2], 1e-12);
+	}
+
+	private static void writeFacet(final ByteBuffer buffer, List<float[]> vectors,
+		final short attributeByteCount)
+	{
+		vectors.forEach(v -> writeVector(buffer, v[0], v[1], v[2]));
+		buffer.putShort(attributeByteCount);
+	}
+
+	private static void writeVector(final ByteBuffer buffer, final float x,
+		final float y, final float z)
+	{
+		buffer.order(ByteOrder.LITTLE_ENDIAN).putFloat(x);
+		buffer.order(ByteOrder.LITTLE_ENDIAN).putFloat(y);
+		buffer.order(ByteOrder.LITTLE_ENDIAN).putFloat(z);
+	}
+
+	private static void assertFacet(STLFacet expected, ByteBuffer buffer,
+		double delta)
+	{
+		assertVector(expected.normal, buffer, delta);
+		assertVector(expected.vertex0, buffer, delta);
+		assertVector(expected.vertex1, buffer, delta);
+		assertVector(expected.vertex2, buffer, delta);
+
+		final short attributeByteCount = buffer.getShort();
+		assertEquals(expected.attributeByteCount, attributeByteCount);
+	}
+
+	private static void assertVector(final Vec3f expected,
+		final ByteBuffer buffer, final double delta)
+	{
+		assertEquals(expected.x, buffer.getFloat(), delta);
+		assertEquals(expected.y, buffer.getFloat(), delta);
+		assertEquals(expected.z, buffer.getFloat(), delta);
+	}
+}


### PR DESCRIPTION
Add support for standard binary STL files, and possibility to extend i/o for ascii STLs etc.

This PR is just to initiate support for STL files, I am aware it'll probably need a lot of work to be merged. For instance, I could add support for ASCII STL files from the ThreeDViewer repo of @kephale.

What would be a good way to determine `boolean supports` in `STLIOPlugin`, i.e. when trying to decide between using binary and ascii formats for opening and saving files?
