### PR TITLE
Log revamp

### DIFF
--- a/src/main/java/org/scijava/console/ConsoleService.java
+++ b/src/main/java/org/scijava/console/ConsoleService.java
@@ -31,6 +31,7 @@
 
 package org.scijava.console;
 
+import java.io.PrintStream;
 import java.util.LinkedList;
 
 import org.scijava.plugin.HandlerService;

--- a/src/main/java/org/scijava/console/DefaultConsoleService.java
+++ b/src/main/java/org/scijava/console/DefaultConsoleService.java
@@ -36,6 +36,7 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.scijava.Context;
 import org.scijava.console.OutputEvent.Source;
@@ -68,9 +69,7 @@ public class DefaultConsoleService extends
 	private OutputStreamReporter out, err;
 
 	/** List of listeners for {@code stdout} and {@code stderr} output. */
-	private ArrayList<OutputListener> listeners;
-
-	private OutputListener[] cachedListeners;
+	private List<OutputListener> listeners;
 
 	// -- ConsoleService methods --
 
@@ -115,26 +114,19 @@ public class DefaultConsoleService extends
 	@Override
 	public void addOutputListener(final OutputListener l) {
 		if (listeners == null) initListeners();
-		synchronized (listeners) {
-			listeners.add(l);
-			cacheListeners();
-		}
+		listeners.add(l);
 	}
 
 	@Override
 	public void removeOutputListener(final OutputListener l) {
 		if (listeners == null) initListeners();
-		synchronized (listeners) {
-			listeners.remove(l);
-			cacheListeners();
-		}
+		listeners.remove(l);
 	}
 
 	@Override
 	public void notifyListeners(final OutputEvent event) {
 		if (listeners == null) initListeners();
-		final OutputListener[] toNotify = cachedListeners;
-		for (final OutputListener l : toNotify)
+		for (final OutputListener l : listeners)
 			l.outputOccurred(event);
 	}
 
@@ -162,15 +154,10 @@ public class DefaultConsoleService extends
 		err = new OutputStreamReporter(Source.STDERR);
 		syserr.getParent().addOutputStream(err);
 
-		listeners = new ArrayList<>();
-		cachedListeners = listeners.toArray(new OutputListener[0]);
+		listeners = new CopyOnWriteArrayList<>();
 	}
 
 	// -- Helper methods --
-
-	private void cacheListeners() {
-		cachedListeners = listeners.toArray(new OutputListener[listeners.size()]);
-	}
 
 	private MultiPrintStream multiPrintStream(final PrintStream ps) {
 		if (ps instanceof MultiPrintStream) return (MultiPrintStream) ps;

--- a/src/main/java/org/scijava/console/DefaultConsoleService.java
+++ b/src/main/java/org/scijava/console/DefaultConsoleService.java
@@ -32,13 +32,16 @@
 package org.scijava.console;
 
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiFunction;
 
 import org.scijava.Context;
 import org.scijava.console.OutputEvent.Source;
+import org.scijava.log.LogLevel;
 import org.scijava.log.LogService;
 import org.scijava.plugin.AbstractHandlerService;
 import org.scijava.plugin.Parameter;
@@ -70,6 +73,13 @@ public class DefaultConsoleService extends
 	private List<OutputListener> listeners;
 
 	// -- ConsoleService methods --
+
+	@Override
+	public void initialize() {
+		PrintStream logErr = logStream(Source.STDERR);
+		PrintStream logOut = logStream(Source.STDOUT);
+		log.setPrintStreams(level -> (level <= LogLevel.WARN) ? logErr : logOut);
+	}
 
 	@Override
 	public void processArgs(final String... args) {
@@ -128,6 +138,27 @@ public class DefaultConsoleService extends
 			l.outputOccurred(event);
 	}
 
+	PrintStream logStream(Source source) {
+		OutputStream a = getBypassingStream(source);
+		OutputStream b = new OutputStreamReporter((relevance, text) -> {
+			final Context context = getContext();
+			final boolean contextual = true;
+			final boolean containsLog = true;
+			return new OutputEvent(context, source, text, contextual, containsLog);
+		});
+		return new PrintStream(new MultiOutputStream(a, b));
+	}
+
+	private OutputStream getBypassingStream(Source source) {
+		switch (source) {
+			case STDOUT:
+				return ListenableSystemStreams.out().bypass();
+			case STDERR:
+				return ListenableSystemStreams.err().bypass();
+		}
+		throw new AssertionError();
+	}
+
 	// -- Disposable methods --
 
 	@Override
@@ -142,12 +173,21 @@ public class DefaultConsoleService extends
 	private synchronized void initListeners() {
 		if (listeners != null) return; // already initialized
 
-		out = new OutputStreamReporter(Source.STDOUT);
+		out = setupDefaultReporter(Source.STDOUT);
+		err = setupDefaultReporter(Source.STDERR);
 		ListenableSystemStreams.out().addOutputStream(out);
-		err = new OutputStreamReporter(Source.STDERR);
 		ListenableSystemStreams.err().addOutputStream(err);
 
 		listeners = new CopyOnWriteArrayList<>();
+	}
+
+	private OutputStreamReporter setupDefaultReporter(Source source) {
+		return new OutputStreamReporter((relevance, output) -> {
+			final Context context = getContext();
+			final boolean contextual = relevance == ThreadContext.SAME;
+			final boolean containsLog = false;
+			return new OutputEvent(context, source, output, contextual, containsLog);
+		});
 	}
 
 	// -- Helper methods --
@@ -177,11 +217,12 @@ public class DefaultConsoleService extends
 	 */
 	private class OutputStreamReporter extends OutputStream {
 
-		/** Source of the output stream; i.e., {@code stdout} or {@code stderr}. */
-		private final Source source;
+		private final BiFunction<ThreadContext, String, OutputEvent> eventFactory;
 
-		public OutputStreamReporter(final Source source) {
-			this.source = source;
+		public OutputStreamReporter(
+			BiFunction<ThreadContext, String, OutputEvent> eventFactory)
+		{
+			this.eventFactory = eventFactory;
 		}
 
 		// -- OutputStream methods --
@@ -207,12 +248,8 @@ public class DefaultConsoleService extends
 		}
 
 		private void publish(final ThreadContext relevance, final String output) {
-			final Context context = getContext();
-			final boolean contextual = relevance == ThreadContext.SAME;
-			final OutputEvent event =
-				new OutputEvent(context, source, output, contextual);
+			final OutputEvent event = eventFactory.apply(relevance, output);
 			notifyListeners(event);
 		}
 	}
-
 }

--- a/src/main/java/org/scijava/console/DefaultConsoleService.java
+++ b/src/main/java/org/scijava/console/DefaultConsoleService.java
@@ -32,7 +32,6 @@
 package org.scijava.console;
 
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -65,7 +64,6 @@ public class DefaultConsoleService extends
 	@Parameter
 	private LogService log;
 
-	private MultiPrintStream sysout, syserr;
 	private OutputStreamReporter out, err;
 
 	/** List of listeners for {@code stdout} and {@code stderr} output. */
@@ -134,8 +132,8 @@ public class DefaultConsoleService extends
 
 	@Override
 	public void dispose() {
-		if (out != null) sysout.getParent().removeOutputStream(out);
-		if (err != null) syserr.getParent().removeOutputStream(err);
+		if(out != null) ListenableSystemStreams.out().removeOutputStream(out);
+		if(err != null) ListenableSystemStreams.err().removeOutputStream(err);
 	}
 
 	// -- Helper methods - lazy initialization --
@@ -144,25 +142,15 @@ public class DefaultConsoleService extends
 	private synchronized void initListeners() {
 		if (listeners != null) return; // already initialized
 
-		sysout = multiPrintStream(System.out);
-		if (System.out != sysout) System.setOut(sysout);
 		out = new OutputStreamReporter(Source.STDOUT);
-		sysout.getParent().addOutputStream(out);
-
-		syserr = multiPrintStream(System.err);
-		if (System.err != syserr) System.setErr(syserr);
+		ListenableSystemStreams.out().addOutputStream(out);
 		err = new OutputStreamReporter(Source.STDERR);
-		syserr.getParent().addOutputStream(err);
+		ListenableSystemStreams.err().addOutputStream(err);
 
 		listeners = new CopyOnWriteArrayList<>();
 	}
 
 	// -- Helper methods --
-
-	private MultiPrintStream multiPrintStream(final PrintStream ps) {
-		if (ps instanceof MultiPrintStream) return (MultiPrintStream) ps;
-		return new MultiPrintStream(ps);
-	}
 
 	/**
 	 * Gets whether two lists have exactly the same elements in them.

--- a/src/main/java/org/scijava/console/OutputEvent.java
+++ b/src/main/java/org/scijava/console/OutputEvent.java
@@ -67,20 +67,25 @@ public class OutputEvent extends SciJavaEvent {
 	 */
 	private final boolean contextual;
 
+	/** Whether the output is a printed log message. */
+	private final boolean containsLog;
+
 	/**
 	 * Creates a new output event.
-	 *
+	 * 
 	 * @param source The source of the output.
 	 * @param output The output string.
 	 * @param contextual Whether the output was produced within this specific
 	 *          SciJava {@link Context}.
+	 * @param containsLog Whether the output is contains a log message.
 	 */
 	public OutputEvent(final Context context, final Source source,
-		final String output, final boolean contextual)
+		final String output, final boolean contextual, boolean containsLog)
 	{
 		this.source = source;
 		this.output = output;
 		this.contextual = contextual;
+		this.containsLog = containsLog;
 		setContext(context);
 		setCallingThread(Thread.currentThread());
 	}
@@ -111,6 +116,14 @@ public class OutputEvent extends SciJavaEvent {
 	/** Returns true of the source of the output is {@code stderr}. */
 	public boolean isStderr() {
 		return source == Source.STDERR;
+	}
+
+	/**
+	 * Returns true if the source of the output is a streams returned
+	 * {@link org.scijava.console.ConsoleService#logStream(org.scijava.console.OutputEvent.Source)}
+	 */
+	public boolean containsLog() {
+		return containsLog;
 	}
 
 	// -- Object methods --

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -114,102 +114,102 @@ public abstract class AbstractLogService extends AbstractService implements
 
 	@Override
 	public void debug(final Object msg) {
-		log(DEBUG, msg, null);
+		log(LogLevel.DEBUG, msg, null);
 	}
 
 	@Override
 	public void debug(final Throwable t) {
-		log(DEBUG, null, t);
+		log(LogLevel.DEBUG, null, t);
 	}
 
 	@Override
 	public void debug(final Object msg, final Throwable t) {
-		log(DEBUG, msg, t);
+		log(LogLevel.DEBUG, msg, t);
 	}
 
 	@Override
 	public void error(final Object msg) {
-		log(ERROR, msg, null);
+		log(LogLevel.ERROR, msg, null);
 	}
 
 	@Override
 	public void error(final Throwable t) {
-		log(ERROR, null, t);
+		log(LogLevel.ERROR, null, t);
 	}
 
 	@Override
 	public void error(final Object msg, final Throwable t) {
-		log(ERROR, msg, t);
+		log(LogLevel.ERROR, msg, t);
 	}
 
 	@Override
 	public void info(final Object msg) {
-		log(INFO, msg, null);
+		log(LogLevel.INFO, msg, null);
 	}
 
 	@Override
 	public void info(final Throwable t) {
-		log(INFO, null, t);
+		log(LogLevel.INFO, null, t);
 	}
 
 	@Override
 	public void info(final Object msg, final Throwable t) {
-		log(INFO, msg, t);
+		log(LogLevel.INFO, msg, t);
 	}
 
 	@Override
 	public void trace(final Object msg) {
-		log(TRACE, msg, null);
+		log(LogLevel.TRACE, msg, null);
 	}
 
 	@Override
 	public void trace(final Throwable t) {
-		log(TRACE, null, t);
+		log(LogLevel.TRACE, null, t);
 	}
 
 	@Override
 	public void trace(final Object msg, final Throwable t) {
-		log(TRACE, msg, t);
+		log(LogLevel.TRACE, msg, t);
 	}
 
 	@Override
 	public void warn(final Object msg) {
-		log(WARN, msg, null);
+		log(LogLevel.WARN, msg, null);
 	}
 
 	@Override
 	public void warn(final Throwable t) {
-		log(WARN, null, t);
+		log(LogLevel.WARN, null, t);
 	}
 
 	@Override
 	public void warn(final Object msg, final Throwable t) {
-		log(WARN, msg, t);
+		log(LogLevel.WARN, msg, t);
 	}
 
 	@Override
 	public boolean isDebug() {
-		return getLevel() >= DEBUG;
+		return getLevel() >= LogLevel.DEBUG;
 	}
 
 	@Override
 	public boolean isError() {
-		return getLevel() >= ERROR;
+		return getLevel() >= LogLevel.ERROR;
 	}
 
 	@Override
 	public boolean isInfo() {
-		return getLevel() >= INFO;
+		return getLevel() >= LogLevel.INFO;
 	}
 
 	@Override
 	public boolean isTrace() {
-		return getLevel() >= TRACE;
+		return getLevel() >= LogLevel.TRACE;
 	}
 
 	@Override
 	public boolean isWarn() {
-		return getLevel() >= WARN;
+		return getLevel() >= LogLevel.WARN;
 	}
 
 	@Override
@@ -257,7 +257,7 @@ public abstract class AbstractLogService extends AbstractService implements
 
 	private int levelFromEnvironment() {
 		// use the default, which is INFO unless the DEBUG env. variable is set
-		return System.getenv("DEBUG") == null ? INFO : DEBUG;
+		return System.getenv("DEBUG") == null ? LogLevel.INFO : LogLevel.DEBUG;
 	}
 
 }

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -46,7 +46,7 @@ public abstract class AbstractLogService extends AbstractService implements
 	LogService
 {
 
-	private int currentLevel = System.getenv("DEBUG") == null ? INFO : DEBUG;
+	private int currentLevel = levelFromEnvironment();
 
 	private final Map<String, Integer> classAndPackageLevels =
 		new HashMap<>();
@@ -77,10 +77,8 @@ public abstract class AbstractLogService extends AbstractService implements
 		final int level = level(logProp);
 		if (level >= 0) setLevel(level);
 
-		if (getLevel() == 0) {
-			// use the default, which is INFO unless the DEBUG env. variable is set
-			setLevel(System.getenv("DEBUG") == null ? INFO : DEBUG);
-		}
+		if (getLevel() == 0)
+			setLevel(levelFromEnvironment());
 
 		// populate custom class- and package-specific log level properties
 		final String logLevelPrefix = LOG_LEVEL_PROPERTY + ":";
@@ -295,6 +293,11 @@ public abstract class AbstractLogService extends AbstractService implements
 		final int dot = classOrPackageName.lastIndexOf(".");
 		if (dot < 0) return null;
 		return classOrPackageName.substring(0, dot);
+	}
+
+	private int levelFromEnvironment() {
+		// use the default, which is INFO unless the DEBUG env. variable is set
+		return System.getenv("DEBUG") == null ? INFO : DEBUG;
 	}
 
 }

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -54,7 +54,9 @@ public abstract class AbstractLogService extends AbstractService implements
 	// -- constructor --
 
 	public AbstractLogService() {
-		logger = new DefaultListenableLogger(this::messageLogged, "", LogLevel.NONE) {
+		logger = new DefaultListenableLogger(this::messageLogged, LogSource
+			.root(), LogLevel.NONE)
+		{
 
 			@Override
 			public int getLevel() {
@@ -102,8 +104,8 @@ public abstract class AbstractLogService extends AbstractService implements
 	}
 
 	@Override
-	public String getName() {
-		return logger.getName();
+	public LogSource getSource() {
+		return logger.getSource();
 	}
 
 	@Override
@@ -112,8 +114,8 @@ public abstract class AbstractLogService extends AbstractService implements
 	}
 
 	@Override
-	public Logger subLogger(String nameExtension, int level) {
-		return logger.subLogger(nameExtension, level);
+	public Logger subLogger(String name, int level) {
+		return logger.subLogger(name, level);
 	}
 
 }

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -31,6 +31,8 @@
 
 package org.scijava.log;
 
+import java.util.function.Predicate;
+
 import org.scijava.service.AbstractService;
 
 /**
@@ -52,44 +54,16 @@ public abstract class AbstractLogService extends AbstractService implements
 	// -- constructor --
 
 	public AbstractLogService() {
-		logger = new DefaultListenableLogger(LogLevel.NONE) {
+		logger = new DefaultListenableLogger(this::messageLogged, "", LogLevel.NONE) {
 
 			@Override
 			public int getLevel() {
 				return logLevelStrategy.getLevel();
 			}
-
-			@Override
-			protected void messageLogged(LogMessage message) {
-				super.messageLogged(message);
-				AbstractLogService.this.messageLogged(message);
-			}
-
 		};
 	}
 
 	// -- AbstractLogService methods --
-
-	abstract void messageLogged(LogMessage message);
-
-	// -- Logger methods --
-
-	@Override
-	public void addListener(LogListener listener) {
-		logger.addListener(listener);
-	}
-
-	@Override
-	public void removeListener(LogListener listener) {
-		logger.removeListener(listener);
-	}
-
-	// -- Logger methods --
-
-	@Override
-	public int getLevel() {
-		return logLevelStrategy.getLevel();
-	}
 
 	@Override
 	public void setLevel(final int level) {
@@ -101,8 +75,45 @@ public abstract class AbstractLogService extends AbstractService implements
 		logLevelStrategy.setLevel(classOrPackageName, level);
 	}
 
+	abstract void messageLogged(LogMessage message);
+
+	// -- ListenableLogger methods --
+
+	@Override
+	public void addListener(LogListener listener) {
+		logger.addListener(listener);
+	}
+
+	@Override
+	public void removeListener(LogListener listener) {
+		logger.removeListener(listener);
+	}
+
+	@Override
+	public void setParentForwardingFilter(Predicate<LogMessage> filter) {
+		throw new UnsupportedOperationException();
+	}
+
+	// -- Logger methods --
+
 	@Override
 	public void alwaysLog(final int level, final Object msg, final Throwable t) {
 		logger.alwaysLog(level, msg, t);
 	}
+
+	@Override
+	public String getName() {
+		return logger.getName();
+	}
+
+	@Override
+	public int getLevel() {
+		return logLevelStrategy.getLevel();
+	}
+
+	@Override
+	public Logger subLogger(String nameExtension, int level) {
+		return logger.subLogger(nameExtension, level);
+	}
+
 }

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -38,7 +38,7 @@ import java.util.Properties;
 import org.scijava.service.AbstractService;
 
 /**
- * Base class for {@link LogService} implementationst.
+ * Base class for {@link LogService} implementations.
  *
  * @author Johannes Schindelin
  */

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -118,4 +118,8 @@ public abstract class AbstractLogService extends AbstractService implements
 		return logger.subLogger(name, level);
 	}
 
+	@Override
+	public ListenableLogger listenableLogger(int level) {
+		return logger.listenableLogger(level);
+	}
 }

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -41,6 +41,7 @@ import org.scijava.service.AbstractService;
  * Base class for {@link LogService} implementations.
  *
  * @author Johannes Schindelin
+ * @author Curtis Rueden
  */
 public abstract class AbstractLogService extends AbstractService implements
 	LogService
@@ -50,22 +51,6 @@ public abstract class AbstractLogService extends AbstractService implements
 
 	private final Map<String, Integer> classAndPackageLevels =
 		new HashMap<>();
-
-	// -- abstract methods --
-
-	/**
-	 * Displays a message.
-	 *
-	 * @param msg the message to display.
-	 */
-	protected abstract void log(final String msg);
-
-	/**
-	 * Displays an exception.
-	 *
-	 * @param t the exception to display.
-	 */
-	protected abstract void log(final Throwable t);
 
 	// -- constructor --
 
@@ -91,126 +76,9 @@ public abstract class AbstractLogService extends AbstractService implements
 				propName.substring(logLevelPrefix.length());
 			setLevel(classOrPackageName, LogLevel.value(props.getProperty(propName)));
 		}
-
 	}
 
-	// -- helper methods --
-
-	protected void log(final int level, final Object msg, final Throwable t) {
-		if (level > getLevel()) return;
-
-		if (msg != null || t == null) {
-			log(level, msg);
-		}
-		if (t != null) log(t);
-	}
-
-	protected void log(final int level, final Object msg) {
-		final String prefix = LogLevel.prefix(level);
-		log((prefix == null ? "" : prefix + " ") + msg);
-	}
-
-	// -- LogService methods --
-
-	@Override
-	public void debug(final Object msg) {
-		log(LogLevel.DEBUG, msg, null);
-	}
-
-	@Override
-	public void debug(final Throwable t) {
-		log(LogLevel.DEBUG, null, t);
-	}
-
-	@Override
-	public void debug(final Object msg, final Throwable t) {
-		log(LogLevel.DEBUG, msg, t);
-	}
-
-	@Override
-	public void error(final Object msg) {
-		log(LogLevel.ERROR, msg, null);
-	}
-
-	@Override
-	public void error(final Throwable t) {
-		log(LogLevel.ERROR, null, t);
-	}
-
-	@Override
-	public void error(final Object msg, final Throwable t) {
-		log(LogLevel.ERROR, msg, t);
-	}
-
-	@Override
-	public void info(final Object msg) {
-		log(LogLevel.INFO, msg, null);
-	}
-
-	@Override
-	public void info(final Throwable t) {
-		log(LogLevel.INFO, null, t);
-	}
-
-	@Override
-	public void info(final Object msg, final Throwable t) {
-		log(LogLevel.INFO, msg, t);
-	}
-
-	@Override
-	public void trace(final Object msg) {
-		log(LogLevel.TRACE, msg, null);
-	}
-
-	@Override
-	public void trace(final Throwable t) {
-		log(LogLevel.TRACE, null, t);
-	}
-
-	@Override
-	public void trace(final Object msg, final Throwable t) {
-		log(LogLevel.TRACE, msg, t);
-	}
-
-	@Override
-	public void warn(final Object msg) {
-		log(LogLevel.WARN, msg, null);
-	}
-
-	@Override
-	public void warn(final Throwable t) {
-		log(LogLevel.WARN, null, t);
-	}
-
-	@Override
-	public void warn(final Object msg, final Throwable t) {
-		log(LogLevel.WARN, msg, t);
-	}
-
-	@Override
-	public boolean isDebug() {
-		return getLevel() >= LogLevel.DEBUG;
-	}
-
-	@Override
-	public boolean isError() {
-		return getLevel() >= LogLevel.ERROR;
-	}
-
-	@Override
-	public boolean isInfo() {
-		return getLevel() >= LogLevel.INFO;
-	}
-
-	@Override
-	public boolean isTrace() {
-		return getLevel() >= LogLevel.TRACE;
-	}
-
-	@Override
-	public boolean isWarn() {
-		return getLevel() >= LogLevel.WARN;
-	}
+	// -- Logger methods --
 
 	@Override
 	public int getLevel() {

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -74,7 +74,7 @@ public abstract class AbstractLogService extends AbstractService implements
 
 		// global log level property
 		final String logProp = System.getProperty(LOG_LEVEL_PROPERTY);
-		final int level = level(logProp);
+		final int level = LogLevel.value(logProp);
 		if (level >= 0) setLevel(level);
 
 		if (getLevel() == 0)
@@ -89,7 +89,7 @@ public abstract class AbstractLogService extends AbstractService implements
 			if (!propName.startsWith(logLevelPrefix)) continue;
 			final String classOrPackageName =
 				propName.substring(logLevelPrefix.length());
-			setLevel(classOrPackageName, level(props.getProperty(propName)));
+			setLevel(classOrPackageName, LogLevel.value(props.getProperty(propName)));
 		}
 
 	}
@@ -238,29 +238,6 @@ public abstract class AbstractLogService extends AbstractService implements
 	}
 
 	// -- Helper methods --
-
-	/** Extracts the log level value from a string. */
-	private int level(final String logProp) {
-		if (logProp == null) return -1;
-
-		// check whether it's a string label (e.g., "debug")
-		final String log = logProp.trim().toLowerCase();
-		if (log.startsWith("n")) return NONE;
-		if (log.startsWith("e")) return ERROR;
-		if (log.startsWith("w")) return WARN;
-		if (log.startsWith("i")) return INFO;
-		if (log.startsWith("d")) return DEBUG;
-		if (log.startsWith("t")) return TRACE;
-
-		// check whether it's a numerical value (e.g., 5)
-		try {
-			return Integer.parseInt(log);
-		}
-		catch (final NumberFormatException exc) {
-			// nope!
-		}
-		return -1;
-	}
 
 	private String callingClass() {
 		final String thisClass = AbstractLogService.class.getName();

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -106,25 +106,8 @@ public abstract class AbstractLogService extends AbstractService implements
 	}
 
 	protected void log(final int level, final Object msg) {
-		final String prefix = getPrefix(level);
+		final String prefix = LogLevel.prefix(level);
 		log((prefix == null ? "" : prefix + " ") + msg);
-	}
-
-	protected String getPrefix(final int level) {
-		switch (level) {
-			case ERROR:
-				return "[ERROR]";
-			case WARN:
-				return "[WARNING]";
-			case INFO:
-				return "[INFO]";
-			case DEBUG:
-				return "[DEBUG]";
-			case TRACE:
-				return "[TRACE]";
-			default:
-				return null;
-		}
 	}
 
 	// -- LogService methods --

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -78,7 +78,7 @@ public abstract class AbstractLogService extends AbstractService implements
 		if (level >= 0) setLevel(level);
 
 		if (getLevel() == 0) {
-			// use the default, which is WARN unless the DEBUG env. variable is set
+			// use the default, which is INFO unless the DEBUG env. variable is set
 			setLevel(System.getenv("DEBUG") == null ? INFO : DEBUG);
 		}
 

--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -31,6 +31,9 @@
 
 package org.scijava.log;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import org.scijava.service.AbstractService;
 
 /**
@@ -44,7 +47,21 @@ public abstract class AbstractLogService extends AbstractService implements
 	LogService
 {
 
-	private LogLevelStrategy logLevelStrategy = new LogLevelStrategy();
+	private final LogLevelStrategy logLevelStrategy = new LogLevelStrategy();
+
+	private final List<LogListener> listeners = new CopyOnWriteArrayList<>();
+
+	// -- ListenableLogger methods --
+
+	@Override
+	public void addListener(final LogListener listener) {
+		listeners.add(listener);
+	}
+
+	@Override
+	public void removeListener(final LogListener listener) {
+		listeners.remove(listener);
+	}
 
 	// -- Logger methods --
 
@@ -64,7 +81,14 @@ public abstract class AbstractLogService extends AbstractService implements
 	}
 
 	@Override
-	public abstract void alwaysLog(final int level, final Object msg,
-		final Throwable t);
+	public void alwaysLog(final int level, final Object msg, final Throwable t) {
+		messageLogged(new LogMessage(level, msg, t));
+	}
 
+	// -- Helper methods --
+
+	protected void messageLogged(LogMessage message) {
+		for (LogListener listener : listeners)
+			listener.messageLogged(message);
+	}
 }

--- a/src/main/java/org/scijava/log/CallingClassUtils.java
+++ b/src/main/java/org/scijava/log/CallingClassUtils.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,40 +31,35 @@
 
 package org.scijava.log;
 
-import org.scijava.service.AbstractService;
-
 /**
- * Base class for {@link LogService} implementations.
+ * Utility class for getting the calling class of a method.
  *
- * @author Johannes Schindelin
- * @author Curtis Rueden
+ * @author Matthias Arzt
  */
+
 @IgnoreAsCallingClass
-public abstract class AbstractLogService extends AbstractService implements
-	LogService
-{
+public class CallingClassUtils {
 
-	private LogLevelStrategy logLevelStrategy = new LogLevelStrategy();
+	private CallingClassUtils() {} // forbid instances of this class
 
-	// -- Logger methods --
-
-	@Override
-	public int getLevel() {
-		return logLevelStrategy.getLevel();
+	/**
+	 * Inspects the stack trace to return the class that calls this method, but
+	 * ignores every class annotated with @IgnoreAsCallingClass.
+	 *
+	 * @throws IllegalStateException if every method on the stack, is in a class
+	 *           annotated with @IgnoreAsCallingClass.
+	 */
+	public static Class<?> getCallingClass() {
+		try {
+			StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+			for (int i = 1; i < stackTrace.length; i++) {
+				Class<?> clazz = Class.forName(stackTrace[i].getClassName());
+				if (!clazz.isAnnotationPresent(IgnoreAsCallingClass.class))
+					return clazz;
+			}
+		}
+		catch (ClassNotFoundException ignore) {}
+		throw new IllegalStateException();
 	}
-
-	@Override
-	public void setLevel(final int level) {
-		logLevelStrategy.setLevel(level);
-	}
-
-	@Override
-	public void setLevel(final String classOrPackageName, final int level) {
-		logLevelStrategy.setLevel(classOrPackageName, level);
-	}
-
-	@Override
-	public abstract void alwaysLog(final int level, final Object msg,
-		final Throwable t);
 
 }

--- a/src/main/java/org/scijava/log/DefaultListenableLogger.java
+++ b/src/main/java/org/scijava/log/DefaultListenableLogger.java
@@ -47,7 +47,7 @@ class DefaultListenableLogger implements ListenableLogger, LogListener {
 
 	private final LogListener destination;
 
-	private final String name;
+	private LogSource source;
 
 	private final int level;
 
@@ -56,14 +56,14 @@ class DefaultListenableLogger implements ListenableLogger, LogListener {
 	private Predicate<LogMessage> filter = DEFAULT_FILTER;
 
 	public static ListenableLogger newRoot(int level) {
-		return new DefaultListenableLogger(message -> {}, "", level);
+		return new DefaultListenableLogger(message -> {}, LogSource.root(), level);
 	}
 
-	public DefaultListenableLogger(final LogListener destination, final String name,
-								   final int level)
+	public DefaultListenableLogger(final LogListener destination,
+		final LogSource source, final int level)
 	{
 		this.destination = destination;
-		this.name = name;
+		this.source = source;
 		this.level = level;
 	}
 
@@ -88,12 +88,12 @@ class DefaultListenableLogger implements ListenableLogger, LogListener {
 
 	@Override
 	public void alwaysLog(final int level, final Object msg, final Throwable t) {
-		messageLogged(new LogMessage(level, msg, t));
+		messageLogged(new LogMessage(source, level, msg, t));
 	}
 
 	@Override
-	public String getName() {
-		return name;
+	public LogSource getSource() {
+		return source;
 	}
 
 	@Override
@@ -103,7 +103,7 @@ class DefaultListenableLogger implements ListenableLogger, LogListener {
 
 	@Override
 	public Logger subLogger(final String name, final int level) {
-		return new DefaultListenableLogger(this, name, level);
+		return new DefaultListenableLogger(this, source.subSource(name), level);
 	}
 
 	// -- LogListener methods --

--- a/src/main/java/org/scijava/log/DefaultListenableLogger.java
+++ b/src/main/java/org/scijava/log/DefaultListenableLogger.java
@@ -106,6 +106,11 @@ class DefaultListenableLogger implements ListenableLogger, LogListener {
 		return new DefaultListenableLogger(this, source.subSource(name), level);
 	}
 
+	@Override
+	public ListenableLogger listenableLogger(final int level) {
+		return new DefaultListenableLogger(this, source, level);
+	}
+
 	// -- LogListener methods --
 
 	@Override

--- a/src/main/java/org/scijava/log/DefaultLogFormatter.java
+++ b/src/main/java/org/scijava/log/DefaultLogFormatter.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,31 +31,32 @@
 
 package org.scijava.log;
 
-import java.io.PrintStream;
-
-import org.scijava.Priority;
-import org.scijava.plugin.Plugin;
-import org.scijava.service.Service;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 /**
- * Implementation of {@link LogService} using the standard error stream.
- * <p>
- * Actually, this service is somewhat misnamed now, since it prints {@code WARN}
- * and {@code ERROR} messages to stderr, but messages at lesser severities to
- * stdout.
- * </p>
- * 
- * @author Johannes Schindelin
- * @author Curtis Rueden
+ * Default implementation of {@link LogFormatter}
+ *
+ * @author Matthias Arzt
  */
-@Plugin(type = Service.class, priority = Priority.LOW_PRIORITY)
-public class StderrLogService extends AbstractLogService {
-
-	private final LogFormatter formatter = new DefaultLogFormatter();
+public class DefaultLogFormatter implements LogFormatter {
 
 	@Override
-	public void alwaysLog(final int level, final Object msg, final Throwable t) {
-		final PrintStream out = (level <= LogLevel.WARN) ? System.err : System.out;
-		out.print(formatter.format(new LogMessage(level, msg, t)));
+	public String format(LogMessage message) {
+		final StringWriter sw = new StringWriter();
+		final PrintWriter printer = new PrintWriter(sw);
+		printWithBrackets(printer, message.time().toString());
+		printWithBrackets(printer, LogLevel.prefix(message.level()));
+		printer.println(message.text());
+		if (message.throwable() != null) message.throwable().printStackTrace(
+			printer);
+		return sw.toString();
 	}
+
+	private void printWithBrackets(PrintWriter printer, String prefix) {
+		printer.print('[');
+		printer.print(prefix);
+		printer.print("] ");
+	}
+
 }

--- a/src/main/java/org/scijava/log/IgnoreAsCallingClass.java
+++ b/src/main/java/org/scijava/log/IgnoreAsCallingClass.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,40 +31,14 @@
 
 package org.scijava.log;
 
-import org.scijava.service.AbstractService;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 /**
- * Base class for {@link LogService} implementations.
+ * Classes annotated with {@link IgnoreAsCallingClass} are ignored by
+ * {@link CallingClassUtils#getCallingClass()
  *
- * @author Johannes Schindelin
- * @author Curtis Rueden
+ * @author Matthias Arzt
  */
-@IgnoreAsCallingClass
-public abstract class AbstractLogService extends AbstractService implements
-	LogService
-{
-
-	private LogLevelStrategy logLevelStrategy = new LogLevelStrategy();
-
-	// -- Logger methods --
-
-	@Override
-	public int getLevel() {
-		return logLevelStrategy.getLevel();
-	}
-
-	@Override
-	public void setLevel(final int level) {
-		logLevelStrategy.setLevel(level);
-	}
-
-	@Override
-	public void setLevel(final String classOrPackageName, final int level) {
-		logLevelStrategy.setLevel(classOrPackageName, level);
-	}
-
-	@Override
-	public abstract void alwaysLog(final int level, final Object msg,
-		final Throwable t);
-
-}
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IgnoreAsCallingClass {}

--- a/src/main/java/org/scijava/log/ListenableLogger.java
+++ b/src/main/java/org/scijava/log/ListenableLogger.java
@@ -31,6 +31,8 @@
 
 package org.scijava.log;
 
+import java.util.function.Predicate;
+
 /**
  * Interface for loggers, that provides a callback mechanism for listening to
  * the generated logs.
@@ -41,12 +43,23 @@ public interface ListenableLogger extends Logger {
 
 	/**
 	 * {@link LogListener}s added with this method are notified of every message,
-	 * NB: Messages are only logged, if their level is lower than the logger's
-	 * level.
+	 * that is logged to this logger or it's sub loggers. NB: Messages are only
+	 * logged, if their level is lower than the logger's level.
 	 *
 	 * @param listener
 	 */
 	void addListener(LogListener listener);
 
 	void removeListener(LogListener listener);
+
+	/**
+	 * A sub logger (see {@link Logger#subLogger(String)} forwards the
+	 * {@link LogMessage}s it gets to its parent logger. This method enables
+	 * setting a filter for this mechanism.
+	 *
+	 * @param filter Only the {@link LogMessage}s for which the filter method
+	 *          returns true are forwarded to the parent logger.
+	 */
+	void setParentForwardingFilter(Predicate<LogMessage> filter);
+
 }

--- a/src/main/java/org/scijava/log/ListenableLogger.java
+++ b/src/main/java/org/scijava/log/ListenableLogger.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,47 +31,22 @@
 
 package org.scijava.log;
 
-import org.scijava.service.SciJavaService;
-
 /**
- * Interface for the logging service.
- * <p>
- * The service supports five common logging levels: {@link #ERROR},
- * {@link #WARN}, {@link #INFO}, {@link #TRACE} and {@link #DEBUG}. It provides
- * methods for logging messages, exception stack traces and combinations of the
- * two.
- * </p>
- * 
- * @author Curtis Rueden
+ * Interface for loggers, that provides a callback mechanism for listening to
+ * the generated logs.
+ *
+ * @author Matthias Arzt
  */
-public interface LogService extends SciJavaService, ListenableLogger {
+public interface ListenableLogger extends Logger {
 
-	/** System property to set for overriding the default logging level. */
-	String LOG_LEVEL_PROPERTY = "scijava.log.level";
+	/**
+	 * {@link LogListener}s added with this method are notified of every message,
+	 * NB: Messages are only logged, if their level is lower than the logger's
+	 * level.
+	 *
+	 * @param listener
+	 */
+	void addListener(LogListener listener);
 
-	// -- Deprecated --
-
-	/** @deprecated Use {@link LogLevel#NONE}. */
-	@Deprecated
-	int NONE = LogLevel.NONE;
-	/** @deprecated Use {@link LogLevel#ERROR}. */
-	@Deprecated
-	int ERROR = LogLevel.ERROR;
-	/** @deprecated Use {@link LogLevel#WARN}. */
-	@Deprecated
-	int WARN = LogLevel.WARN;
-	/** @deprecated Use {@link LogLevel#INFO}. */
-	@Deprecated
-	int INFO = LogLevel.INFO;
-	/** @deprecated Use {@link LogLevel#DEBUG}. */
-	@Deprecated
-	int DEBUG = LogLevel.DEBUG;
-	/** @deprecated Use {@link LogLevel#TRACE}. */
-	@Deprecated
-	int TRACE = LogLevel.TRACE;
-
-	void setLevel(int level);
-
-	void setLevel(String classOrPackageName, int level);
-
+	void removeListener(LogListener listener);
 }

--- a/src/main/java/org/scijava/log/LogFormatter.java
+++ b/src/main/java/org/scijava/log/LogFormatter.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,31 +31,13 @@
 
 package org.scijava.log;
 
-import java.io.PrintStream;
-
-import org.scijava.Priority;
-import org.scijava.plugin.Plugin;
-import org.scijava.service.Service;
-
 /**
- * Implementation of {@link LogService} using the standard error stream.
- * <p>
- * Actually, this service is somewhat misnamed now, since it prints {@code WARN}
- * and {@code ERROR} messages to stderr, but messages at lesser severities to
- * stdout.
- * </p>
- * 
- * @author Johannes Schindelin
- * @author Curtis Rueden
+ * A LogFormatter is used to convert a {@link LogMessage} into a nicely
+ * formatted String.
+ *
+ * @author Matthias Arzt
  */
-@Plugin(type = Service.class, priority = Priority.LOW_PRIORITY)
-public class StderrLogService extends AbstractLogService {
+public interface LogFormatter {
 
-	private final LogFormatter formatter = new DefaultLogFormatter();
-
-	@Override
-	public void alwaysLog(final int level, final Object msg, final Throwable t) {
-		final PrintStream out = (level <= LogLevel.WARN) ? System.err : System.out;
-		out.print(formatter.format(new LogMessage(level, msg, t)));
-	}
+	String format(LogMessage message);
 }

--- a/src/main/java/org/scijava/log/LogLevel.java
+++ b/src/main/java/org/scijava/log/LogLevel.java
@@ -65,4 +65,32 @@ public final class LogLevel {
 				return "LEVEL" + level;
 		}
 	}
+
+	/**
+	 * Extracts the log level value from a string.
+	 * 
+	 * @return The log level, or -1 if the level cannot be parsed.
+	 */
+	public static int value(final String s) {
+		if (s == null) return -1;
+
+		// check whether it's a string label (e.g., "debug")
+		final String log = s.trim().toLowerCase();
+		if (log.startsWith("n")) return LogLevel.NONE;
+		if (log.startsWith("e")) return LogLevel.ERROR;
+		if (log.startsWith("w")) return LogLevel.WARN;
+		if (log.startsWith("i")) return LogLevel.INFO;
+		if (log.startsWith("d")) return LogLevel.DEBUG;
+		if (log.startsWith("t")) return LogLevel.TRACE;
+
+		// check whether it's a numerical value (e.g., 5)
+		try {
+			return Integer.parseInt(log);
+		}
+		catch (final NumberFormatException exc) {
+			// nope!
+		}
+		return -1;
+	}
+
 }

--- a/src/main/java/org/scijava/log/LogLevel.java
+++ b/src/main/java/org/scijava/log/LogLevel.java
@@ -31,51 +31,38 @@
 
 package org.scijava.log;
 
-import org.scijava.Priority;
-import org.scijava.plugin.Plugin;
-import org.scijava.service.Service;
-
 /**
- * Implementation of {@link LogService} using the standard error stream.
- * <p>
- * Actually, this service is somewhat misnamed now, since it prints {@code WARN}
- * and {@code ERROR} messages to stderr, but messages at lesser severities to
- * stdout.
- * </p>
+ * Constants for specifying a logger's level of verbosity.
  * 
- * @author Johannes Schindelin
  * @author Curtis Rueden
  */
-@Plugin(type = Service.class, priority = Priority.LOW_PRIORITY)
-public class StderrLogService extends AbstractLogService {
+public final class LogLevel {
 
-	@Override
-	protected void log(final int level, final Object msg) {
-		final String prefix = LogLevel.prefix(level);
-		final String message = (prefix == null ? "" : prefix + " ") + msg;
-		// NB: Emit severe messages to stderr, and less severe ones to stdout.
-		if (level <= WARN) System.err.println(message);
-		else System.out.println(message);
+	private LogLevel() {
+		// prevent instantiation of utility class
 	}
 
-	/**
-	 * Prints a message to stderr.
-	 * 
-	 * @param message the message
-	 */
-	@Override
-	protected void log(final String message) {
-		System.err.println(message);
-	}
+	public static final int NONE = 0;
+	public static final int ERROR = 1;
+	public static final int WARN = 2;
+	public static final int INFO = 3;
+	public static final int DEBUG = 4;
+	public static final int TRACE = 5;
 
-	/**
-	 * Prints an exception to stderr.
-	 * 
-	 * @param t the exception
-	 */
-	@Override
-	protected void log(final Throwable t) {
-		t.printStackTrace();
+	public static String prefix(final int level) {
+		switch (level) {
+			case ERROR:
+				return "ERROR";
+			case WARN:
+				return "WARNING";
+			case INFO:
+				return "INFO";
+			case DEBUG:
+				return "DEBUG";
+			case TRACE:
+				return "TRACE";
+			default:
+				return "LEVEL" + level;
+		}
 	}
-
 }

--- a/src/main/java/org/scijava/log/LogLevelStrategy.java
+++ b/src/main/java/org/scijava/log/LogLevelStrategy.java
@@ -36,8 +36,12 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
+ * LogLevelStrategy provides a detailed control of logger's levels for the
+ * AbstractLogService.
+ * 
  * @author Matthias Arzt
  */
+@IgnoreAsCallingClass
 class LogLevelStrategy {
 
 	private final Map<String, Integer> classAndPackageLevels = new HashMap<>();
@@ -96,13 +100,7 @@ class LogLevelStrategy {
 	// -- Helper methods --
 
 	private String callingClass() {
-		final String thisClass = LogLevelStrategy.class.getName();
-		for (final StackTraceElement element : new Exception().getStackTrace()) {
-			final String className = element.getClassName();
-			// NB: Skip stack trace elements from other methods of this class.
-			if (!thisClass.equals(className)) return className;
-		}
-		return null;
+		return CallingClassUtils.getCallingClass().getName();
 	}
 
 	private String parentPackage(final String classOrPackageName) {

--- a/src/main/java/org/scijava/log/LogLevelStrategy.java
+++ b/src/main/java/org/scijava/log/LogLevelStrategy.java
@@ -1,0 +1,117 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.log;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * @author Matthias Arzt
+ */
+class LogLevelStrategy {
+
+	private final Map<String, Integer> classAndPackageLevels = new HashMap<>();
+
+	private int currentLevel = levelFromEnvironment();
+
+	LogLevelStrategy() {
+		// check SciJava log level system properties for initial logging levels
+
+		// global log level property
+		final String logProp = System.getProperty(LogService.LOG_LEVEL_PROPERTY);
+		final int level = LogLevel.value(logProp);
+		if (level >= 0) setLevel(level);
+
+		if (getLevel() == 0) {
+			// use the default, which is INFO unless the DEBUG env. variable is set
+			setLevel(levelFromEnvironment());
+		}
+
+		// populate custom class- and package-specific log level properties
+		final String logLevelPrefix = LogService.LOG_LEVEL_PROPERTY + ":";
+		final Properties props = System.getProperties();
+		for (final Object propKey : props.keySet()) {
+			if (!(propKey instanceof String)) continue;
+			final String propName = (String) propKey;
+			if (!propName.startsWith(logLevelPrefix)) continue;
+			final String classOrPackageName = propName.substring(logLevelPrefix
+					.length());
+			setLevel(classOrPackageName, LogLevel.value(props.getProperty(propName)));
+		}
+
+	}
+
+	public int getLevel() {
+		if (!classAndPackageLevels.isEmpty()) {
+			// check for a custom log level for calling class or its parent packages
+			String classOrPackageName = callingClass();
+			while (classOrPackageName != null) {
+				final Integer level = classAndPackageLevels.get(classOrPackageName);
+				if (level != null) return level;
+				classOrPackageName = parentPackage(classOrPackageName);
+			}
+		}
+		// no custom log level; return the global log level
+		return currentLevel;
+	}
+
+	public void setLevel(final int level) {
+		currentLevel = level;
+	}
+
+	public void setLevel(final String classOrPackageName, final int level) {
+		classAndPackageLevels.put(classOrPackageName, level);
+	}
+
+	// -- Helper methods --
+
+	private String callingClass() {
+		final String thisClass = LogLevelStrategy.class.getName();
+		for (final StackTraceElement element : new Exception().getStackTrace()) {
+			final String className = element.getClassName();
+			// NB: Skip stack trace elements from other methods of this class.
+			if (!thisClass.equals(className)) return className;
+		}
+		return null;
+	}
+
+	private String parentPackage(final String classOrPackageName) {
+		final int dot = classOrPackageName.lastIndexOf(".");
+		if (dot < 0) return null;
+		return classOrPackageName.substring(0, dot);
+	}
+
+	private int levelFromEnvironment() {
+		return System.getenv("DEBUG") == null ? LogLevel.INFO : LogLevel.DEBUG;
+	}
+}

--- a/src/main/java/org/scijava/log/LogListener.java
+++ b/src/main/java/org/scijava/log/LogListener.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,47 +31,19 @@
 
 package org.scijava.log;
 
-import org.scijava.service.SciJavaService;
-
 /**
- * Interface for the logging service.
- * <p>
- * The service supports five common logging levels: {@link #ERROR},
- * {@link #WARN}, {@link #INFO}, {@link #TRACE} and {@link #DEBUG}. It provides
- * methods for logging messages, exception stack traces and combinations of the
- * two.
- * </p>
- * 
- * @author Curtis Rueden
+ * Callback function used by {@link ListenableLogger}.
+ *
+ * @author Matthias Arzt
+ * @see ListenableLogger
+ * @see LogMessage
  */
-public interface LogService extends SciJavaService, ListenableLogger {
+public interface LogListener {
 
-	/** System property to set for overriding the default logging level. */
-	String LOG_LEVEL_PROPERTY = "scijava.log.level";
-
-	// -- Deprecated --
-
-	/** @deprecated Use {@link LogLevel#NONE}. */
-	@Deprecated
-	int NONE = LogLevel.NONE;
-	/** @deprecated Use {@link LogLevel#ERROR}. */
-	@Deprecated
-	int ERROR = LogLevel.ERROR;
-	/** @deprecated Use {@link LogLevel#WARN}. */
-	@Deprecated
-	int WARN = LogLevel.WARN;
-	/** @deprecated Use {@link LogLevel#INFO}. */
-	@Deprecated
-	int INFO = LogLevel.INFO;
-	/** @deprecated Use {@link LogLevel#DEBUG}. */
-	@Deprecated
-	int DEBUG = LogLevel.DEBUG;
-	/** @deprecated Use {@link LogLevel#TRACE}. */
-	@Deprecated
-	int TRACE = LogLevel.TRACE;
-
-	void setLevel(int level);
-
-	void setLevel(String classOrPackageName, int level);
+	/**
+	 * This method is normally called from many threads in parallel. It must be
+	 * implemented highly thread safe and must not use any kind of locks.
+	 */
+	void messageLogged(LogMessage message);
 
 }

--- a/src/main/java/org/scijava/log/LogMessage.java
+++ b/src/main/java/org/scijava/log/LogMessage.java
@@ -43,6 +43,8 @@ import java.util.LinkedList;
  */
 public class LogMessage {
 
+	private final LogSource source;
+
 	private final int level;
 
 	private final String message;
@@ -53,9 +55,10 @@ public class LogMessage {
 
 	private Collection<Object> attachments;
 
-	public LogMessage(int level, Object message,
+	public LogMessage(LogSource source, int level, Object message,
 		Throwable throwable)
 	{
+		this.source = source;
 		this.attachments = null;
 		this.level = level;
 		this.message = message == null ? null : message.toString();
@@ -63,8 +66,13 @@ public class LogMessage {
 		this.time = new Date();
 	}
 
-	public LogMessage(int level, Object msg) {
-		this(level, msg, null);
+	public LogMessage(LogSource source, int level, Object msg) {
+		this(source, level, msg, null);
+	}
+
+	/** Represents the source of the message. */
+	public LogSource source() {
+		return source;
 	}
 
 	/**

--- a/src/main/java/org/scijava/log/LogMessage.java
+++ b/src/main/java/org/scijava/log/LogMessage.java
@@ -1,0 +1,118 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.log;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedList;
+
+/**
+ * LogMessage represents a log message.
+ *
+ * @author Matthias Arzt
+ */
+public class LogMessage {
+
+	private final int level;
+
+	private final String message;
+
+	private final Throwable throwable;
+
+	private final Date time;
+
+	private Collection<Object> attachments;
+
+	public LogMessage(int level, Object message,
+		Throwable throwable)
+	{
+		this.attachments = null;
+		this.level = level;
+		this.message = message == null ? null : message.toString();
+		this.throwable = throwable;
+		this.time = new Date();
+	}
+
+	public LogMessage(int level, Object msg) {
+		this(level, msg, null);
+	}
+
+	/**
+	 * Log level of the message.
+	 * 
+	 * @see LogLevel
+	 */
+	public int level() {
+		return level;
+	}
+
+	/** The content of this log message. */
+	public String text() {
+		return message;
+	}
+
+	/** A throwable that has been provided together with the message */
+	public Throwable throwable() {
+		return throwable;
+	}
+
+	/** Time of the creation of the log message. */
+	public Date time() {
+		return time;
+	}
+
+	/**
+	 * Collection of all objects, that had been attached to this message with
+	 * {@link #attach(Object)}.
+	 */
+	public Collection<Object> attachments() {
+		if (attachments == null) return Collections.emptyList();
+		return Collections.unmodifiableCollection(attachments);
+	}
+
+	/**
+	 * Attach object to this log message. This can be used to attach addition
+	 * information to the log message.
+	 */
+	public void attach(Object value) {
+		if (attachments == null) attachments = new LinkedList<>();
+		attachments.add(value);
+	}
+
+	// -- Object methods --
+
+	public String toString() {
+		return "LogMessage {" + level + ", " + message + ", " + throwable + "}";
+	}
+
+}

--- a/src/main/java/org/scijava/log/LogRecorder.java
+++ b/src/main/java/org/scijava/log/LogRecorder.java
@@ -1,0 +1,329 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.log;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.scijava.console.OutputEvent;
+import org.scijava.console.OutputListener;
+
+/**
+ * LogRecorder can be used to record {@link LogMessage}s and text outputted to
+ * {@link PrintStream}s at the same time. The recorded {@link LogMessage}s and
+ * text are stored in a list. New items are always added to the end of the list.
+ * Items in the list are either instances of {@link LogMessage} or
+ * {@link TaggedLine}.
+ *
+ * @author Matthias Arzt
+ */
+@IgnoreAsCallingClass
+public class LogRecorder implements LogListener, OutputListener,
+	Iterable<Object>
+{
+
+	public static final String STDOUT_TAG = "out";
+	public static final String STDERR_TAG = "err";
+	public static final String GLOBAL_STDOUT_TAG = "global_out";
+	public static final String GLOBAL_STDERR_TAG = "global_err";
+
+	private final PrintStream outStream = printStream(STDOUT_TAG);
+	private final PrintStream errStream = printStream(STDERR_TAG);
+	private final PrintStream globalOutStream = printStream(GLOBAL_STDOUT_TAG);
+	private final PrintStream globalErrStream = printStream(GLOBAL_STDERR_TAG);
+
+	private Container recorded = new Container();
+
+	private List<Runnable> observers = new CopyOnWriteArrayList<>();
+
+	private ConcurrentMap<String, PrintStream> printStreams =
+		new ConcurrentSkipListMap<>();
+
+	private boolean recordCallingClass = false;
+
+	/**
+	 * The {@link Runnable} observer will be executed, after every new log message
+	 * or text recorded. The code executed by the {@link Runnable} must by highly
+	 * thread safe and must not use any kind of locks.
+	 */
+	public void addObservers(Runnable observer) {
+		observers.add(observer);
+	}
+
+	public void removeObserver(Runnable observer) {
+		observers.remove(observer);
+	}
+
+	/**
+	 * The returned Iterator never fails, and will always be updated. Even if an
+	 * element is added after an iterator reached the end of the list,
+	 * {@link Iterator#hasNext()} will return true again, and
+	 * {@link Iterator#next()} will return the newly added element.
+	 */
+	public Iterator<Object> iterator() {
+		return recorded.iterator();
+	}
+
+	public Stream<Object> stream() {
+		return recorded.stream();
+	}
+
+	/**
+	 * The returned Iterator never fails, and will always be updated. The Iterator
+	 * will only return log messages and text recorded after the iterator has been
+	 * created.
+	 */
+	public Iterator<Object> iteratorAtEnd() {
+		return recorded.iteratorAtEnd();
+	}
+
+	public void clear() {
+		recorded.clear();
+	}
+
+	public PrintStream printStream(String tag) {
+		return new PrintStream(new StreamAdapter(tag), true);
+	}
+
+	public boolean isRecordCallingClass() {
+		return recordCallingClass;
+	}
+
+	public void setRecordCallingClass(boolean enable) {
+		this.recordCallingClass = enable;
+	}
+
+	// -- LogListener methods --
+
+	@Override
+	public void messageLogged(LogMessage message) {
+		if (recordCallingClass) message.attach(CallingClassUtils.getCallingClass());
+		recorded.add(message);
+		notifyListeners();
+	}
+
+	// -- OutputListener methods --
+
+	@Override
+	public void outputOccurred(OutputEvent event) {
+		if(event.containsLog()) return;
+		PrintStream stream = (event.getSource() == OutputEvent.Source.STDOUT)
+			? (event.isContextual() ? outStream : globalOutStream)
+			: (event.isContextual() ? errStream : globalErrStream);
+		stream.append(event.getOutput());
+	}
+
+	// -- Helper methods --
+
+	private void notifyListeners() {
+		for (Runnable listener : observers)
+			listener.run();
+	}
+
+	// -- Helper classes --
+
+	/**
+	 * This Container manages a list of items. Items can only be added to end of
+	 * the list. It's possible to add items, while iterating over the list.
+	 * Iterators never fail, and they will always be updated. Even if an element
+	 * is added after an iterator reached the end of the list,
+	 * {@link Iterator#hasNext()} will return true again, and
+	 * {@link Iterator#next()} will return the newly added element. This Container
+	 * is fully thread safe.
+	 */
+	private static class Container implements Iterable<Object> {
+
+		private final AtomicLong lastKey = new AtomicLong(0);
+
+		private final NavigableMap<Long, Object> map =
+			new ConcurrentSkipListMap<>();
+
+		private final Object lock = new Object();
+
+		public Stream<Object> stream() {
+			Spliterator<Object> spliterator = Spliterators.spliteratorUnknownSize(
+				iterator(), Spliterator.ORDERED);
+			return StreamSupport.stream(spliterator, /* parallel */ false);
+		}
+
+		public Iterator<Object> iterator() {
+			return new MyIterator();
+		}
+
+		public Iterator<Object> iteratorAtEnd() {
+			return new MyIterator(map.lastEntry());
+		}
+
+		private long add(Object value) {
+			synchronized (lock) {
+				long key = lastKey.incrementAndGet();
+				map.put(key, value);
+				return key;
+			}
+		}
+
+		private void remove(long key) {
+			map.remove(key);
+		}
+
+		public void clear() {
+			map.clear();
+		}
+
+		private class MyIterator implements Iterator<Object> {
+
+			private Map.Entry<Long, Object> entry;
+
+			private Map.Entry<Long, Object> nextEntry = null;
+
+			public MyIterator() {
+				this(null);
+			}
+
+			public MyIterator(Map.Entry<Long, Object> entry) {
+				this.entry = entry;
+			}
+
+			@Override
+			public boolean hasNext() {
+				nextEntry = (entry == null) ? map.firstEntry() : map.higherEntry(entry
+					.getKey());
+				return nextEntry != null;
+			}
+
+			@Override
+			public Object next() {
+				if (nextEntry == null) if (!hasNext())
+					throw new NoSuchElementException();
+				entry = nextEntry;
+				nextEntry = null;
+				return entry.getValue();
+			}
+		}
+
+	}
+
+	/**
+	 * TaggedLine is a pair of a {@link String} and an {@link Object} used to tag
+	 * it.
+	 */
+	public static class TaggedLine {
+
+		private final String line;
+
+		private final String tag;
+
+		TaggedLine(String line, String tag) {
+			this.line = line;
+			this.tag = tag;
+		}
+
+		public String line() {
+			return line;
+		}
+
+		public Object tag() {
+			return tag;
+		}
+
+		public boolean isComplete() {
+			return line.endsWith("\n");
+		}
+
+	}
+
+	/**
+	 * Text written to this {@link StreamAdapter} is split into lines and recorded
+	 * by {@link LogRecorder}.
+	 */
+	private class StreamAdapter extends ByteArrayOutputStream {
+
+		private final String tag;
+
+		long lastKey = -1;
+
+		String remainder = "";
+
+		private StreamAdapter(String tag) {
+			this.tag = tag;
+		}
+
+		@Override
+		public void flush() {
+			String text = toString();
+			if (text.isEmpty()) return;
+			splitToLines(text);
+			reset();
+		}
+
+		public void splitToLines(String s) {
+			int indexBefore = 0;
+			while (true) {
+				int index = s.indexOf("\n", indexBefore) + 1;
+				if (index == 0) break;
+				completeLine(remainder + s.substring(indexBefore, index));
+				remainder = "";
+				indexBefore = index;
+			}
+			remainder = remainder + s.substring(indexBefore);
+			if (!remainder.isEmpty()) incompleteLine(remainder);
+		}
+
+		private void incompleteLine(String line) {
+			if (lastKey >= 0) recorded.remove(lastKey);
+			lastKey = recorded.add(new TaggedLine(line, tag));
+			notifyListeners();
+		}
+
+		private void completeLine(String line) {
+			if (lastKey >= 0) recorded.remove(lastKey);
+			lastKey = -1;
+			recorded.add(new TaggedLine(line, tag));
+			notifyListeners();
+		}
+
+	}
+
+}

--- a/src/main/java/org/scijava/log/LogService.java
+++ b/src/main/java/org/scijava/log/LogService.java
@@ -49,6 +49,30 @@ public interface LogService extends SciJavaService, ListenableLogger {
 	/** System property to set for overriding the default logging level. */
 	String LOG_LEVEL_PROPERTY = "scijava.log.level";
 
+	String LOG_LEVEL_BY_SOURCE_PROPERTY = "scijava.log.level.source";
+
+	/** Changes the log level of the root logger */
+	void setLevel(int level);
+
+	/**
+	 * For messages that are logged directly to the LogService. The log level can
+	 * be set depending on the class that makes the log.
+	 * 
+	 * @param classOrPackageName If this is the name of a class. Messages logged
+	 *          directly by this class are logged, if the message's level is less
+	 *          or equal to the given level. If this is a package, the same holds
+	 *          for all classes in this package.
+	 * @param level Given level.
+	 */
+	void setLevel(String classOrPackageName, int level);
+
+	/**
+	 * Setting the log level for loggers depending on their {@link LogSource}.
+	 * This will only effect loggers that are created after is method has been
+	 * called.
+	 */
+	void setLevelForLogger(LogSource source, int level);
+
 	// -- Deprecated --
 
 	/** @deprecated Use {@link LogLevel#NONE}. */
@@ -69,9 +93,4 @@ public interface LogService extends SciJavaService, ListenableLogger {
 	/** @deprecated Use {@link LogLevel#TRACE}. */
 	@Deprecated
 	int TRACE = LogLevel.TRACE;
-
-	void setLevel(int level);
-
-	void setLevel(String classOrPackageName, int level);
-
 }

--- a/src/main/java/org/scijava/log/LogService.java
+++ b/src/main/java/org/scijava/log/LogService.java
@@ -49,12 +49,26 @@ public interface LogService extends SciJavaService {
 	/** System property to set for overriding the default logging level. */
 	String LOG_LEVEL_PROPERTY = "scijava.log.level";
 
-	int NONE = 0;
-	int ERROR = 1;
-	int WARN = 2;
-	int INFO = 3;
-	int DEBUG = 4;
-	int TRACE = 5;
+	// -- Deprecated --
+
+	/** @deprecated Use {@link LogLevel#NONE}. */
+	@Deprecated
+	int NONE = LogLevel.NONE;
+	/** @deprecated Use {@link LogLevel#ERROR}. */
+	@Deprecated
+	int ERROR = LogLevel.ERROR;
+	/** @deprecated Use {@link LogLevel#WARN}. */
+	@Deprecated
+	int WARN = LogLevel.WARN;
+	/** @deprecated Use {@link LogLevel#INFO}. */
+	@Deprecated
+	int INFO = LogLevel.INFO;
+	/** @deprecated Use {@link LogLevel#DEBUG}. */
+	@Deprecated
+	int DEBUG = LogLevel.DEBUG;
+	/** @deprecated Use {@link LogLevel#TRACE}. */
+	@Deprecated
+	int TRACE = LogLevel.TRACE;
 
 	void debug(Object msg);
 

--- a/src/main/java/org/scijava/log/LogService.java
+++ b/src/main/java/org/scijava/log/LogService.java
@@ -33,6 +33,9 @@ package org.scijava.log;
 
 import org.scijava.service.SciJavaService;
 
+import java.io.PrintStream;
+import java.util.function.Function;
+
 /**
  * Interface for the logging service.
  * <p>
@@ -73,6 +76,12 @@ public interface LogService extends SciJavaService, ListenableLogger {
 	 */
 	void setLevelForLogger(LogSource source, int level);
 
+	/**
+	 * If the a LogService writes the log messages to streams,
+	 * it should implement this method for setting the output streams.
+	 */
+	default void setPrintStreams(Function<Integer, PrintStream> levelToStream) {}
+
 	// -- Deprecated --
 
 	/** @deprecated Use {@link LogLevel#NONE}. */
@@ -93,4 +102,5 @@ public interface LogService extends SciJavaService, ListenableLogger {
 	/** @deprecated Use {@link LogLevel#TRACE}. */
 	@Deprecated
 	int TRACE = LogLevel.TRACE;
+
 }

--- a/src/main/java/org/scijava/log/LogSource.java
+++ b/src/main/java/org/scijava/log/LogSource.java
@@ -32,6 +32,7 @@
 package org.scijava.log;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
@@ -47,6 +48,8 @@ import java.util.concurrent.ConcurrentSkipListMap;
  * @author Matthias Arzt
  */
 public class LogSource {
+
+	public static final String SEPARATOR = ":";
 
 	private static final LogSource ROOT = new LogSource();
 
@@ -86,6 +89,10 @@ public class LogSource {
 		return result;
 	}
 
+	public static LogSource parse(String text) {
+		return of(Arrays.asList(text.split(SEPARATOR)));
+	}
+
 	/** Returns the list of strings which is represented by this LogSource. */
 	public List<String> path() {
 		return path;
@@ -111,7 +118,7 @@ public class LogSource {
 
 	public String toString() {
 		if (formatted != null) return formatted;
-		StringJoiner joiner = new StringJoiner(":");
+		StringJoiner joiner = new StringJoiner(SEPARATOR);
 		path.forEach(s -> joiner.add(s));
 		formatted = joiner.toString();
 		return formatted;

--- a/src/main/java/org/scijava/log/LogSource.java
+++ b/src/main/java/org/scijava/log/LogSource.java
@@ -1,0 +1,129 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.log;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+/**
+ * An instance of LogSource represents an immutable list of Strings. LogSource
+ * is used to identify the source of a {@link LogMessage}. Two instances of
+ * LogSource are not the same, if and only if they represent two different list
+ * of strings.
+ *
+ * @author Matthias Arzt
+ */
+public class LogSource {
+
+	private static final LogSource ROOT = new LogSource();
+
+	private final LogSource parent;
+
+	private final List<String> path;
+
+	private final ConcurrentMap<String, LogSource> children =
+		new ConcurrentSkipListMap<>();
+
+	private String formatted = null;
+
+	private LogSource(LogSource parent, String name) {
+		this.parent = parent;
+		List<String> parentPath = parent.path();
+		List<String> list = new ArrayList<>(parentPath.size() + 1);
+		list.addAll(parentPath);
+		list.add(name);
+		this.path = Collections.unmodifiableList(list);
+	}
+
+	private LogSource() {
+		this.parent = null;
+		this.path = Collections.emptyList();
+	}
+
+	/** Returns the root log source. This LogSource represents the empty list. */
+	public static LogSource root() {
+		return ROOT;
+	}
+
+	/** Returns the LogSource which represents path. */
+	public static LogSource of(List<String> path) {
+		LogSource result = root();
+		for (String name : path)
+			result = result.subSource(name);
+		return result;
+	}
+
+	/** Returns the list of strings which is represented by this LogSource. */
+	public List<String> path() {
+		return path;
+	}
+
+	/** Returns the last entry in the list of strings. */
+	public String name() {
+		if (path.isEmpty()) return "";
+		return path.get(path.size() - 1);
+	}
+
+	/**
+	 * Returns the LogSource which represents the path of this LogSource extended
+	 * by name.
+	 */
+	public LogSource subSource(String name) {
+		LogSource child = children.get(name);
+		if (child != null) return child;
+		child = new LogSource(this, name);
+		children.putIfAbsent(name, child);
+		return children.get(name);
+	}
+
+	public String toString() {
+		if (formatted != null) return formatted;
+		StringJoiner joiner = new StringJoiner(":");
+		path.forEach(s -> joiner.add(s));
+		formatted = joiner.toString();
+		return formatted;
+	}
+
+	public boolean isRoot() {
+		return parent == null;
+	}
+
+	public LogSource parent() {
+		if (isRoot()) throw new IllegalStateException(
+			"Trying to retrieve the parent of the root LogSource.");
+		return parent;
+	}
+}

--- a/src/main/java/org/scijava/log/Logger.java
+++ b/src/main/java/org/scijava/log/Logger.java
@@ -161,7 +161,7 @@ public interface Logger {
 
 	/**
 	 * Logs a message with an exception.
-	 * 
+	 *
 	 * @param level The level at which the information will be logged. If the
 	 *          current level (given by {@link #getLevel()} is below this one, no
 	 *          logging is performed.
@@ -182,6 +182,25 @@ public interface Logger {
 	 */
 	void alwaysLog(int level, Object msg, Throwable t);
 
+	/** Returns the name of this logger. */
+	String getName();
+
 	/** Returns the log level of this logger. see {@link LogLevel} */
 	int getLevel();
+
+	/**
+	 * Creates a sub logger, that forwards the message it gets to this logger. The
+	 * sub logger will have the same log level as this logger.
+	 */
+	default Logger subLogger(String name) {
+		return subLogger(name, getLevel());
+	}
+
+	/**
+	 * Creates a sub logger, that forwards the message it gets to this logger.
+	 *
+	 * @param level The log level of the sub logger.
+	 */
+	Logger subLogger(String name, int level);
+
 }

--- a/src/main/java/org/scijava/log/Logger.java
+++ b/src/main/java/org/scijava/log/Logger.java
@@ -31,6 +31,12 @@
 
 package org.scijava.log;
 
+import static org.scijava.log.LogLevel.DEBUG;
+import static org.scijava.log.LogLevel.ERROR;
+import static org.scijava.log.LogLevel.INFO;
+import static org.scijava.log.LogLevel.TRACE;
+import static org.scijava.log.LogLevel.WARN;
+
 /**
  * Interface for objects which can produce log messages.
  * <p>
@@ -44,45 +50,137 @@ package org.scijava.log;
  */
 public interface Logger {
 
-	void debug(Object msg);
+	default void debug(final Object msg) {
+		log(DEBUG, msg);
+	}
 
-	void debug(Throwable t);
+	default void debug(final Throwable t) {
+		log(DEBUG, t);
+	}
 
-	void debug(Object msg, Throwable t);
+	default void debug(final Object msg, final Throwable t) {
+		log(DEBUG, msg, t);
+	}
 
-	void error(Object msg);
+	default void error(final Object msg) {
+		log(ERROR, msg);
+	}
 
-	void error(Throwable t);
+	default void error(final Throwable t) {
+		log(ERROR, t);
+	}
 
-	void error(Object msg, Throwable t);
+	default void error(final Object msg, final Throwable t) {
+		log(ERROR, msg, t);
+	}
 
-	void info(Object msg);
+	default void info(final Object msg) {
+		log(INFO, msg);
+	}
 
-	void info(Throwable t);
+	default void info(final Throwable t) {
+		log(INFO, t);
+	}
 
-	void info(Object msg, Throwable t);
+	default void info(final Object msg, final Throwable t) {
+		log(INFO, msg, t);
+	}
 
-	void trace(Object msg);
+	default void trace(final Object msg) {
+		log(TRACE, msg);
+	}
 
-	void trace(Throwable t);
+	default void trace(final Throwable t) {
+		log(TRACE, t);
+	}
 
-	void trace(Object msg, Throwable t);
+	default void trace(final Object msg, final Throwable t) {
+		log(TRACE, msg, t);
+	}
 
-	void warn(Object msg);
+	default void warn(final Object msg) {
+		log(WARN, msg);
+	}
 
-	void warn(Throwable t);
+	default void warn(final Throwable t) {
+		log(WARN, t);
+	}
 
-	void warn(Object msg, Throwable t);
+	default void warn(final Object msg, final Throwable t) {
+		log(WARN, msg, t);
+	}
 
-	boolean isDebug();
+	default boolean isDebug() {
+		return isLevel(DEBUG);
+	}
 
-	boolean isError();
+	default boolean isError() {
+		return isLevel(ERROR);
+	}
 
-	boolean isInfo();
+	default boolean isInfo() {
+		return isLevel(INFO);
+	}
 
-	boolean isTrace();
+	default boolean isTrace() {
+		return isLevel(TRACE);
+	}
 
-	boolean isWarn();
+	default boolean isWarn() {
+		return isLevel(WARN);
+	}
 
+	default boolean isLevel(final int level) {
+		return getLevel() >= level;
+	}
+
+	/**
+	 * Logs a message.
+	 * 
+	 * @param level The level at which the message will be logged. If the current
+	 *          level (given by {@link #getLevel()} is below this one, no logging
+	 *          is performed.
+	 * @param msg The message to log.
+	 */
+	default void log(final int level, final Object msg) {
+		log(level, msg, null);
+	}
+
+	/**
+	 * Logs an exception.
+	 * 
+	 * @param level The level at which the exception will be logged. If the
+	 *          current level (given by {@link #getLevel()} is below this one, no
+	 *          logging is performed.
+	 * @param t The exception to log.
+	 */
+	default void log(final int level, final Throwable t) {
+		log(level, null, t);
+	}
+
+	/**
+	 * Logs a message with an exception.
+	 * 
+	 * @param level The level at which the information will be logged. If the
+	 *          current level (given by {@link #getLevel()} is below this one, no
+	 *          logging is performed.
+	 * @param msg The message to log.
+	 * @param t The exception to log.
+	 */
+	default void log(final int level, final Object msg, final Throwable t) {
+		if (isLevel(level)) alwaysLog(level, msg, t);
+	}
+
+	/**
+	 * Logs a message with an exception. This message will always be logged even
+	 * if it's level is above the current level (given by {@link #getLevel()}).
+	 *
+	 * @param level The level at which the information will be logged.
+	 * @param msg The message to log.
+	 * @param t The exception to log.
+	 */
+	void alwaysLog(int level, Object msg, Throwable t);
+
+	/** Returns the log level of this logger. see {@link LogLevel} */
 	int getLevel();
 }

--- a/src/main/java/org/scijava/log/Logger.java
+++ b/src/main/java/org/scijava/log/Logger.java
@@ -31,47 +31,58 @@
 
 package org.scijava.log;
 
-import org.scijava.service.SciJavaService;
-
 /**
- * Interface for the logging service.
+ * Interface for objects which can produce log messages.
  * <p>
- * The service supports five common logging levels: {@link #ERROR},
- * {@link #WARN}, {@link #INFO}, {@link #TRACE} and {@link #DEBUG}. It provides
- * methods for logging messages, exception stack traces and combinations of the
- * two.
+ * It provides methods for logging messages, exception stack traces and
+ * combinations of the two.
  * </p>
  * 
  * @author Curtis Rueden
+ * @see LogLevel
+ * @see LogService
  */
-public interface LogService extends SciJavaService, Logger {
+public interface Logger {
 
-	/** System property to set for overriding the default logging level. */
-	String LOG_LEVEL_PROPERTY = "scijava.log.level";
+	void debug(Object msg);
 
-	// -- Deprecated --
+	void debug(Throwable t);
 
-	/** @deprecated Use {@link LogLevel#NONE}. */
-	@Deprecated
-	int NONE = LogLevel.NONE;
-	/** @deprecated Use {@link LogLevel#ERROR}. */
-	@Deprecated
-	int ERROR = LogLevel.ERROR;
-	/** @deprecated Use {@link LogLevel#WARN}. */
-	@Deprecated
-	int WARN = LogLevel.WARN;
-	/** @deprecated Use {@link LogLevel#INFO}. */
-	@Deprecated
-	int INFO = LogLevel.INFO;
-	/** @deprecated Use {@link LogLevel#DEBUG}. */
-	@Deprecated
-	int DEBUG = LogLevel.DEBUG;
-	/** @deprecated Use {@link LogLevel#TRACE}. */
-	@Deprecated
-	int TRACE = LogLevel.TRACE;
+	void debug(Object msg, Throwable t);
 
-	void setLevel(int level);
+	void error(Object msg);
 
-	void setLevel(String classOrPackageName, int level);
+	void error(Throwable t);
 
+	void error(Object msg, Throwable t);
+
+	void info(Object msg);
+
+	void info(Throwable t);
+
+	void info(Object msg, Throwable t);
+
+	void trace(Object msg);
+
+	void trace(Throwable t);
+
+	void trace(Object msg, Throwable t);
+
+	void warn(Object msg);
+
+	void warn(Throwable t);
+
+	void warn(Object msg, Throwable t);
+
+	boolean isDebug();
+
+	boolean isError();
+
+	boolean isInfo();
+
+	boolean isTrace();
+
+	boolean isWarn();
+
+	int getLevel();
 }

--- a/src/main/java/org/scijava/log/Logger.java
+++ b/src/main/java/org/scijava/log/Logger.java
@@ -48,6 +48,7 @@ import static org.scijava.log.LogLevel.WARN;
  * @see LogLevel
  * @see LogService
  */
+@IgnoreAsCallingClass
 public interface Logger {
 
 	default void debug(final Object msg) {

--- a/src/main/java/org/scijava/log/Logger.java
+++ b/src/main/java/org/scijava/log/Logger.java
@@ -183,7 +183,12 @@ public interface Logger {
 	void alwaysLog(int level, Object msg, Throwable t);
 
 	/** Returns the name of this logger. */
-	String getName();
+	default String getName() {
+		return getSource().name();
+	}
+
+	/** Returns the {@link LogSource} associated with this logger. */
+	LogSource getSource();
 
 	/** Returns the log level of this logger. see {@link LogLevel} */
 	int getLevel();
@@ -199,6 +204,7 @@ public interface Logger {
 	/**
 	 * Creates a sub logger, that forwards the message it gets to this logger.
 	 *
+	 * @param name The name of the sub logger.
 	 * @param level The log level of the sub logger.
 	 */
 	Logger subLogger(String name, int level);

--- a/src/main/java/org/scijava/log/Logger.java
+++ b/src/main/java/org/scijava/log/Logger.java
@@ -209,4 +209,22 @@ public interface Logger {
 	 */
 	Logger subLogger(String name, int level);
 
+	/**
+	 * Creates an {@link ListenableLogger} with the same name and log level as this
+	 * logger. The {@link ListenableLogger} will forward all messages it gets to
+	 * this logger, but provides additional functionality.
+	 */
+	default ListenableLogger listenableLogger() {
+		return listenableLogger(getLevel());
+	}
+
+	/**
+	 * Creates an {@link ListenableLogger} with the same name as this logger. The
+	 * {@link ListenableLogger} will forward all messages it gets to this logger,
+	 * but provides additional functionality.
+	 * 
+	 * @param level Defines the log level of the generated logger.
+	 */
+	ListenableLogger listenableLogger(int level);
+
 }

--- a/src/main/java/org/scijava/log/LoggerPreprocessor.java
+++ b/src/main/java/org/scijava/log/LoggerPreprocessor.java
@@ -1,0 +1,75 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.log;
+
+import org.scijava.Priority;
+import org.scijava.module.Module;
+import org.scijava.module.ModuleItem;
+import org.scijava.module.ModuleService;
+import org.scijava.module.process.AbstractPreprocessorPlugin;
+import org.scijava.module.process.PreprocessorPlugin;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * This {@link PreprocessorPlugin} affects {@link Module}s with a single
+ * {@link Parameter} of type {@link Logger}. It will assign a Logger to that
+ * Parameter, that is named like the modules class.
+ *
+ * @author Matthias Arzt
+ */
+@Plugin(type = PreprocessorPlugin.class, priority = Priority.NORMAL_PRIORITY)
+public class LoggerPreprocessor extends AbstractPreprocessorPlugin {
+
+	@Parameter(required = false)
+	private LogService logService;
+
+	@Parameter(required = false)
+	private ModuleService moduleService;
+
+	// -- ModuleProcessor methods --
+
+	@Override
+	public void process(final Module module) {
+		if (logService == null || moduleService == null) return;
+
+		final ModuleItem<?> loggerInput = moduleService.getSingleInput(module,
+			Logger.class);
+		if (loggerInput == null || !loggerInput.isAutoFill()) return;
+
+		final String name = loggerInput.getName();
+		module.setInput(name, logService.subLogger(module.getDelegateObject()
+			.getClass().getSimpleName()));
+		module.resolveInput(name);
+	}
+
+}

--- a/src/main/java/org/scijava/log/LoggerPreprocessor.java
+++ b/src/main/java/org/scijava/log/LoggerPreprocessor.java
@@ -66,9 +66,13 @@ public class LoggerPreprocessor extends AbstractPreprocessorPlugin {
 			Logger.class);
 		if (loggerInput == null || !loggerInput.isAutoFill()) return;
 
+		String loggerName = loggerInput.getLabel();
+		if(loggerName.isEmpty())
+			loggerName = module.getDelegateObject().getClass().getSimpleName();
+		Logger logger = logService.subLogger(loggerName);
+
 		final String name = loggerInput.getName();
-		module.setInput(name, logService.subLogger(module.getDelegateObject()
-			.getClass().getSimpleName()));
+		module.setInput(name, logger);
 		module.resolveInput(name);
 	}
 

--- a/src/main/java/org/scijava/log/Loggers.java
+++ b/src/main/java/org/scijava/log/Loggers.java
@@ -1,0 +1,103 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.log;
+
+import java.util.function.Predicate;
+
+/**
+ * @author Matthias Arzt
+ */
+@IgnoreAsCallingClass
+public class Loggers {
+
+	private static final ListenableLogger DUMMY_LOGGER = new ListenableLogger() {
+
+		@Override
+		public void addListener(LogListener listener) {
+			// ignore
+		}
+
+		@Override
+		public void removeListener(LogListener listener) {
+			// ignore
+		}
+
+		@Override
+		public void setParentForwardingFilter(Predicate<LogMessage> filter) {
+			// ignore
+		}
+
+		@Override
+		public void alwaysLog(int level, Object msg, Throwable t) {
+			// ignore
+		}
+
+		@Override
+		public String getName() {
+			return "";
+		}
+
+		@Override
+		public LogSource getSource() {
+			return LogSource.root();
+		}
+
+		@Override
+		public int getLevel() {
+			return LogLevel.NONE;
+		}
+
+		@Override
+		public Logger subLogger(String name, int level) {
+			return this;
+		}
+
+		@Override
+		public ListenableLogger listenableLogger(int level) {
+			return this;
+		}
+	};
+
+	private Loggers() {
+		// prevent instantiation of utility class
+	}
+
+	/** A {@link Logger} that discards all log messages */
+	public static ListenableLogger silent() {
+		return DUMMY_LOGGER;
+	}
+
+	/** Returns a new {@link ListenableLogger}. */
+	public static ListenableLogger newRoot(int logLevel) {
+		return DefaultListenableLogger.newRoot(logLevel);
+	}
+}

--- a/src/main/java/org/scijava/log/StderrLogService.java
+++ b/src/main/java/org/scijava/log/StderrLogService.java
@@ -32,6 +32,7 @@
 package org.scijava.log;
 
 import java.io.PrintStream;
+import java.util.function.Predicate;
 
 import org.scijava.Priority;
 import org.scijava.plugin.Plugin;

--- a/src/main/java/org/scijava/log/StderrLogService.java
+++ b/src/main/java/org/scijava/log/StderrLogService.java
@@ -54,8 +54,10 @@ public class StderrLogService extends AbstractLogService {
 	private final LogFormatter formatter = new DefaultLogFormatter();
 
 	@Override
-	public void alwaysLog(final int level, final Object msg, final Throwable t) {
-		final PrintStream out = (level <= LogLevel.WARN) ? System.err : System.out;
-		out.print(formatter.format(new LogMessage(level, msg, t)));
+	public void messageLogged(final LogMessage message) {
+		super.messageLogged(message);
+		final PrintStream out = (message.level() <= LogLevel.WARN) ? System.err
+			: System.out;
+		out.print(formatter.format(message));
 	}
 }

--- a/src/main/java/org/scijava/log/StderrLogService.java
+++ b/src/main/java/org/scijava/log/StderrLogService.java
@@ -50,32 +50,12 @@ import org.scijava.service.Service;
 public class StderrLogService extends AbstractLogService {
 
 	@Override
-	protected void log(final int level, final Object msg) {
+	public void alwaysLog(final int level, final Object msg, final Throwable t) {
 		final String prefix = LogLevel.prefix(level);
 		final String message = (prefix == null ? "" : prefix + " ") + msg;
 		// NB: Emit severe messages to stderr, and less severe ones to stdout.
 		if (level <= LogLevel.WARN) System.err.println(message);
 		else System.out.println(message);
+		if (t != null) t.printStackTrace();
 	}
-
-	/**
-	 * Prints a message to stderr.
-	 * 
-	 * @param message the message
-	 */
-	@Override
-	protected void log(final String message) {
-		System.err.println(message);
-	}
-
-	/**
-	 * Prints an exception to stderr.
-	 * 
-	 * @param t the exception
-	 */
-	@Override
-	protected void log(final Throwable t) {
-		t.printStackTrace();
-	}
-
 }

--- a/src/main/java/org/scijava/log/StderrLogService.java
+++ b/src/main/java/org/scijava/log/StderrLogService.java
@@ -54,7 +54,7 @@ public class StderrLogService extends AbstractLogService {
 		final String prefix = LogLevel.prefix(level);
 		final String message = (prefix == null ? "" : prefix + " ") + msg;
 		// NB: Emit severe messages to stderr, and less severe ones to stdout.
-		if (level <= WARN) System.err.println(message);
+		if (level <= LogLevel.WARN) System.err.println(message);
 		else System.out.println(message);
 	}
 

--- a/src/main/java/org/scijava/log/StderrLogService.java
+++ b/src/main/java/org/scijava/log/StderrLogService.java
@@ -32,7 +32,7 @@
 package org.scijava.log;
 
 import java.io.PrintStream;
-import java.util.function.Predicate;
+import java.util.function.Function;
 
 import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
@@ -54,10 +54,16 @@ public class StderrLogService extends AbstractLogService {
 
 	private final LogFormatter formatter = new DefaultLogFormatter();
 
+	private Function<Integer, PrintStream> levelToStream =
+		level -> (level <= LogLevel.WARN) ? System.err : System.out;
+
+	public void setPrintStreams(Function<Integer, PrintStream> levelToStream) {
+		this.levelToStream = levelToStream;
+	}
+
 	@Override
-	public void messageLogged(final LogMessage message) {
-		final PrintStream out = (message.level() <= LogLevel.WARN) ? System.err
-			: System.out;
+	public void messageLogged(LogMessage message) {
+		final PrintStream out = levelToStream.apply(message.level());
 		out.print(formatter.format(message));
 	}
 }

--- a/src/main/java/org/scijava/log/StderrLogService.java
+++ b/src/main/java/org/scijava/log/StderrLogService.java
@@ -55,7 +55,6 @@ public class StderrLogService extends AbstractLogService {
 
 	@Override
 	public void messageLogged(final LogMessage message) {
-		super.messageLogged(message);
 		final PrintStream out = (message.level() <= LogLevel.WARN) ? System.err
 			: System.out;
 		out.print(formatter.format(message));

--- a/src/main/java/org/scijava/log/StderrLogService.java
+++ b/src/main/java/org/scijava/log/StderrLogService.java
@@ -57,6 +57,7 @@ public class StderrLogService extends AbstractLogService {
 	private Function<Integer, PrintStream> levelToStream =
 		level -> (level <= LogLevel.WARN) ? System.err : System.out;
 
+	@Override
 	public void setPrintStreams(Function<Integer, PrintStream> levelToStream) {
 		this.levelToStream = levelToStream;
 	}

--- a/src/test/java/org/scijava/console/ConsoleServiceTest.java
+++ b/src/test/java/org/scijava/console/ConsoleServiceTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -48,6 +49,8 @@ import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.Priority;
 import org.scijava.console.OutputEvent.Source;
+import org.scijava.convert.ConvertService;
+import org.scijava.log.LogService;
 import org.scijava.plugin.Plugin;
 import org.scijava.thread.ThreadService;
 
@@ -205,6 +208,25 @@ public class ConsoleServiceTest {
 		assertOutputEvent(Source.STDERR, c2RunErr, true, events2.get(3));
 		assertOutputEvent(Source.STDOUT, c2InvokeOut, true, events2.get(4));
 		assertOutputEvent(Source.STDERR, c2InvokeErr, true, events2.get(5));
+	}
+
+	@Test
+	public void testLogToStream() {
+		final Context context = new Context(LogService.class, ConsoleService.class);
+		final ConsoleService consoleService = context.getService(ConsoleService.class);
+		final LogService logService = context.getService(LogService.class);
+		final ArrayList<OutputEvent> events = new ArrayList<>();
+		final OutputListener outputListener = new OutputTracker(events);
+
+		consoleService.addOutputListener(outputListener);
+		logService.warn("Hello");
+		System.out.print("World");
+		consoleService.removeOutputListener(outputListener);
+
+		assertEquals(2, events.size());
+		assertTrue(events.get(0).containsLog());
+		assertTrue(events.get(0).isContextual());
+		assertFalse(events.get(1).containsLog());
 	}
 
 	// -- Helper methods --

--- a/src/test/java/org/scijava/console/ListenableSystemStreamsTest.java
+++ b/src/test/java/org/scijava/console/ListenableSystemStreamsTest.java
@@ -1,0 +1,88 @@
+
+package org.scijava.console;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link ListenableSystemStreams}
+ *
+ * @author Matthias Arzt
+ */
+public class ListenableSystemStreamsTest {
+
+	private final String TEXT = "Hello World!\n";
+
+	private static PrintStream bufferingPrintStream() {
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+		return new PrintStream(buffer) {
+
+			@Override
+			public String toString() {
+				return buffer.toString();
+			}
+		};
+	}
+
+	@Test
+	public void testListenerSystemOut() {
+		OutputStream listener = new ByteArrayOutputStream();
+		ListenableSystemStreams.out().addOutputStream(listener);
+		System.out.print(TEXT);
+		ListenableSystemStreams.out().removeOutputStream(listener);
+		assertEquals(TEXT, listener.toString());
+	}
+
+	@Test
+	public void testListening() {
+		// setup
+		PrintStream output = bufferingPrintStream();
+		OutputStream listener = new ByteArrayOutputStream();
+		ListenableSystemStreams.ListenableStream l =
+			new ListenableSystemStreams.ListenableStream(output, s -> {});
+		// process
+		l.addOutputStream(listener);
+		l.stream().print(TEXT);
+		// test
+		assertEquals(TEXT, listener.toString());
+		assertEquals(TEXT, output.toString());
+	}
+
+	@Test
+	public void testBypass() {
+		// setup
+		PrintStream output = bufferingPrintStream();
+		OutputStream listener = new ByteArrayOutputStream();
+		ListenableSystemStreams.ListenableStream l =
+			new ListenableSystemStreams.ListenableStream(output, s -> {});
+		l.addOutputStream(listener);
+		// process
+		l.bypass().print(TEXT);
+		// test
+		assertTrue(listener.toString().isEmpty());
+		assertEquals(TEXT, output.toString());
+	}
+
+	@Test
+	public void testSetter() {
+		// setup
+		List<PrintStream> set = new ArrayList<>();
+		PrintStream output = bufferingPrintStream();
+		// process
+		ListenableSystemStreams.ListenableStream l =
+			new ListenableSystemStreams.ListenableStream(output, set::add);
+		// test
+		assertEquals(1, set.size());
+		assertSame(l.stream(), set.get(0));
+	}
+
+}

--- a/src/test/java/org/scijava/log/CallingClassUtilsTest.java
+++ b/src/test/java/org/scijava/log/CallingClassUtilsTest.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,40 +31,36 @@
 
 package org.scijava.log;
 
-import org.scijava.service.AbstractService;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
- * Base class for {@link LogService} implementations.
- *
- * @author Johannes Schindelin
- * @author Curtis Rueden
+ * @author Matthias Arzt
  */
-@IgnoreAsCallingClass
-public abstract class AbstractLogService extends AbstractService implements
-	LogService
-{
-
-	private LogLevelStrategy logLevelStrategy = new LogLevelStrategy();
-
-	// -- Logger methods --
-
-	@Override
-	public int getLevel() {
-		return logLevelStrategy.getLevel();
+public class CallingClassUtilsTest {
+	@Test
+	public void testGetCallingClass() {
+		Class<?> callingClass = CallingClassUtils.getCallingClass();
+		assertEquals(this.getClass(), callingClass);
 	}
 
-	@Override
-	public void setLevel(final int level) {
-		logLevelStrategy.setLevel(level);
+	@Test
+	public void testIgnoreAsCallingClass() {
+		assertEquals(ClassA.class, ClassA.returnGetCallingClass());
+		assertEquals(this.getClass(), ClassB.returnGetCallingClass());
 	}
 
-	@Override
-	public void setLevel(final String classOrPackageName, final int level) {
-		logLevelStrategy.setLevel(classOrPackageName, level);
+	public static class ClassA {
+		static Class<?> returnGetCallingClass() {
+			return CallingClassUtils.getCallingClass();
+		}
 	}
 
-	@Override
-	public abstract void alwaysLog(final int level, final Object msg,
-		final Throwable t);
-
+	@IgnoreAsCallingClass
+	private static class ClassB {
+		static Class<?> returnGetCallingClass() {
+			return CallingClassUtils.getCallingClass();
+		}
+	}
 }

--- a/src/test/java/org/scijava/log/DefaultListenableLoggerTest.java
+++ b/src/test/java/org/scijava/log/DefaultListenableLoggerTest.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,78 +31,34 @@
 
 package org.scijava.log;
 
-import org.scijava.service.AbstractService;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
- * Base class for {@link LogService} implementations.
- *
- * @author Johannes Schindelin
- * @author Curtis Rueden
  * @author Matthias Arzt
  */
-@IgnoreAsCallingClass
-public abstract class AbstractLogService extends AbstractService implements
-	LogService
-{
+public class DefaultListenableLoggerTest {
 
-	private final ListenableLogger logger;
+	private ListenableLogger logger;
+	private TestLogListener listener;
 
-	private final LogLevelStrategy logLevelStrategy = new LogLevelStrategy();
-
-	// -- constructor --
-
-	public AbstractLogService() {
-		logger = new DefaultListenableLogger(LogLevel.NONE) {
-
-			@Override
-			public int getLevel() {
-				return logLevelStrategy.getLevel();
-			}
-
-			@Override
-			protected void messageLogged(LogMessage message) {
-				super.messageLogged(message);
-				AbstractLogService.this.messageLogged(message);
-			}
-
-		};
-	}
-
-	// -- AbstractLogService methods --
-
-	abstract void messageLogged(LogMessage message);
-
-	// -- Logger methods --
-
-	@Override
-	public void addListener(LogListener listener) {
+	@Before
+	public void setup() {
+		logger = new DefaultListenableLogger(LogLevel.INFO);
+		listener = new TestLogListener();
 		logger.addListener(listener);
 	}
 
-	@Override
-	public void removeListener(LogListener listener) {
-		logger.removeListener(listener);
-	}
+	@Test
+	public void test() {
+		listener.clear();
 
-	// -- Logger methods --
+		logger.error("Hello World!");
 
-	@Override
-	public int getLevel() {
-		return logLevelStrategy.getLevel();
-	}
-
-	@Override
-	public void setLevel(final int level) {
-		logLevelStrategy.setLevel(level);
-	}
-
-	@Override
-	public void setLevel(String classOrPackageName, final int level) {
-		logLevelStrategy.setLevel(classOrPackageName, level);
-	}
-
-	@Override
-	public void alwaysLog(final int level, final Object msg, final Throwable t) {
-		logger.alwaysLog(level, msg, t);
+		assertTrue(listener.hasLogged(m -> m.text().equals("Hello World!")));
+		assertTrue(listener.hasLogged(m -> m.level() == LogLevel.ERROR));
 	}
 }

--- a/src/test/java/org/scijava/log/DefaultListenableLoggerTest.java
+++ b/src/test/java/org/scijava/log/DefaultListenableLoggerTest.java
@@ -47,7 +47,7 @@ public class DefaultListenableLoggerTest {
 
 	@Before
 	public void setup() {
-		logger = new DefaultListenableLogger(LogLevel.INFO);
+		logger = DefaultListenableLogger.newRoot(LogLevel.INFO);
 		listener = new TestLogListener();
 		logger.addListener(listener);
 	}
@@ -60,5 +60,15 @@ public class DefaultListenableLoggerTest {
 
 		assertTrue(listener.hasLogged(m -> m.text().equals("Hello World!")));
 		assertTrue(listener.hasLogged(m -> m.level() == LogLevel.ERROR));
+	}
+
+	@Test
+	public void testSubLogger() {
+		listener.clear();
+		Logger sub = logger.subLogger("sub");
+
+		sub.error("Hello World!");
+
+		assertTrue(listener.hasLogged(m -> m.text().equals("Hello World!")));
 	}
 }

--- a/src/test/java/org/scijava/log/DefaultListenableLoggerTest.java
+++ b/src/test/java/org/scijava/log/DefaultListenableLoggerTest.java
@@ -87,4 +87,31 @@ public class DefaultListenableLoggerTest {
 		assertEquals(Arrays.asList("subA"), subA.getSource().path());
 		assertEquals(Arrays.asList("subA", "subB"), subB.getSource().path());
 	}
+
+	@Test
+	public void testListenableLogger() {
+		ListenableLogger log = logger.listenableLogger();
+		TestLogListener listener = new TestLogListener();
+		log.addListener(listener);
+
+		log.error("Hello World!");
+		logger.error("Goodbye!");
+
+		assertTrue(listener.hasLogged(m -> m.text().equals("Hello World!")));
+		assertFalse(listener.hasLogged(m -> m.text().equals("Goodbye!")));
+	}
+
+	@Test
+	public void testForwardingFilter() {
+		listener.clear();
+		ListenableLogger sub = logger.subLogger("sub").listenableLogger();
+
+		sub.setParentForwardingFilter(m -> m.text().contains("Hello"));
+		sub.error("Hello World!");
+		sub.error("Goodbye!");
+
+		assertTrue(listener.hasLogged(m -> m.text().equals("Hello World!")));
+		assertFalse(listener.hasLogged(m -> m.text().equals("Goodbye!")));
+	}
+
 }

--- a/src/test/java/org/scijava/log/DefaultListenableLoggerTest.java
+++ b/src/test/java/org/scijava/log/DefaultListenableLoggerTest.java
@@ -34,6 +34,9 @@ package org.scijava.log;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -69,6 +72,19 @@ public class DefaultListenableLoggerTest {
 
 		sub.error("Hello World!");
 
-		assertTrue(listener.hasLogged(m -> m.text().equals("Hello World!")));
+		assertTrue(listener.hasLogged(m -> m.source().path().contains("sub")));
+	}
+
+	@Test
+	public void testHierarchicLogger() {
+		listener.clear();
+		Logger subA = logger.subLogger("subA");
+		Logger subB = subA.subLogger("subB");
+
+		subB.error("Hello World!");
+
+		assertTrue(listener.hasLogged(m -> m.source().equals(subB.getSource())));
+		assertEquals(Arrays.asList("subA"), subA.getSource().path());
+		assertEquals(Arrays.asList("subA", "subB"), subB.getSource().path());
 	}
 }

--- a/src/test/java/org/scijava/log/DefaultLogFormatterTest.java
+++ b/src/test/java/org/scijava/log/DefaultLogFormatterTest.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,31 +31,56 @@
 
 package org.scijava.log;
 
-import java.io.PrintStream;
-
-import org.scijava.Priority;
-import org.scijava.plugin.Plugin;
-import org.scijava.service.Service;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
- * Implementation of {@link LogService} using the standard error stream.
- * <p>
- * Actually, this service is somewhat misnamed now, since it prints {@code WARN}
- * and {@code ERROR} messages to stderr, but messages at lesser severities to
- * stdout.
- * </p>
- * 
- * @author Johannes Schindelin
- * @author Curtis Rueden
+ * @author Matthias Arzt
  */
-@Plugin(type = Service.class, priority = Priority.LOW_PRIORITY)
-public class StderrLogService extends AbstractLogService {
+public class DefaultLogFormatterTest {
 
-	private final LogFormatter formatter = new DefaultLogFormatter();
+	private final DefaultLogFormatter logFormatter = new DefaultLogFormatter();
 
-	@Override
-	public void alwaysLog(final int level, final Object msg, final Throwable t) {
-		final PrintStream out = (level <= LogLevel.WARN) ? System.err : System.out;
-		out.print(formatter.format(new LogMessage(level, msg, t)));
+	class DummyClass {}
+
+	@Test
+	public void testFormatMessage() {
+		String nameOfThisMethod = "testFormatMessage";
+		// setup
+		LogMessage message = new LogMessage(LogLevel.DEBUG, 42, generateThrowableWithStackTrace());
+		// process
+		String s = logFormatter.format(message);
+		//test
+		Assert.assertTrue("Log message contains level", s.contains(LogLevel.prefix(message.level())));
+		Assert.assertTrue("Log message contains msg", s.contains(message.text()));
+		Assert.assertTrue("Log message contains throwable", s.contains(message.throwable().toString()));
+		Assert.assertTrue("Log message contains stack trace", s.contains(nameOfThisMethod));
 	}
+
+	@Test
+	public void testFormatMessageOptionalParameters() {
+		// setup
+		LogMessage message = new LogMessage(LogLevel.WARN, null, null);
+
+		// process
+		// Can it still format the message if optional parameters are null?
+		String s = logFormatter.format(message);
+
+		// test
+		Assert.assertTrue("Log message contains level", s.contains(LogLevel.prefix(message.level())));
+	}
+
+	// -- Helper methods --
+
+	private Throwable generateThrowableWithStackTrace() {
+		Throwable t;
+		try {
+			throw new NullPointerException();
+		}
+		catch (Throwable e) {
+			t = e;
+		}
+		return t;
+	}
+
 }

--- a/src/test/java/org/scijava/log/DefaultLogFormatterTest.java
+++ b/src/test/java/org/scijava/log/DefaultLogFormatterTest.java
@@ -47,7 +47,7 @@ public class DefaultLogFormatterTest {
 	public void testFormatMessage() {
 		String nameOfThisMethod = "testFormatMessage";
 		// setup
-		LogMessage message = new LogMessage(LogLevel.DEBUG, 42, generateThrowableWithStackTrace());
+		LogMessage message = new LogMessage(LogSource.root(), LogLevel.DEBUG, 42, generateThrowableWithStackTrace());
 		// process
 		String s = logFormatter.format(message);
 		//test
@@ -60,7 +60,7 @@ public class DefaultLogFormatterTest {
 	@Test
 	public void testFormatMessageOptionalParameters() {
 		// setup
-		LogMessage message = new LogMessage(LogLevel.WARN, null, null);
+		LogMessage message = new LogMessage(LogSource.root(), LogLevel.WARN, null, null);
 
 		// process
 		// Can it still format the message if optional parameters are null?

--- a/src/test/java/org/scijava/log/LogLevelStrategyTest.java
+++ b/src/test/java/org/scijava/log/LogLevelStrategyTest.java
@@ -33,6 +33,7 @@ package org.scijava.log;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Properties;
 
 import static org.junit.Assert.*;
@@ -74,7 +75,7 @@ public class LogLevelStrategyTest {
 	@Test
 	public void testClassLogLevel() {
 		final LogLevelStrategy log = new LogLevelStrategy();
-		log.setLevel(Dummy.class.getName(), LogLevel.ERROR);
+		log.setLevelForClass(Dummy.class.getName(), LogLevel.ERROR);
 		int level = Dummy.getLevel(log);
 		assertEquals(ERROR, level);
 	}
@@ -92,9 +93,31 @@ public class LogLevelStrategyTest {
 	@Test
 	public void testPackageLogLevel() {
 		final LogLevelStrategy log = new LogLevelStrategy();
-		log.setLevel("org.scijava.log", LogLevel.TRACE);
-		log.setLevel("xyz.foo.bar", LogLevel.ERROR);
+		log.setLevelForClass("org.scijava.log", LogLevel.TRACE);
+		log.setLevelForClass("xyz.foo.bar", LogLevel.ERROR);
 		int level = log.getLevel();
+		assertEquals(TRACE, level);
+	}
+
+	@Test
+	public void testSourceLogLevel() {
+		final LogLevelStrategy log = new LogLevelStrategy();
+		LogSource sourceA = LogSource.of(Arrays.asList("Hello", "World"));
+		LogSource sourceB = LogSource.of(Arrays.asList("foo", "bar"));
+		log.setLevelForLogger(sourceA, LogLevel.TRACE);
+		log.setLevelForLogger(sourceB, LogLevel.ERROR);
+		int level = log.getLevelForLogger(sourceA, LogLevel.NONE);
+		assertEquals(TRACE, level);
+	}
+	@Test
+
+	public void testSourceLogLevelViaProperties() {
+		Properties properties = new Properties();
+		properties.setProperty(LogService.LOG_LEVEL_BY_SOURCE_PROPERTY + ":Hello:World", "TRACE");
+		properties.setProperty(LogService.LOG_LEVEL_BY_SOURCE_PROPERTY + ":foo:bar", "ERROR");
+		final LogLevelStrategy log = new LogLevelStrategy(properties);
+		LogSource source = LogSource.of(Arrays.asList("Hello", "World"));
+		int level = log.getLevelForLogger(source, LogLevel.NONE);
 		assertEquals(TRACE, level);
 	}
 }

--- a/src/test/java/org/scijava/log/LogLevelStrategyTest.java
+++ b/src/test/java/org/scijava/log/LogLevelStrategyTest.java
@@ -1,0 +1,100 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.log;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+import static org.scijava.log.LogLevel.*;
+
+/**
+ * Tests {@link LogLevelStrategy}
+ * @author Matthias Arzt
+ */
+public class LogLevelStrategyTest {
+
+	@Test
+	public void testDefaultLevel() {
+		assertEquals(INFO, new LogLevelStrategy().getLevel());
+	}
+
+	@Test
+	public void testMainSystemProperty() {
+		Properties properties = new Properties();
+		properties.setProperty(LogService.LOG_LEVEL_PROPERTY, "error");
+		int level = new LogLevelStrategy(properties).getLevel();
+		assertEquals(ERROR, level);
+	}
+
+	@Test
+	public void testSetLevel() {
+		LogLevelStrategy log = new LogLevelStrategy();
+		log.setLevel(LogLevel.ERROR);
+		int level = log.getLevel();
+		assertEquals(ERROR, level);
+	}
+
+	static class Dummy {
+		public static int getLevel(LogLevelStrategy log) {
+			return log.getLevel();
+		}
+	}
+
+	@Test
+	public void testClassLogLevel() {
+		final LogLevelStrategy log = new LogLevelStrategy();
+		log.setLevel(Dummy.class.getName(), LogLevel.ERROR);
+		int level = Dummy.getLevel(log);
+		assertEquals(ERROR, level);
+	}
+
+	@Test
+	public void testClassLogLevelViaProperties() {
+		Properties properties = new Properties();
+		properties.setProperty(LogService.LOG_LEVEL_PROPERTY + ":" + Dummy.class.getName(), LogLevel.prefix(LogLevel.ERROR));
+		properties.setProperty(LogService.LOG_LEVEL_PROPERTY + ":" + LogLevelStrategyTest.class.getName(), LogLevel.prefix(LogLevel.ERROR));
+		final LogLevelStrategy log = new LogLevelStrategy(properties);
+		int level = Dummy.getLevel(log);
+		assertEquals(ERROR, level);
+	}
+
+	@Test
+	public void testPackageLogLevel() {
+		final LogLevelStrategy log = new LogLevelStrategy();
+		log.setLevel("org.scijava.log", LogLevel.TRACE);
+		log.setLevel("xyz.foo.bar", LogLevel.ERROR);
+		int level = log.getLevel();
+		assertEquals(TRACE, level);
+	}
+}

--- a/src/test/java/org/scijava/log/LogRecorderTest.java
+++ b/src/test/java/org/scijava/log/LogRecorderTest.java
@@ -1,0 +1,239 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.log;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Matthias Arzt
+ */
+public class LogRecorderTest {
+
+	private LogRecorder recorder;
+	private MyListener listener;
+
+	@Before
+	public void setup() {
+		recorder = new LogRecorder();
+		listener = new MyListener(recorder);
+	}
+
+	@Test
+	public void testLogMessageDelivery() {
+		recorder.clear();
+		LogMessage message = newLogMessage();
+		recorder.messageLogged(message);
+		assertEquals(Arrays.asList(message), listener.messages());
+	}
+
+	private LogMessage newLogMessage() {
+		return new LogMessage(LogSource.root(), LogLevel.INFO, "Hello World!");
+	}
+
+	@Test
+	public void testStreamMessageDelivery() {
+		listener.clear();
+		String message = "Hello World!\n";
+		recorder.printStream("").print(message);
+		assertTrue(listener.lines().contains(message));
+	}
+
+	@Test
+	public void testStreamMessageDeliveryPrintLn() {
+		listener.clear();
+		String message = "Hello World!";
+		recorder.printStream("").println(message);
+		assertTrue(listener.lines().contains(message + "\n"));
+	}
+
+	@Test
+	public void testStreamMessageDeliveryMultiLine() {
+		listener.clear();
+		String line1 = "Hello\n";
+		String line2 = "World!\n";
+		String line3 = "foo bar";
+		recorder.printStream("").print(line1 + line2 + line3);
+		assertEquals(Arrays.asList(line1, line2, line3), listener.lines());
+	}
+
+	@Test
+	public void testSplittedLine() {
+		listener.clear();
+		String part1 = "Hello ";
+		String part2 = "World!\n";
+		PrintStream stream = recorder.printStream("");
+		stream.print(part1);
+		assertEquals(Arrays.asList(part1), listener.lines());
+		stream.print(part2);
+		assertEquals(Arrays.asList(part1, part1 + part2), listener.lines());
+	}
+
+	@Test
+	public void testReadOldLog() {
+		LogRecorder recorder = new LogRecorder();
+		LogMessage message = newLogMessage();
+		recorder.messageLogged(message);
+		assertEquals(Arrays.asList(message), recorder.stream().collect(Collectors
+			.toList()));
+	}
+
+	@Test
+	public void testReadOldLine() {
+		LogRecorder recorder = new LogRecorder();
+		String text = "Hello World!";
+		recorder.printStream("").println(text);
+		assertEquals(Arrays.asList(text + "\n"), recordedLines(recorder));
+	}
+
+	@Test
+	public void testReadOldIncompleteLine() {
+		LogRecorder recorder = new LogRecorder();
+		recorder.printStream("").print("Hello");
+		assertEquals(Arrays.asList("Hello"), recordedLines(recorder));
+	}
+
+	@Test
+	public void testReadOldIncompleteLines() {
+		LogRecorder recorder = new LogRecorder();
+		PrintStream stream = recorder.printStream("");
+		stream.print("Hello ");
+		stream.print("World!");
+		assertEquals(Arrays.asList("Hello World!"), recordedLines(recorder));
+	}
+
+	@Test
+	public void testReadMultipleStreams() {
+		LogRecorder recorder = new LogRecorder();
+		PrintStream streamA = recorder.printStream("A");
+		PrintStream streamB = recorder.printStream("B");
+		streamA.print("Hello ");
+		streamB.print("Hello ");
+		streamA.print("World!");
+		streamB.print("World!");
+		assertEquals(Arrays.asList("Hello World!", "Hello World!"), recordedLines(
+			recorder));
+	}
+
+	private List<String> recordedLines(LogRecorder recorder) {
+		return recorder.stream().filter(LogRecorder.TaggedLine.class::isInstance)
+			.map(LogRecorder.TaggedLine.class::cast).map(LogRecorder.TaggedLine::line)
+			.collect(Collectors.toList());
+	}
+
+	@Test
+	public void testUpdatedReading() {
+		// setup
+		LogRecorder recorder = new LogRecorder();
+		LogMessage msgA = newLogMessage();
+		LogMessage msgB = newLogMessage();
+		Iterator<Object> iterator = recorder.iterator();
+		// process & test
+		assertFalse(iterator.hasNext());
+		recorder.messageLogged(msgA);
+		assertTrue(iterator.hasNext());
+		assertSame(msgA, iterator.next());
+		assertFalse(iterator.hasNext());
+		recorder.messageLogged(msgB);
+		assertTrue(iterator.hasNext());
+		assertSame(msgB, iterator.next());
+	}
+
+	@Test
+	public void testUpdatedStream() {
+		// setup
+		LogRecorder recorder = new LogRecorder();
+		LogMessage msgA = newLogMessage();
+		LogMessage msgB = newLogMessage();
+		Iterator<Object> iterator = recorder.stream().iterator();
+		// process & test
+		assertFalse(iterator.hasNext());
+		recorder.messageLogged(msgA);
+		assertTrue(iterator.hasNext());
+		assertEquals(msgA, iterator.next());
+		assertFalse(iterator.hasNext());
+		recorder.messageLogged(msgB);
+		assertTrue(iterator.hasNext());
+		assertEquals(msgB, iterator.next());
+	}
+
+	private static class MyListener implements Runnable {
+
+		private final Iterator<Object> iterator;
+
+		private List<LogMessage> messages = new LinkedList<>();
+
+		private List<String> lines = new LinkedList<>();
+
+		private MyListener(LogRecorder recorder) {
+			this.iterator = recorder.iterator();
+			recorder.addObservers(this);
+		}
+
+		@Override
+		public void run() {
+			while (iterator.hasNext()) {
+				Object item = iterator.next();
+				if (item instanceof LogMessage) messages.add((LogMessage) item);
+				if (item instanceof LogRecorder.TaggedLine) lines.add(
+					((LogRecorder.TaggedLine) item).line());
+			}
+		}
+
+		public void clear() {
+			messages.clear();
+			lines.clear();
+		}
+
+		public List<LogMessage> messages() {
+			return messages;
+		}
+
+		public List<String> lines() {
+			return lines;
+		}
+
+	}
+
+}

--- a/src/test/java/org/scijava/log/LogServiceTest.java
+++ b/src/test/java/org/scijava/log/LogServiceTest.java
@@ -32,7 +32,7 @@
 package org.scijava.log;
 
 import static org.junit.Assert.assertTrue;
-import static org.scijava.log.LogService.WARN;
+import static org.scijava.log.LogLevel.WARN;
 
 import org.junit.Test;
 
@@ -46,6 +46,7 @@ public class LogServiceTest {
 	public void testDefaultLevel() {
 		final LogService log = new StderrLogService();
 		int level = log.getLevel();
-		assertTrue("default level (" + level + ") is at least INFO(" + WARN + ")", level >= WARN);
+		assertTrue("default level (" + level + //
+			") is at least INFO(" + WARN + ")", level >= WARN);
 	}
 }

--- a/src/test/java/org/scijava/log/LogSourceTest.java
+++ b/src/test/java/org/scijava/log/LogSourceTest.java
@@ -31,33 +31,59 @@
 
 package org.scijava.log;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 /**
- * Default implementation of {@link LogFormatter}
- *
- * @author Matthias Arzt
+ * Tests {@link LogSource}
  */
-public class DefaultLogFormatter implements LogFormatter {
+public class LogSourceTest {
 
-	@Override
-	public String format(LogMessage message) {
-		final StringWriter sw = new StringWriter();
-		final PrintWriter printer = new PrintWriter(sw);
-		printWithBrackets(printer, message.time().toString());
-		printWithBrackets(printer, LogLevel.prefix(message.level()));
-		printWithBrackets(printer, message.source().toString());
-		printer.println(message.text());
-		if (message.throwable() != null) message.throwable().printStackTrace(
-			printer);
-		return sw.toString();
+	@Test
+	public void testRoot() {
+		LogSource root = LogSource.root();
+		assertEquals(Collections.emptyList(), root.path());
+		assertEquals("", root.name());
+		assertTrue(root.isRoot());
 	}
 
-	private void printWithBrackets(PrintWriter printer, String prefix) {
-		printer.print('[');
-		printer.print(prefix);
-		printer.print("] ");
+	@Test
+	public void testRootIsUnique() {
+		LogSource a = LogSource.root();
+		LogSource b = LogSource.root();
+		assertSame(a, b);
+	}
+
+	@Test
+	public void testChildIsUnique() {
+		String name = "foo";
+		LogSource root = LogSource.root();
+		LogSource a = root.subSource(name);
+		LogSource b = root.subSource(name);
+		assertSame(a, b);
+	}
+
+	@Test
+	public void testOfIsUnique() {
+		List<String> path = Arrays.asList("foo", "bar");
+		LogSource a = LogSource.of(path);
+		LogSource b = LogSource.of(path);
+		assertSame(a, b);
+	}
+
+	@Test
+	public void testOf() {
+		List<String> path = Arrays.asList("foo", "bar");
+		LogSource source = LogSource.of(path);
+		assertEquals(path, source.path());
+		assertEquals("bar", source.name());
+		assertFalse(source.isRoot());
+		assertEquals("foo:bar", source.toString());
 	}
 
 }

--- a/src/test/java/org/scijava/log/LoggerPreprocessorTest.java
+++ b/src/test/java/org/scijava/log/LoggerPreprocessorTest.java
@@ -1,0 +1,78 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.log;
+
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.command.Command;
+import org.scijava.command.CommandModule;
+import org.scijava.command.CommandService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link LoggerPreprocessor}.
+ *
+ * @author Matthias Arzt
+ */
+public class LoggerPreprocessorTest {
+
+	@Test
+	public void testInjection() throws InterruptedException, ExecutionException {
+		final Context context = new Context(CommandService.class);
+		final CommandService commandService = context.service(CommandService.class);
+		final LogService logService = context.service(LogService.class);
+		final TestLogListener listener = new TestLogListener();
+		logService.addListener(listener);
+
+		final CommandModule module = //
+				commandService.run(CommandWithLogger.class, true).get();
+		assertTrue(listener.hasLogged(m -> m.source().path().contains(CommandWithLogger.class.getSimpleName())));
+	}
+
+	@Plugin(type = Command.class)
+	public static class CommandWithLogger implements Command {
+
+		@Parameter
+		public Logger log;
+
+		@Override
+		public void run() {
+			log.info("log from the command.");
+		}
+	}
+
+}

--- a/src/test/java/org/scijava/log/StderrLogServiceTest.java
+++ b/src/test/java/org/scijava/log/StderrLogServiceTest.java
@@ -34,19 +34,43 @@ package org.scijava.log;
 import static org.junit.Assert.assertTrue;
 import static org.scijava.log.LogLevel.WARN;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
 import org.junit.Test;
 
 /**
- * Tests {@link LogService}.
+ * Tests {@link StderrLogService}.
  * 
  * @author Johannes Schindelin
+ * @author Matthias Arzt
  */
-public class LogServiceTest {
+public class StderrLogServiceTest {
+
+	private final static String TEXT_1 = "Hello World!";
+	private static final String TEXT_2 = "foo bar";
+
 	@Test
 	public void testDefaultLevel() {
 		final LogService log = new StderrLogService();
 		int level = log.getLevel();
 		assertTrue("default level (" + level + //
 			") is at least INFO(" + WARN + ")", level >= WARN);
+	}
+
+	@Test
+	public void testOutputToStream() {
+		// setup
+		final StderrLogService logService = new StderrLogService();
+		final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		final PrintStream p = new PrintStream(outputStream);
+		logService.setPrintStreams(ignore -> p);
+
+		// process
+		logService.warn(TEXT_1);
+		logService.subLogger("sub").error(TEXT_2);
+
+		// test
+		assertTrue(outputStream.toString().contains(TEXT_1));
 	}
 }

--- a/src/test/java/org/scijava/log/TestLogListener.java
+++ b/src/test/java/org/scijava/log/TestLogListener.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,78 +31,33 @@
 
 package org.scijava.log;
 
-import org.scijava.service.AbstractService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
 
 /**
- * Base class for {@link LogService} implementations.
+ * TestLogListener is a {@ling LogListener} usable for testing. It stores all
+ * the LogMessages it receives and allows to test if any LogMessage fulfills a
+ * given predicate.
  *
- * @author Johannes Schindelin
- * @author Curtis Rueden
  * @author Matthias Arzt
  */
-@IgnoreAsCallingClass
-public abstract class AbstractLogService extends AbstractService implements
-	LogService
-{
 
-	private final ListenableLogger logger;
+class TestLogListener implements LogListener {
 
-	private final LogLevelStrategy logLevelStrategy = new LogLevelStrategy();
-
-	// -- constructor --
-
-	public AbstractLogService() {
-		logger = new DefaultListenableLogger(LogLevel.NONE) {
-
-			@Override
-			public int getLevel() {
-				return logLevelStrategy.getLevel();
-			}
-
-			@Override
-			protected void messageLogged(LogMessage message) {
-				super.messageLogged(message);
-				AbstractLogService.this.messageLogged(message);
-			}
-
-		};
-	}
-
-	// -- AbstractLogService methods --
-
-	abstract void messageLogged(LogMessage message);
-
-	// -- Logger methods --
+	List<LogMessage> messages = new ArrayList<>();
 
 	@Override
-	public void addListener(LogListener listener) {
-		logger.addListener(listener);
+	public void messageLogged(LogMessage message) {
+		messages.add(message);
 	}
 
-	@Override
-	public void removeListener(LogListener listener) {
-		logger.removeListener(listener);
+	public boolean hasLogged(Predicate<LogMessage> predicate) {
+		return messages.stream().anyMatch(predicate);
 	}
 
-	// -- Logger methods --
-
-	@Override
-	public int getLevel() {
-		return logLevelStrategy.getLevel();
+	public void clear() {
+		messages.clear();
 	}
 
-	@Override
-	public void setLevel(final int level) {
-		logLevelStrategy.setLevel(level);
-	}
-
-	@Override
-	public void setLevel(String classOrPackageName, final int level) {
-		logLevelStrategy.setLevel(classOrPackageName, level);
-	}
-
-	@Override
-	public void alwaysLog(final int level, final Object msg, final Throwable t) {
-		logger.alwaysLog(level, msg, t);
-	}
 }


### PR DESCRIPTION
Proposals concerning pull request https://github.com/scijava/scijava-common/pull/253:
* Don't publish stdout/stderr to log channels, log messages and stream are too different in their concepts.
* Refactoring: Use CopyOnWriteArrayList to manage LogListeners, extract LogFormatter from StderrLogService, make LogLevel an enum.
* Make DefaultLogService::channel(String name) thread safe
* Add the ability to listen to all log channels at once. Use this in StderrLogService.