### PR TITLE
Modify cancast

### DIFF
--- a/src/main/java/org/scijava/util/ConversionUtils.java
+++ b/src/main/java/org/scijava/util/ConversionUtils.java
@@ -97,13 +97,34 @@ public class ConversionUtils {
 	}
 
 	/**
-	 * Checks whether objects of the given class can be cast to the specified
-	 * type.
-	 *
+	 * Checks whether objects of the given class can be assigned to the specified
+	 * type. Unlike {@link Class#isAssignableFrom(Class)}, this method considers
+	 * auto-unboxing.
+	 * 
 	 * @return true If the destination class is assignable from the source one, or
 	 *         if the source class is null and destination class is non-null.
-	 * @see #cast(Object, Class)
 	 */
+	public static boolean canAssign(final Class<?> src, final Class<?> dest) {
+		return canCast(src, dest);
+	}
+
+	/**
+	 * Checks whether the given object can be assigned to the specified type.
+	 * Unlike {@link Class#isAssignableFrom(Class)}, this method considers
+	 * auto-unboxing.
+	 * 
+	 * @return true If the destination class is assignable from the source
+	 *         object's class, or if the source object is null and destionation
+	 *         class is non-null.
+	 */
+	public static boolean canAssign(final Object src, final Class<?> dest) {
+		return canCast(src, dest);
+	}
+
+	/**
+	 * @deprecated use {@link #canAssign(Class, Class)} instead
+	 */
+	@Deprecated
 	public static boolean canCast(final Class<?> src, final Class<?> dest) {
 		if (dest == null) return false;
 		if (src == null) return true;
@@ -113,13 +134,9 @@ public class ConversionUtils {
 	}
 
 	/**
-	 * Checks whether the given object can be cast to the specified type.
-	 *
-	 * @return true If the destination class is assignable from the source
-	 *         object's class, or if the source object is null and destionation
-	 *         class is non-null.
-	 * @see #cast(Object, Class)
+	 * @deprecated use {@link #canAssign(Object, Class)} instead
 	 */
+	@Deprecated
 	public static boolean canCast(final Object src, final Class<?> dest) {
 		if (dest == null) return false;
 		return src == null || canCast(src.getClass(), dest);

--- a/src/main/java/org/scijava/util/ConversionUtils.java
+++ b/src/main/java/org/scijava/util/ConversionUtils.java
@@ -106,7 +106,10 @@ public class ConversionUtils {
 	 */
 	public static boolean canCast(final Class<?> src, final Class<?> dest) {
 		if (dest == null) return false;
-		return src == null || dest.isAssignableFrom(src);
+		if (src == null) return true;
+		final Class<?> saneSrc = getNonprimitiveType(src);
+		final Class<?> saneDest = getNonprimitiveType(dest);
+		return saneDest.isAssignableFrom(saneSrc);
 	}
 
 	/**

--- a/src/test/java/org/scijava/convert/ConvertServiceTest.java
+++ b/src/test/java/org/scijava/convert/ConvertServiceTest.java
@@ -500,6 +500,22 @@ public class ConvertServiceTest {
 
 	/**
 	 * Test behavior when setting a single element field with a constructor that
+	 * accepts a primitive type (int).
+	 */
+	@Test
+	public void testLegitimateSingletonInt() {
+		class Struct {
+			
+			private IntWrapper intWrapper;
+		}
+		final Struct struct = new Struct();
+		
+		setFieldValue(struct, "intWrapper", Integer.valueOf(12));
+		assertNotNull(struct.intWrapper);
+	}
+
+	/**
+	 * Test behavior when setting a single element field with a constructor that
 	 * accepts a primitive array.
 	 */
 	@Test
@@ -626,6 +642,18 @@ public class ConvertServiceTest {
 	 */
 	private static interface INumberList extends List<Number> {
 		// NB: No implementation needed.
+	}
+
+	/**
+	 * Dummy class with an int constructor to ensure that when converting using
+	 * constructors, auto-unboxing should work as expected.
+	 */
+	public static class IntWrapper {
+		
+		@SuppressWarnings("unused")
+		public IntWrapper(final int gonnaWrapThisInt) {
+			// nothing to do
+		}
 	}
 
 	/**

--- a/src/test/java/org/scijava/util/ConversionUtilsTest.java
+++ b/src/test/java/org/scijava/util/ConversionUtilsTest.java
@@ -73,9 +73,8 @@ public class ConversionUtilsTest {
 		assertFalse(ConversionUtils.canCast(double.class, float.class));
 		assertFalse(ConversionUtils.canCast(float.class, double.class));
 
-		// boxing is not reported to work
-		// TODO: Consider changing this behavior.
-		assertFalse(ConversionUtils.canCast(int.class, Number.class));
+		// check casting with boxing
+		assertTrue(ConversionUtils.canCast(int.class, Number.class));
 
 		// casting from null always works
 		final Class<?> nullClass = null;


### PR DESCRIPTION
canCast now supports auto-unboxing, and is renamed to canAssigned.

Auto-unboxing is important for conversion using constructors. For example, conversion from `Integer` to `IntType` was not working because the constructor of `IntType` only accepts `int` as parameter.

The renaming is because that this method does not allow "casting" between different primitive types, which is effectively assignment instead.