### PR TITLE
Ui console tweaks

### DIFF
--- a/src/main/java/org/scijava/ui/console/HeadlessArgument.java
+++ b/src/main/java/org/scijava/ui/console/HeadlessArgument.java
@@ -28,11 +28,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package org.scijava.console;
+package org.scijava.ui.console;
 
 import java.util.LinkedList;
 
 import org.scijava.Context;
+import org.scijava.console.AbstractConsoleArgument;
+import org.scijava.console.ConsoleArgument;
+import org.scijava.console.ConsoleService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.UIService;

--- a/src/main/java/org/scijava/ui/console/ShowUIArgument.java
+++ b/src/main/java/org/scijava/ui/console/ShowUIArgument.java
@@ -1,0 +1,83 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.scijava.ui.console;
+
+import java.util.LinkedList;
+
+import org.scijava.Gateway;
+import org.scijava.console.AbstractConsoleArgument;
+import org.scijava.console.ConsoleArgument;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.UIService;
+
+/**
+ * Handles the {@code --showUI} argument, which signals that the UI should be
+ * opened immediately.
+ * <p>
+ * This is useful for specifying later command line arguments to be handled
+ * <em>after</em> the UI is shown, since normally, all arguments are processed
+ * before showing the UI.
+ * </p>
+ *
+ * @author Curtis Rueden
+ * @see Gateway#launch(String[])
+ */
+@Plugin(type = ConsoleArgument.class)
+public class ShowUIArgument extends AbstractConsoleArgument {
+
+	@Parameter(required = false)
+	private UIService uiService;
+
+	// -- Constructor --
+
+	public ShowUIArgument() {
+		super(1, "--showUI");
+	}
+
+	// -- ConsoleArgument methods --
+
+	@Override
+	public void handle(final LinkedList<String> args) {
+		if (!supports(args)) return;
+
+		args.removeFirst(); // --showUI
+
+		uiService.showUI();
+	}
+	// -- Typed methods --
+
+	@Override
+	public boolean supports(final LinkedList<String> args) {
+		return uiService != null && super.supports(args);
+	}
+
+}

--- a/src/main/java/org/scijava/ui/console/UIArgument.java
+++ b/src/main/java/org/scijava/ui/console/UIArgument.java
@@ -43,6 +43,9 @@ import org.scijava.ui.UserInterface;
 
 /**
  * Handles the {@code --ui} command line argument.
+ * <p>
+ * This argument overrides the default user interface.
+ * </p>
  * 
  * @author Curtis Rueden
  */


### PR DESCRIPTION
This branch adds the `--showUI` console argument, which allows you to show the UI before other console arguments have been processed.

Thanks to @stelfrich for the idea; see [this Gitter log](https://gitter.im/imagej/imagej/archives/2017/02/09) for related discussion.