### PR TITLE
Create Initializable

### DIFF
--- a/src/main/java/org/scijava/Initializable.java
+++ b/src/main/java/org/scijava/Initializable.java
@@ -1,0 +1,45 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava;
+
+/**
+ * Interface for objects which can be initialized.
+ * 
+ * @author Curtis Rueden
+ */
+public interface Initializable {
+
+	/** Initializes the object. */
+	default void initialize() {
+		// NB: Do nothing by default.
+	}
+
+}

--- a/src/main/java/org/scijava/module/AbstractModule.java
+++ b/src/main/java/org/scijava/module/AbstractModule.java
@@ -35,6 +35,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
+import org.scijava.Initializable;
+
 /**
  * Abstract superclass of {@link Module} implementations.
  * <p>
@@ -76,11 +78,16 @@ public abstract class AbstractModule implements Module {
 	public void initialize() throws MethodCallException {
 		// execute global module initializer
 		final Object delegateObject = getDelegateObject();
-		if (initializerRef == null) {
-			final String initializer = getInfo().getInitializer();
-			initializerRef = new MethodRef(delegateObject.getClass(), initializer);
+		if (delegateObject instanceof Initializable) {
+			((Initializable) delegateObject).initialize();
 		}
-		initializerRef.execute(delegateObject);
+		else {
+			if (initializerRef == null) {
+				final String initializer = getInfo().getInitializer();
+				initializerRef = new MethodRef(delegateObject.getClass(), initializer);
+			}
+			initializerRef.execute(delegateObject);
+		}
 
 		// execute individual module item initializers
 		for (final ModuleItem<?> item : getInfo().inputs()) {


### PR DESCRIPTION
See [imagej-ops#455](https://github.com/imagej/imagej-ops/issues/455)

This interface is moved from imagej-ops. It might be easier for the
underlying class inside the module to implement this interface than to
specify the initializer inside the Plugin annotation, especially because
annotation could not be partially overridden. Now the Initializable
interface has higher priority than the initializer annotation, and at
most one of them will be called when a module is initialized.
