### PR TITLE
Revamp the LogService

### DIFF
--- a/src/main/java/org/scijava/console/DefaultConsoleService.java
+++ b/src/main/java/org/scijava/console/DefaultConsoleService.java
@@ -39,7 +39,9 @@ import java.util.List;
 
 import org.scijava.Context;
 import org.scijava.console.OutputEvent.Source;
+import org.scijava.log.LogLevel;
 import org.scijava.log.LogService;
+import org.scijava.log.Logger;
 import org.scijava.plugin.AbstractHandlerService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -58,11 +60,17 @@ public class DefaultConsoleService extends
 	ConsoleService
 {
 
+	private static final String STDOUT_LOG_CHANNEL = "stdout";
+	private static final String STDERR_LOG_CHANNEL = "stderr";
+
 	@Parameter
 	private ThreadService threadService;
 
 	@Parameter
 	private LogService log;
+
+	private Logger stdoutLogger;
+	private Logger stderrLogger;
 
 	private MultiPrintStream sysout, syserr;
 	private OutputStreamReporter out, err;
@@ -153,6 +161,63 @@ public class DefaultConsoleService extends
 		if (System.err != syserr) System.setErr(syserr);
 		err = new OutputStreamReporter(Source.STDERR);
 		syserr.getParent().addOutputStream(err);
+
+		// publish stdout and stderr messages on dedicated log channels
+		stdoutLogger = log.channel(STDOUT_LOG_CHANNEL);
+		stderrLogger = log.channel(STDERR_LOG_CHANNEL);
+		addOutputListener(new OutputListener() {
+
+			private StringBuilder outBuf = new StringBuilder();
+			private StringBuilder errBuf = new StringBuilder();
+
+			@Override
+			public void outputOccurred(final OutputEvent event) {
+				if (event.isStderr()) {
+					log(stderrLogger, LogLevel.ERROR, event.getOutput(), errBuf);
+				}
+				else if (event.isStdout()) {
+					log(stdoutLogger, LogLevel.INFO, event.getOutput(), outBuf);
+				}
+			}
+
+			/**
+			 * Clever logging method which accumulates output, flushing to the log
+			 * channel whenever a newline is encountered.
+			 * <p>
+			 * Note that if a newline is encountered <em>anywhere</em> in the string,
+			 * the <em>entire</em> accumulated buffer is flushed. Messages ending in
+			 * a newline have one newline stripped. Here are some examples:
+			 * </p>
+			 * 
+			 * <pre>
+			 * ['foo', '\n'] -> 'foo'
+			 * ['foo\n'] -> 'foo'
+			 * ['foo\nbar'] -> 'foo\nbar'
+			 * ['foo', '\nbar'] -> 'foo\nbar'
+			 * ['foo', 'abc\ndef'] -> 'fooabc\ndef'
+			 * ['foo', 'abc\ndef\n'] -> 'fooabc\ndef'
+			 * ['foo\nbar\n\n'] -> 'foo\nbar\n'
+			 * </pre>
+			 */
+			private void log(final Logger logger, final int level,
+				final String output, final StringBuilder buf)
+			{
+				if (output.contains("\n")) {
+					// append the completed message
+					buf.append(output);
+					// strip one trailing newline, if any
+					if (output.endsWith("\n")) buf.setLength(buf.length() - 1);
+					// flush the buffer
+					final String message = buf.toString();
+					if (!message.isEmpty()) logger.log(level, message);
+					buf.setLength(0);
+				}
+				else {
+					// message was a fragment; append but do not flush
+					buf.append(output);
+				}
+			}
+		});
 	}
 
 	// -- Disposable methods --

--- a/src/main/java/org/scijava/console/DefaultConsoleService.java
+++ b/src/main/java/org/scijava/console/DefaultConsoleService.java
@@ -138,6 +138,23 @@ public class DefaultConsoleService extends
 			l.outputOccurred(event);
 	}
 
+	// -- Initializable methods --
+
+	@Override
+	public void initialize() {
+		// intercept messages on sysout
+		sysout = multiPrintStream(System.out);
+		if (System.out != sysout) System.setOut(sysout);
+		out = new OutputStreamReporter(Source.STDOUT);
+		sysout.getParent().addOutputStream(out);
+
+		// intercept messages on syserr
+		syserr = multiPrintStream(System.err);
+		if (System.err != syserr) System.setErr(syserr);
+		err = new OutputStreamReporter(Source.STDERR);
+		syserr.getParent().addOutputStream(err);
+	}
+
 	// -- Disposable methods --
 
 	@Override
@@ -151,16 +168,6 @@ public class DefaultConsoleService extends
 	/** Initializes {@link #listeners} and related data structures. */
 	private synchronized void initListeners() {
 		if (listeners != null) return; // already initialized
-
-		sysout = multiPrintStream(System.out);
-		if (System.out != sysout) System.setOut(sysout);
-		out = new OutputStreamReporter(Source.STDOUT);
-		sysout.getParent().addOutputStream(out);
-
-		syserr = multiPrintStream(System.err);
-		if (System.err != syserr) System.setErr(syserr);
-		err = new OutputStreamReporter(Source.STDERR);
-		syserr.getParent().addOutputStream(err);
 
 		listeners = new ArrayList<>();
 		cachedListeners = listeners.toArray(new OutputListener[0]);

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -38,7 +38,7 @@ import java.util.Properties;
 import org.scijava.service.AbstractService;
 
 /**
- * Base class for {@link LogService} implementationst.
+ * Base class for {@link LogService} implementations.
  *
  * @author Johannes Schindelin
  */

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -74,7 +74,7 @@ public abstract class AbstractLogService extends AbstractService implements
 
 		// global log level property
 		final String logProp = System.getProperty(LOG_LEVEL_PROPERTY);
-		final int level = level(logProp);
+		final int level = LogLevel.value(logProp);
 		if (level >= 0) setLevel(level);
 
 		if (getLevel() == 0) {
@@ -91,7 +91,7 @@ public abstract class AbstractLogService extends AbstractService implements
 			if (!propName.startsWith(logLevelPrefix)) continue;
 			final String classOrPackageName =
 				propName.substring(logLevelPrefix.length());
-			setLevel(classOrPackageName, level(props.getProperty(propName)));
+			setLevel(classOrPackageName, LogLevel.value(props.getProperty(propName)));
 		}
 
 	}
@@ -240,29 +240,6 @@ public abstract class AbstractLogService extends AbstractService implements
 	}
 
 	// -- Helper methods --
-
-	/** Extracts the log level value from a string. */
-	private int level(final String logProp) {
-		if (logProp == null) return -1;
-
-		// check whether it's a string label (e.g., "debug")
-		final String log = logProp.trim().toLowerCase();
-		if (log.startsWith("n")) return NONE;
-		if (log.startsWith("e")) return ERROR;
-		if (log.startsWith("w")) return WARN;
-		if (log.startsWith("i")) return INFO;
-		if (log.startsWith("d")) return DEBUG;
-		if (log.startsWith("t")) return TRACE;
-
-		// check whether it's a numerical value (e.g., 5)
-		try {
-			return Integer.parseInt(log);
-		}
-		catch (final NumberFormatException exc) {
-			// nope!
-		}
-		return -1;
-	}
 
 	private String callingClass() {
 		final String thisClass = AbstractLogService.class.getName();

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -31,6 +31,9 @@
 
 package org.scijava.log;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.scijava.service.AbstractService;
 
 /**
@@ -42,29 +45,43 @@ public abstract class AbstractLogService extends AbstractService implements
 	LogService
 {
 
-	private final Logger logger;
+	private final Map<String, Logger> channels = new HashMap<>();
+	private final Logger defaultChannel;
 
 	// -- constructor --
 
 	public AbstractLogService() {
-		logger = new DefaultLogger();
+		defaultChannel = channel(DEFAULT_CHANNEL);
+	}
+
+	// -- LogService methods --
+
+	@Override
+	public Logger channel(final String name) {
+		// TODO: Consider whether to make this thread-safe.
+		final Logger channel = channels.get(name);
+		if (channel != null) return channel;
+		final Logger newChannel = new DefaultLogger();
+		newChannel.setName(name);
+		channels.put(name, newChannel);
+		return newChannel;
 	}
 
 	// -- Logger methods --
 
 	@Override
 	public int getLevel() {
-		return logger.getLevel();
+		return defaultChannel.getLevel();
 	}
 
 	@Override
 	public void setLevel(final int level) {
-		logger.setLevel(level);
+		defaultChannel.setLevel(level);
 	}
 
 	@Override
 	public void setLevel(final String classOrPackageName, final int level) {
-		logger.setLevel(classOrPackageName, level);
+		defaultChannel.setLevel(classOrPackageName, level);
 	}
 
 	@Override
@@ -75,11 +92,11 @@ public abstract class AbstractLogService extends AbstractService implements
 
 	@Override
 	public String getName() {
-		return logger.getName();
+		return defaultChannel.getName();
 	}
 
 	@Override
 	public void setName(final String name) {
-		logger.setName(name);
+		defaultChannel.setName(name);
 	}
 }

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -46,7 +46,7 @@ public abstract class AbstractLogService extends AbstractService implements
 	LogService
 {
 
-	private int currentLevel = System.getenv("DEBUG") == null ? INFO : DEBUG;
+	private int currentLevel = levelFromEnvironment();
 
 	private final Map<String, Integer> classAndPackageLevels =
 		new HashMap<>();
@@ -79,7 +79,7 @@ public abstract class AbstractLogService extends AbstractService implements
 
 		if (getLevel() == 0) {
 			// use the default, which is WARN unless the DEBUG env. variable is set
-			setLevel(System.getenv("DEBUG") == null ? INFO : DEBUG);
+			setLevel(levelFromEnvironment());
 		}
 
 		// populate custom class- and package-specific log level properties
@@ -278,6 +278,10 @@ public abstract class AbstractLogService extends AbstractService implements
 		final int dot = classOrPackageName.lastIndexOf(".");
 		if (dot < 0) return null;
 		return classOrPackageName.substring(0, dot);
+	}
+
+	private int levelFromEnvironment() {
+		return System.getenv("DEBUG") == null ? LogLevel.INFO : LogLevel.DEBUG;
 	}
 
 }

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -108,25 +108,8 @@ public abstract class AbstractLogService extends AbstractService implements
 	}
 
 	protected void log(final int level, final Object msg) {
-		final String prefix = getPrefix(level);
+		final String prefix = LogLevel.prefix(level);
 		log((prefix == null ? "" : prefix + " ") + msg);
-	}
-
-	protected String getPrefix(final int level) {
-		switch (level) {
-			case ERROR:
-				return "[ERROR]";
-			case WARN:
-				return "[WARNING]";
-			case INFO:
-				return "[INFO]";
-			case DEBUG:
-				return "[DEBUG]";
-			case TRACE:
-				return "[TRACE]";
-			default:
-				return null;
-		}
 	}
 
 	// -- LogService methods --

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -78,7 +78,7 @@ public abstract class AbstractLogService extends AbstractService implements
 		if (level >= 0) setLevel(level);
 
 		if (getLevel() == 0) {
-			// use the default, which is WARN unless the DEBUG env. variable is set
+			// use the default, which is INFO unless the DEBUG env. variable is set
 			setLevel(levelFromEnvironment());
 		}
 

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -92,8 +92,28 @@ public abstract class AbstractLogService extends AbstractService implements
 	}
 
 	@Override
-	public abstract void alwaysLog(final int level, final Object msg,
-		final Throwable t);
+	public void alwaysLog(final int level, final Object msg,
+		final Throwable t)
+	{
+		defaultChannel.alwaysLog(level, msg, t);
+	}
+
+	@Override
+	public void addLogListener(final LogListener l) {
+		defaultChannel.addLogListener(l);
+	}
+
+	@Override
+	public void removeLogListener(final LogListener l) {
+		defaultChannel.removeLogListener(l);
+	}
+
+	@Override
+	public void notifyListeners(final int level, final Object msg,
+		final Throwable t)
+	{
+		defaultChannel.notifyListeners(level, msg, t);
+	}
 
 	// -- Named methods --
 

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -70,4 +70,16 @@ public abstract class AbstractLogService extends AbstractService implements
 	@Override
 	public abstract void alwaysLog(final int level, final Object msg,
 		final Throwable t);
+
+	// -- Named methods --
+
+	@Override
+	public String getName() {
+		return logger.getName();
+	}
+
+	@Override
+	public void setName(final String name) {
+		logger.setName(name);
+	}
 }

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -31,6 +31,7 @@
 
 package org.scijava.log;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -65,6 +66,12 @@ public abstract class AbstractLogService extends AbstractService implements
 		newChannel.setName(name);
 		channels.put(name, newChannel);
 		return newChannel;
+	}
+
+	@Override
+	public Collection<Logger> allChannels() {
+		// TODO: Consider whether to make this thread-safe.
+		return channels.values();
 	}
 
 	// -- Logger methods --

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -116,102 +116,102 @@ public abstract class AbstractLogService extends AbstractService implements
 
 	@Override
 	public void debug(final Object msg) {
-		log(DEBUG, msg, null);
+		log(LogLevel.DEBUG, msg, null);
 	}
 
 	@Override
 	public void debug(final Throwable t) {
-		log(DEBUG, null, t);
+		log(LogLevel.DEBUG, null, t);
 	}
 
 	@Override
 	public void debug(final Object msg, final Throwable t) {
-		log(DEBUG, msg, t);
+		log(LogLevel.DEBUG, msg, t);
 	}
 
 	@Override
 	public void error(final Object msg) {
-		log(ERROR, msg, null);
+		log(LogLevel.ERROR, msg, null);
 	}
 
 	@Override
 	public void error(final Throwable t) {
-		log(ERROR, null, t);
+		log(LogLevel.ERROR, null, t);
 	}
 
 	@Override
 	public void error(final Object msg, final Throwable t) {
-		log(ERROR, msg, t);
+		log(LogLevel.ERROR, msg, t);
 	}
 
 	@Override
 	public void info(final Object msg) {
-		log(INFO, msg, null);
+		log(LogLevel.INFO, msg, null);
 	}
 
 	@Override
 	public void info(final Throwable t) {
-		log(INFO, null, t);
+		log(LogLevel.INFO, null, t);
 	}
 
 	@Override
 	public void info(final Object msg, final Throwable t) {
-		log(INFO, msg, t);
+		log(LogLevel.INFO, msg, t);
 	}
 
 	@Override
 	public void trace(final Object msg) {
-		log(TRACE, msg, null);
+		log(LogLevel.TRACE, msg, null);
 	}
 
 	@Override
 	public void trace(final Throwable t) {
-		log(TRACE, null, t);
+		log(LogLevel.TRACE, null, t);
 	}
 
 	@Override
 	public void trace(final Object msg, final Throwable t) {
-		log(TRACE, msg, t);
+		log(LogLevel.TRACE, msg, t);
 	}
 
 	@Override
 	public void warn(final Object msg) {
-		log(WARN, msg, null);
+		log(LogLevel.WARN, msg, null);
 	}
 
 	@Override
 	public void warn(final Throwable t) {
-		log(WARN, null, t);
+		log(LogLevel.WARN, null, t);
 	}
 
 	@Override
 	public void warn(final Object msg, final Throwable t) {
-		log(WARN, msg, t);
+		log(LogLevel.WARN, msg, t);
 	}
 
 	@Override
 	public boolean isDebug() {
-		return getLevel() >= DEBUG;
+		return getLevel() >= LogLevel.DEBUG;
 	}
 
 	@Override
 	public boolean isError() {
-		return getLevel() >= ERROR;
+		return getLevel() >= LogLevel.ERROR;
 	}
 
 	@Override
 	public boolean isInfo() {
-		return getLevel() >= INFO;
+		return getLevel() >= LogLevel.INFO;
 	}
 
 	@Override
 	public boolean isTrace() {
-		return getLevel() >= TRACE;
+		return getLevel() >= LogLevel.TRACE;
 	}
 
 	@Override
 	public boolean isWarn() {
-		return getLevel() >= WARN;
+		return getLevel() >= LogLevel.WARN;
 	}
 
 	@Override

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -41,6 +41,7 @@ import org.scijava.service.AbstractService;
  * Base class for {@link LogService} implementations.
  *
  * @author Johannes Schindelin
+ * @author Curtis Rueden
  */
 public abstract class AbstractLogService extends AbstractService implements
 	LogService
@@ -50,22 +51,6 @@ public abstract class AbstractLogService extends AbstractService implements
 
 	private final Map<String, Integer> classAndPackageLevels =
 		new HashMap<>();
-
-	// -- abstract methods --
-
-	/**
-	 * Displays a message.
-	 *
-	 * @param msg the message to display.
-	 */
-	protected abstract void log(final String msg);
-
-	/**
-	 * Displays an exception.
-	 *
-	 * @param t the exception to display.
-	 */
-	protected abstract void log(final Throwable t);
 
 	// -- constructor --
 
@@ -93,126 +78,9 @@ public abstract class AbstractLogService extends AbstractService implements
 				propName.substring(logLevelPrefix.length());
 			setLevel(classOrPackageName, LogLevel.value(props.getProperty(propName)));
 		}
-
 	}
 
-	// -- helper methods --
-
-	protected void log(final int level, final Object msg, final Throwable t) {
-		if (level > getLevel()) return;
-
-		if (msg != null || t == null) {
-			log(level, msg);
-		}
-		if (t != null) log(t);
-	}
-
-	protected void log(final int level, final Object msg) {
-		final String prefix = LogLevel.prefix(level);
-		log((prefix == null ? "" : prefix + " ") + msg);
-	}
-
-	// -- LogService methods --
-
-	@Override
-	public void debug(final Object msg) {
-		log(LogLevel.DEBUG, msg, null);
-	}
-
-	@Override
-	public void debug(final Throwable t) {
-		log(LogLevel.DEBUG, null, t);
-	}
-
-	@Override
-	public void debug(final Object msg, final Throwable t) {
-		log(LogLevel.DEBUG, msg, t);
-	}
-
-	@Override
-	public void error(final Object msg) {
-		log(LogLevel.ERROR, msg, null);
-	}
-
-	@Override
-	public void error(final Throwable t) {
-		log(LogLevel.ERROR, null, t);
-	}
-
-	@Override
-	public void error(final Object msg, final Throwable t) {
-		log(LogLevel.ERROR, msg, t);
-	}
-
-	@Override
-	public void info(final Object msg) {
-		log(LogLevel.INFO, msg, null);
-	}
-
-	@Override
-	public void info(final Throwable t) {
-		log(LogLevel.INFO, null, t);
-	}
-
-	@Override
-	public void info(final Object msg, final Throwable t) {
-		log(LogLevel.INFO, msg, t);
-	}
-
-	@Override
-	public void trace(final Object msg) {
-		log(LogLevel.TRACE, msg, null);
-	}
-
-	@Override
-	public void trace(final Throwable t) {
-		log(LogLevel.TRACE, null, t);
-	}
-
-	@Override
-	public void trace(final Object msg, final Throwable t) {
-		log(LogLevel.TRACE, msg, t);
-	}
-
-	@Override
-	public void warn(final Object msg) {
-		log(LogLevel.WARN, msg, null);
-	}
-
-	@Override
-	public void warn(final Throwable t) {
-		log(LogLevel.WARN, null, t);
-	}
-
-	@Override
-	public void warn(final Object msg, final Throwable t) {
-		log(LogLevel.WARN, msg, t);
-	}
-
-	@Override
-	public boolean isDebug() {
-		return getLevel() >= LogLevel.DEBUG;
-	}
-
-	@Override
-	public boolean isError() {
-		return getLevel() >= LogLevel.ERROR;
-	}
-
-	@Override
-	public boolean isInfo() {
-		return getLevel() >= LogLevel.INFO;
-	}
-
-	@Override
-	public boolean isTrace() {
-		return getLevel() >= LogLevel.TRACE;
-	}
-
-	@Override
-	public boolean isWarn() {
-		return getLevel() >= LogLevel.WARN;
-	}
+	// -- Logger methods --
 
 	@Override
 	public int getLevel() {

--- a/src/main/java/org/scijava/log/DefaultLogger.java
+++ b/src/main/java/org/scijava/log/DefaultLogger.java
@@ -1,0 +1,130 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.log;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Default implementation for {@link Logger}.
+ *
+ * @author Curtis Rueden
+ */
+public class DefaultLogger implements Logger {
+
+	private final Map<String, Integer> classAndPackageLevels = new HashMap<>();
+
+	private int currentLevel = levelFromEnvironment();
+
+	// -- Constructor --
+
+	public DefaultLogger() {
+		// check SciJava log level system properties for initial logging levels
+
+		// global log level property
+		final String logProp = System.getProperty(LogService.LOG_LEVEL_PROPERTY);
+		final int level = LogLevel.value(logProp);
+		if (level >= 0) setLevel(level);
+
+		if (getLevel() == 0) {
+			// use the default, which is INFO unless the DEBUG env. variable is set
+			setLevel(levelFromEnvironment());
+		}
+
+		// populate custom class- and package-specific log level properties
+		final String logLevelPrefix = LogService.LOG_LEVEL_PROPERTY + ":";
+		final Properties props = System.getProperties();
+		for (final Object propKey : props.keySet()) {
+			if (!(propKey instanceof String)) continue;
+			final String propName = (String) propKey;
+			if (!propName.startsWith(logLevelPrefix)) continue;
+			final String classOrPackageName = propName.substring(logLevelPrefix
+				.length());
+			setLevel(classOrPackageName, LogLevel.value(props.getProperty(propName)));
+		}
+	}
+
+	// -- Logger methods --
+
+	@Override
+	public int getLevel() {
+		if (!classAndPackageLevels.isEmpty()) {
+			// check for a custom log level for calling class or its parent packages
+			String classOrPackageName = callingClass();
+			while (classOrPackageName != null) {
+				final Integer level = classAndPackageLevels.get(classOrPackageName);
+				if (level != null) return level;
+				classOrPackageName = parentPackage(classOrPackageName);
+			}
+		}
+		// no custom log level; return the global log level
+		return currentLevel;
+	}
+
+	@Override
+	public void setLevel(final int level) {
+		currentLevel = level;
+	}
+
+	@Override
+	public void setLevel(final String classOrPackageName, final int level) {
+		classAndPackageLevels.put(classOrPackageName, level);
+	}
+
+	@Override
+	public void alwaysLog(final int level, final Object msg, final Throwable t) {
+		// NB: Do nothing by default.
+	}
+
+	// -- Helper methods --
+
+	private String callingClass() {
+		final String thisClass = DefaultLogger.class.getName();
+		for (final StackTraceElement element : new Exception().getStackTrace()) {
+			final String className = element.getClassName();
+			// NB: Skip stack trace elements from other methods of this class.
+			if (!thisClass.equals(className)) return className;
+		}
+		return null;
+	}
+
+	private String parentPackage(final String classOrPackageName) {
+		final int dot = classOrPackageName.lastIndexOf(".");
+		if (dot < 0) return null;
+		return classOrPackageName.substring(0, dot);
+	}
+
+	private int levelFromEnvironment() {
+		return System.getenv("DEBUG") == null ? LogLevel.INFO : LogLevel.DEBUG;
+	}
+}

--- a/src/main/java/org/scijava/log/DefaultLogger.java
+++ b/src/main/java/org/scijava/log/DefaultLogger.java
@@ -46,6 +46,8 @@ public class DefaultLogger implements Logger {
 
 	private int currentLevel = levelFromEnvironment();
 
+	private String name;
+
 	// -- Constructor --
 
 	public DefaultLogger() {
@@ -104,6 +106,18 @@ public class DefaultLogger implements Logger {
 	@Override
 	public void alwaysLog(final int level, final Object msg, final Throwable t) {
 		// NB: Do nothing by default.
+	}
+
+	// -- Named methods --
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setName(final String name) {
+		this.name = name;
 	}
 
 	// -- Helper methods --

--- a/src/main/java/org/scijava/log/LogLevel.java
+++ b/src/main/java/org/scijava/log/LogLevel.java
@@ -52,17 +52,17 @@ public final class LogLevel {
 	public static String prefix(final int level) {
 		switch (level) {
 			case ERROR:
-				return "[ERROR]";
+				return "[ERROR] ";
 			case WARN:
-				return "[WARNING]";
+				return "[WARNING] ";
 			case INFO:
-				return "[INFO]";
+				return "[INFO] ";
 			case DEBUG:
-				return "[DEBUG]";
+				return "[DEBUG] ";
 			case TRACE:
-				return "[TRACE]";
+				return "[TRACE] ";
 			default:
-				return "[" + level + "]";
+				return "[LEVEL:" + level + "] ";
 		}
 	}
 

--- a/src/main/java/org/scijava/log/LogLevel.java
+++ b/src/main/java/org/scijava/log/LogLevel.java
@@ -31,51 +31,38 @@
 
 package org.scijava.log;
 
-import org.scijava.Priority;
-import org.scijava.plugin.Plugin;
-import org.scijava.service.Service;
-
 /**
- * Implementation of {@link LogService} using the standard error stream.
- * <p>
- * Actually, this service is somewhat misnamed now, since it prints {@code WARN}
- * and {@code ERROR} messages to stderr, but messages at lesser severities to
- * stdout.
- * </p>
+ * Constants for specifying a logger's level of verbosity.
  * 
- * @author Johannes Schindelin
  * @author Curtis Rueden
  */
-@Plugin(type = Service.class, priority = Priority.LOW_PRIORITY)
-public class StderrLogService extends AbstractLogService {
+public final class LogLevel {
 
-	@Override
-	protected void log(final int level, final Object msg) {
-		final String prefix = LogLevel.prefix(level);
-		final String message = (prefix == null ? "" : prefix + " ") + msg;
-		// NB: Emit severe messages to stderr, and less severe ones to stdout.
-		if (level <= WARN) System.err.println(message);
-		else System.out.println(message);
+	private LogLevel() {
+		// prevent instantiation of utility class
 	}
 
-	/**
-	 * Prints a message to stderr.
-	 * 
-	 * @param message the message
-	 */
-	@Override
-	protected void log(final String message) {
-		System.err.println(message);
-	}
+	public static final int NONE = 0;
+	public static final int ERROR = 1;
+	public static final int WARN = 2;
+	public static final int INFO = 3;
+	public static final int DEBUG = 4;
+	public static final int TRACE = 5;
 
-	/**
-	 * Prints an exception to stderr.
-	 * 
-	 * @param t the exception
-	 */
-	@Override
-	protected void log(final Throwable t) {
-		t.printStackTrace();
+	public static String prefix(final int level) {
+		switch (level) {
+			case ERROR:
+				return "[ERROR]";
+			case WARN:
+				return "[WARNING]";
+			case INFO:
+				return "[INFO]";
+			case DEBUG:
+				return "[DEBUG]";
+			case TRACE:
+				return "[TRACE]";
+			default:
+				return "[" + level + "]";
+		}
 	}
-
 }

--- a/src/main/java/org/scijava/log/LogLevel.java
+++ b/src/main/java/org/scijava/log/LogLevel.java
@@ -65,4 +65,32 @@ public final class LogLevel {
 				return "[" + level + "]";
 		}
 	}
+
+	/**
+	 * Extracts the log level value from a string.
+	 * 
+	 * @return The log level, or -1 if the level cannot be parsed.
+	 */
+	public static int value(final String s) {
+		if (s == null) return -1;
+
+		// check whether it's a string label (e.g., "debug")
+		final String log = s.trim().toLowerCase();
+		if (log.startsWith("n")) return LogLevel.NONE;
+		if (log.startsWith("e")) return LogLevel.ERROR;
+		if (log.startsWith("w")) return LogLevel.WARN;
+		if (log.startsWith("i")) return LogLevel.INFO;
+		if (log.startsWith("d")) return LogLevel.DEBUG;
+		if (log.startsWith("t")) return LogLevel.TRACE;
+
+		// check whether it's a numerical value (e.g., 5)
+		try {
+			return Integer.parseInt(log);
+		}
+		catch (final NumberFormatException exc) {
+			// nope!
+		}
+		return -1;
+	}
+
 }

--- a/src/main/java/org/scijava/log/LogListener.java
+++ b/src/main/java/org/scijava/log/LogListener.java
@@ -31,36 +31,15 @@
 
 package org.scijava.log;
 
-import org.scijava.Priority;
-import org.scijava.plugin.Plugin;
-import org.scijava.service.Service;
-
 /**
- * Implementation of {@link LogService} using the standard error stream.
- * <p>
- * Actually, this service is somewhat misnamed now, since it prints {@code WARN}
- * and {@code ERROR} messages to stderr, but messages at lesser severities to
- * stdout.
- * </p>
- * 
- * @author Johannes Schindelin
+ * Listener for logging activity.
+ *
  * @author Curtis Rueden
+ * @see LogService
+ * @see Logger
  */
-@Plugin(type = Service.class, priority = Priority.LOW_PRIORITY)
-public class StderrLogService extends AbstractLogService {
+public interface LogListener {
 
-	@Override
-	public void alwaysLog(final int level, final Object msg, final Throwable t) {
-		final String prefix = LogLevel.prefix(level);
-		final String message = (prefix == null ? "" : prefix + " ") + msg;
-		// NB: Emit severe messages to stderr, and less severe ones to stdout.
-		if (level <= LogLevel.WARN) System.err.println(message);
-		else System.out.println(message);
-		if (t != null) t.printStackTrace();
-
-		// NB: Also do the normal things the default channel would do.
-		// Typically, this is notifying log listeners, but if the default
-		// channel has been overridden somehow, this could really do anything.
-		super.alwaysLog(level, msg, t);
-	}
+	/** Method called when a message is logged. */
+	void messageLogged(int level, Object msg, Throwable t);
 }

--- a/src/main/java/org/scijava/log/LogService.java
+++ b/src/main/java/org/scijava/log/LogService.java
@@ -49,12 +49,26 @@ public interface LogService extends SciJavaService {
 	/** System property to set for overriding the default logging level. */
 	String LOG_LEVEL_PROPERTY = "scijava.log.level";
 
-	int NONE = 0;
-	int ERROR = 1;
-	int WARN = 2;
-	int INFO = 3;
-	int DEBUG = 4;
-	int TRACE = 5;
+	// -- Deprecated --
+
+	/** @deprecated Use {@link LogLevel#NONE}. */
+	@Deprecated
+	int NONE = LogLevel.NONE;
+	/** @deprecated Use {@link LogLevel#ERROR}. */
+	@Deprecated
+	int ERROR = LogLevel.ERROR;
+	/** @deprecated Use {@link LogLevel#WARN}. */
+	@Deprecated
+	int WARN = LogLevel.WARN;
+	/** @deprecated Use {@link LogLevel#INFO}. */
+	@Deprecated
+	int INFO = LogLevel.INFO;
+	/** @deprecated Use {@link LogLevel#DEBUG}. */
+	@Deprecated
+	int DEBUG = LogLevel.DEBUG;
+	/** @deprecated Use {@link LogLevel#TRACE}. */
+	@Deprecated
+	int TRACE = LogLevel.TRACE;
 
 	void debug(Object msg);
 

--- a/src/main/java/org/scijava/log/LogService.java
+++ b/src/main/java/org/scijava/log/LogService.java
@@ -46,8 +46,17 @@ import org.scijava.service.SciJavaService;
  */
 public interface LogService extends SciJavaService, Logger {
 
+	/**
+	 * Name of the channel to which information is logged by default. Calls to the
+	 * {@link Logger} API directly on the {@link LogService} (e.g.,
+	 * {@code logService.warn("Warning")}) go to a channel with this name.
+	 */
+	String DEFAULT_CHANNEL = "default";
+
 	/** System property to set for overriding the default logging level. */
 	String LOG_LEVEL_PROPERTY = "scijava.log.level";
+
+	Logger channel(String name);
 
 	// -- Deprecated --
 

--- a/src/main/java/org/scijava/log/LogService.java
+++ b/src/main/java/org/scijava/log/LogService.java
@@ -31,6 +31,8 @@
 
 package org.scijava.log;
 
+import java.util.Collection;
+
 import org.scijava.service.SciJavaService;
 
 /**
@@ -57,6 +59,8 @@ public interface LogService extends SciJavaService, Logger {
 	String LOG_LEVEL_PROPERTY = "scijava.log.level";
 
 	Logger channel(String name);
+
+	Collection<Logger> allChannels();
 
 	// -- Deprecated --
 

--- a/src/main/java/org/scijava/log/Logger.java
+++ b/src/main/java/org/scijava/log/Logger.java
@@ -31,6 +31,12 @@
 
 package org.scijava.log;
 
+import static org.scijava.log.LogLevel.DEBUG;
+import static org.scijava.log.LogLevel.ERROR;
+import static org.scijava.log.LogLevel.INFO;
+import static org.scijava.log.LogLevel.TRACE;
+import static org.scijava.log.LogLevel.WARN;
+
 /**
  * Interface for objects which can produce log messages.
  * <p>
@@ -44,49 +50,143 @@ package org.scijava.log;
  */
 public interface Logger {
 
-	void debug(Object msg);
+	default void debug(final Object msg) {
+		log(DEBUG, msg);
+	}
 
-	void debug(Throwable t);
+	default void debug(final Throwable t) {
+		log(DEBUG, t);
+	}
 
-	void debug(Object msg, Throwable t);
+	default void debug(final Object msg, final Throwable t) {
+		log(DEBUG, msg, t);
+	}
 
-	void error(Object msg);
+	default void error(final Object msg) {
+		log(ERROR, msg);
+	}
 
-	void error(Throwable t);
+	default void error(final Throwable t) {
+		log(ERROR, t);
+	}
 
-	void error(Object msg, Throwable t);
+	default void error(final Object msg, final Throwable t) {
+		log(ERROR, msg, t);
+	}
 
-	void info(Object msg);
+	default void info(final Object msg) {
+		log(INFO, msg);
+	}
 
-	void info(Throwable t);
+	default void info(final Throwable t) {
+		log(INFO, t);
+	}
 
-	void info(Object msg, Throwable t);
+	default void info(final Object msg, final Throwable t) {
+		log(INFO, msg, t);
+	}
 
-	void trace(Object msg);
+	default void trace(final Object msg) {
+		log(TRACE, msg);
+	}
 
-	void trace(Throwable t);
+	default void trace(final Throwable t) {
+		log(TRACE, t);
+	}
 
-	void trace(Object msg, Throwable t);
+	default void trace(final Object msg, final Throwable t) {
+		log(TRACE, msg, t);
+	}
 
-	void warn(Object msg);
+	default void warn(final Object msg) {
+		log(WARN, msg);
+	}
 
-	void warn(Throwable t);
+	default void warn(final Throwable t) {
+		log(WARN, t);
+	}
 
-	void warn(Object msg, Throwable t);
+	default void warn(final Object msg, final Throwable t) {
+		log(WARN, msg, t);
+	}
 
-	boolean isDebug();
+	default boolean isDebug() {
+		return isLevel(DEBUG);
+	}
 
-	boolean isError();
+	default boolean isError() {
+		return isLevel(ERROR);
+	}
 
-	boolean isInfo();
+	default boolean isInfo() {
+		return isLevel(INFO);
+	}
 
-	boolean isTrace();
+	default boolean isTrace() {
+		return isLevel(TRACE);
+	}
 
-	boolean isWarn();
+	default boolean isWarn() {
+		return isLevel(WARN);
+	}
+
+	default boolean isLevel(final int level) {
+		return getLevel() >= level;
+	}
+
+	/**
+	 * Logs a message.
+	 * 
+	 * @param level The level at which the message will be logged. If the current
+	 *          level (given by {@link #getLevel()} is below this one, no logging
+	 *          is performed.
+	 * @param msg The message to log.
+	 */
+	default void log(final int level, final Object msg) {
+		if (isLevel(level)) alwaysLog(level, msg, null);
+	}
+
+	/**
+	 * Logs an exception.
+	 * 
+	 * @param level The level at which the exception will be logged. If the
+	 *          current level (given by {@link #getLevel()} is below this one, no
+	 *          logging is performed.
+	 * @param t The exception to log.
+	 */
+	default void log(final int level, final Throwable t) {
+		if (isLevel(level)) alwaysLog(level, null, t);
+	}
+
+	/**
+	 * Logs a message with an exception.
+	 * 
+	 * @param level The level at which the information will be logged. If the
+	 *          current level (given by {@link #getLevel()} is below this one, no
+	 *          logging is performed.
+	 * @param msg The message to log.
+	 * @param t The exception to log.
+	 */
+	default void log(final int level, final Object msg, final Throwable t) {
+		if (isLevel(level)) alwaysLog(level, msg, t);
+	}
 
 	int getLevel();
 
 	void setLevel(int level);
 
 	void setLevel(String classOrPackageName, int level);
+
+	/**
+	 * Logs a message with an exception, regardless of level. No level threshold
+	 * is applied.
+	 * 
+	 * @param level The level at which the information will be logged. Note that
+	 *          this value will not affect <em>whether</em> logging is performed,
+	 *          but might affect <em>how</em>. For example, some loggers might
+	 *          prepend the message with the level as a prefix.
+	 * @param msg The message to log.
+	 * @param t The exception to log.
+	 */
+	void alwaysLog(int level, Object msg, Throwable t);
 }

--- a/src/main/java/org/scijava/log/Logger.java
+++ b/src/main/java/org/scijava/log/Logger.java
@@ -31,42 +31,62 @@
 
 package org.scijava.log;
 
-import org.scijava.service.SciJavaService;
-
 /**
- * Interface for the logging service.
+ * Interface for objects which can produce log messages.
  * <p>
- * The service supports five common logging levels: {@link #ERROR},
- * {@link #WARN}, {@link #INFO}, {@link #TRACE} and {@link #DEBUG}. It provides
- * methods for logging messages, exception stack traces and combinations of the
- * two.
+ * It provides methods for logging messages, exception stack traces and
+ * combinations of the two.
  * </p>
  * 
  * @author Curtis Rueden
+ * @see LogLevel
+ * @see LogService
  */
-public interface LogService extends SciJavaService, Logger {
+public interface Logger {
 
-	/** System property to set for overriding the default logging level. */
-	String LOG_LEVEL_PROPERTY = "scijava.log.level";
+	void debug(Object msg);
 
-	// -- Deprecated --
+	void debug(Throwable t);
 
-	/** @deprecated Use {@link LogLevel#NONE}. */
-	@Deprecated
-	int NONE = LogLevel.NONE;
-	/** @deprecated Use {@link LogLevel#ERROR}. */
-	@Deprecated
-	int ERROR = LogLevel.ERROR;
-	/** @deprecated Use {@link LogLevel#WARN}. */
-	@Deprecated
-	int WARN = LogLevel.WARN;
-	/** @deprecated Use {@link LogLevel#INFO}. */
-	@Deprecated
-	int INFO = LogLevel.INFO;
-	/** @deprecated Use {@link LogLevel#DEBUG}. */
-	@Deprecated
-	int DEBUG = LogLevel.DEBUG;
-	/** @deprecated Use {@link LogLevel#TRACE}. */
-	@Deprecated
-	int TRACE = LogLevel.TRACE;
+	void debug(Object msg, Throwable t);
+
+	void error(Object msg);
+
+	void error(Throwable t);
+
+	void error(Object msg, Throwable t);
+
+	void info(Object msg);
+
+	void info(Throwable t);
+
+	void info(Object msg, Throwable t);
+
+	void trace(Object msg);
+
+	void trace(Throwable t);
+
+	void trace(Object msg, Throwable t);
+
+	void warn(Object msg);
+
+	void warn(Throwable t);
+
+	void warn(Object msg, Throwable t);
+
+	boolean isDebug();
+
+	boolean isError();
+
+	boolean isInfo();
+
+	boolean isTrace();
+
+	boolean isWarn();
+
+	int getLevel();
+
+	void setLevel(int level);
+
+	void setLevel(String classOrPackageName, int level);
 }

--- a/src/main/java/org/scijava/log/Logger.java
+++ b/src/main/java/org/scijava/log/Logger.java
@@ -37,6 +37,8 @@ import static org.scijava.log.LogLevel.INFO;
 import static org.scijava.log.LogLevel.TRACE;
 import static org.scijava.log.LogLevel.WARN;
 
+import org.scijava.Named;
+
 /**
  * Interface for objects which can produce log messages.
  * <p>
@@ -48,7 +50,7 @@ import static org.scijava.log.LogLevel.WARN;
  * @see LogLevel
  * @see LogService
  */
-public interface Logger {
+public interface Logger extends Named {
 
 	default void debug(final Object msg) {
 		log(DEBUG, msg);

--- a/src/main/java/org/scijava/log/Logger.java
+++ b/src/main/java/org/scijava/log/Logger.java
@@ -191,4 +191,13 @@ public interface Logger extends Named {
 	 * @param t The exception to log.
 	 */
 	void alwaysLog(int level, Object msg, Throwable t);
+
+	/** Adds a listener for logging events. */
+	void addLogListener(LogListener l);
+
+	/** Removes a listener for logging events. */
+	void removeLogListener(LogListener l);
+
+	/** Notifies listeners of a logging event. */
+	void notifyListeners(int level, Object msg, Throwable t);
 }

--- a/src/main/java/org/scijava/log/StderrLogService.java
+++ b/src/main/java/org/scijava/log/StderrLogService.java
@@ -50,32 +50,12 @@ import org.scijava.service.Service;
 public class StderrLogService extends AbstractLogService {
 
 	@Override
-	protected void log(final int level, final Object msg) {
+	public void alwaysLog(final int level, final Object msg, final Throwable t) {
 		final String prefix = LogLevel.prefix(level);
 		final String message = (prefix == null ? "" : prefix + " ") + msg;
 		// NB: Emit severe messages to stderr, and less severe ones to stdout.
 		if (level <= LogLevel.WARN) System.err.println(message);
 		else System.out.println(message);
+		if (t != null) t.printStackTrace();
 	}
-
-	/**
-	 * Prints a message to stderr.
-	 * 
-	 * @param message the message
-	 */
-	@Override
-	protected void log(final String message) {
-		System.err.println(message);
-	}
-
-	/**
-	 * Prints an exception to stderr.
-	 * 
-	 * @param t the exception
-	 */
-	@Override
-	protected void log(final Throwable t) {
-		t.printStackTrace();
-	}
-
 }

--- a/src/main/java/org/scijava/log/StderrLogService.java
+++ b/src/main/java/org/scijava/log/StderrLogService.java
@@ -54,7 +54,7 @@ public class StderrLogService extends AbstractLogService {
 		final String prefix = LogLevel.prefix(level);
 		final String message = (prefix == null ? "" : prefix + " ") + msg;
 		// NB: Emit severe messages to stderr, and less severe ones to stdout.
-		if (level <= WARN) System.err.println(message);
+		if (level <= LogLevel.WARN) System.err.println(message);
 		else System.out.println(message);
 	}
 

--- a/src/main/java/org/scijava/log/StderrLogService.java
+++ b/src/main/java/org/scijava/log/StderrLogService.java
@@ -51,8 +51,7 @@ public class StderrLogService extends AbstractLogService {
 
 	@Override
 	public void alwaysLog(final int level, final Object msg, final Throwable t) {
-		final String prefix = LogLevel.prefix(level);
-		final String message = (prefix == null ? "" : prefix + " ") + msg;
+		final String message = LogLevel.prefix(level) + msg;
 		// NB: Emit severe messages to stderr, and less severe ones to stdout.
 		if (level <= LogLevel.WARN) System.err.println(message);
 		else System.out.println(message);

--- a/src/test/java/org/scijava/log/LogServiceTest.java
+++ b/src/test/java/org/scijava/log/LogServiceTest.java
@@ -32,7 +32,7 @@
 package org.scijava.log;
 
 import static org.junit.Assert.assertTrue;
-import static org.scijava.log.LogService.WARN;
+import static org.scijava.log.LogLevel.WARN;
 
 import org.junit.Test;
 
@@ -46,6 +46,7 @@ public class LogServiceTest {
 	public void testDefaultLevel() {
 		final LogService log = new StderrLogService();
 		int level = log.getLevel();
-		assertTrue("default level (" + level + ") is at least INFO(" + WARN + ")", level >= WARN);
+		assertTrue("default level (" + level + //
+			") is at least INFO(" + WARN + ")", level >= WARN);
 	}
 }

--- a/src/test/java/org/scijava/log/LoggerTest.java
+++ b/src/test/java/org/scijava/log/LoggerTest.java
@@ -1,0 +1,109 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.log;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.scijava.log.LogLevel.DEBUG;
+import static org.scijava.log.LogLevel.ERROR;
+import static org.scijava.log.LogLevel.INFO;
+import static org.scijava.log.LogLevel.WARN;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link Logger}.
+ * 
+ * @author Curtis
+ */
+public class LoggerTest {
+
+	@Test
+	public void testLogListeners() {
+		final Logger log = new StderrLogService().channel("test");
+		final List<Object[]> results = new ArrayList<>();
+		final LogListener l = new LogListener() {
+
+			@Override
+			public void messageLogged(final int level, final Object msg,
+				final Throwable t)
+			{
+				results.add(new Object[] { level, msg, t });
+			}
+		};
+		log.addLogListener(l);
+
+		// test that listeners receive events up to the current level (INFO)
+		log.debug("donkey", new IllegalArgumentException()); // ignored
+		log.error("egrit", new IllegalAccessException());
+		log.info("i");
+		log.trace("turkey", new RuntimeException()); // ignored
+		log.warn("wyvern", new IllegalStateException());
+		assertEquals(3, results.size());
+		assertLogged(ERROR, "egrit", IllegalAccessException.class, results.get(0));
+		assertLogged(INFO, "i", null, results.get(1));
+		assertLogged(WARN, "wyvern", IllegalStateException.class, results.get(2));
+
+		// test that changing the level works
+		log.setLevel(DEBUG);
+		results.clear();
+		log.debug("devilish");
+		log.trace("terrifying");
+		assertEquals(1, results.size());
+		assertLogged(DEBUG, "devilish", null, results.get(0));
+
+		// test that listeners can be removed
+		log.removeLogListener(l);
+		results.clear();
+		log.error("grout");
+		assertTrue(results.isEmpty());
+	}
+
+	// -- Helper methods --
+
+	private void assertLogged(final int level, final String msg,
+		final Class<? extends Throwable> t, final Object[] result)
+	{
+		assertEquals(level, result[0]);
+		assertEquals(msg, result[1]);
+		if (t == null) assertNull(result[2]);
+		else {
+			assertNotNull(result[2]);
+			assertEquals(t, result[2].getClass());
+		}
+	}
+}


### PR DESCRIPTION
As discussed with @fjug in Dresden:

1. The `LogService` now sports a spiffy callback mechanism, so that you can register listeners for log events.
2. You can now create any number of `Logger` channels keyed by name, of which the `LogService` itself functions as the `"default"` one, preserving the convenience of the previous paradigm.
3. The `ConsoleService` now forwards all stdout and stderr messages to special channels of the `LogService` named `"stdout"` and `"stderr"` respectively.

@fjug Please review and test with your logging UI. I will merge once you sign off on it.