### PR TITLE
Add autocompletion framework

### DIFF
--- a/src/main/java/org/scijava/script/AbstractScriptLanguage.java
+++ b/src/main/java/org/scijava/script/AbstractScriptLanguage.java
@@ -31,6 +31,7 @@
 
 package org.scijava.script;
 
+import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 
 import org.scijava.plugin.AbstractRichPlugin;
@@ -72,11 +73,6 @@ public abstract class AbstractScriptLanguage extends AbstractRichPlugin
 		if (info != null) name = info.getName();
 		return name != null && !name.isEmpty() ? name : inferNameFromClassName();
 	}
-    
-    @Override
-    public AutoCompleter getAutoCompleter() {
-        return new DefaultAutoCompleter(getScriptEngine());
-    }
 
 	// -- Helper methods --
 

--- a/src/main/java/org/scijava/script/AdaptedScriptLanguage.java
+++ b/src/main/java/org/scijava/script/AdaptedScriptLanguage.java
@@ -31,6 +31,8 @@
 
 package org.scijava.script;
 
+import org.scijava.script.autocompletion.DefaultAutoCompleter;
+import org.scijava.script.autocompletion.AutoCompleter;
 import java.util.List;
 
 import javax.script.ScriptEngine;

--- a/src/main/java/org/scijava/script/ScriptLanguage.java
+++ b/src/main/java/org/scijava/script/ScriptLanguage.java
@@ -31,6 +31,7 @@
 
 package org.scijava.script;
 
+import org.scijava.script.autocompletion.AutoCompleter;
 import java.util.Collections;
 import java.util.List;
 
@@ -150,5 +151,7 @@ public interface ScriptLanguage extends ScriptEngineFactory, RichPlugin,
 	default String getEngineVersion() {
 		return "0.0";
 	}
+    
+	public AutoCompleter getAutoCompleter();
 
 }

--- a/src/main/java/org/scijava/script/ScriptLanguage.java
+++ b/src/main/java/org/scijava/script/ScriptLanguage.java
@@ -42,6 +42,7 @@ import org.scijava.module.Module;
 import org.scijava.plugin.Plugin;
 import org.scijava.plugin.RichPlugin;
 import org.scijava.plugin.SingletonPlugin;
+import org.scijava.script.autocompletion.DefaultAutoCompleter;
 import org.scijava.util.VersionUtils;
 
 /**
@@ -152,6 +153,8 @@ public interface ScriptLanguage extends ScriptEngineFactory, RichPlugin,
 		return "0.0";
 	}
     
-	public AutoCompleter getAutoCompleter();
+    default AutoCompleter getAutoCompleter() {
+        return new DefaultAutoCompleter(this);
+    }
 
 }

--- a/src/main/java/org/scijava/script/autocompletion/AbstractAutoCompleter.java
+++ b/src/main/java/org/scijava/script/autocompletion/AbstractAutoCompleter.java
@@ -30,15 +30,13 @@
  */
 package org.scijava.script.autocompletion;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
+import java.util.stream.Collectors;
 import javax.script.Bindings;
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
@@ -82,7 +80,12 @@ public abstract class AbstractAutoCompleter implements AutoCompleter {
             matches.addAll(this.engineVariablesCompleter(code, index, engine));
         }
 
-        // Sort matches alphabetcially
+        // Remove duplicates
+        matches.stream()
+                .distinct()
+                .collect(Collectors.toList());
+
+        // Sort alphabetcially
         Collections.sort(matches, new SortIgnoreCase());
 
         // Return results. For now we ignore index and startIndex.

--- a/src/main/java/org/scijava/script/autocompletion/AbstractAutoCompleter.java
+++ b/src/main/java/org/scijava/script/autocompletion/AbstractAutoCompleter.java
@@ -28,67 +28,40 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
+package org.scijava.script.autocompletion;
 
-package org.scijava.script;
-
-import javax.script.ScriptEngineFactory;
-
-import org.scijava.plugin.AbstractRichPlugin;
-import org.scijava.plugin.PluginInfo;
-import org.scijava.script.autocompletion.AutoCompleter;
-import org.scijava.script.autocompletion.DefaultAutoCompleter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import javax.script.ScriptEngine;
 
 /**
- * Abstract superclass for {@link ScriptLanguage} implementations.
- * <p>
- * This class implements dummy versions of {@link ScriptEngineFactory}'s methods
- * that are not needed by the SciJava scripting framework.
- * </p>
- * 
- * @author Johannes Schindelin
+ *
+ * @author Hadrien Mary
  */
-public abstract class AbstractScriptLanguage extends AbstractRichPlugin
-	implements ScriptLanguage
-{
+public abstract class AbstractAutoCompleter implements AutoCompleter {
 
-	// -- Object methods --
+    protected ScriptEngine engine = null;
 
-	@Override
-	public String toString() {
-		return getLanguageName();
-	}
-
-	// -- Default implementations --
-
-	@Override
-	public String getEngineName() {
-		return inferNameFromClassName();
-	}
-
-	@Override
-	public String getLanguageName() {
-		String name = null;
-		final PluginInfo<?> info = getInfo();
-		if (info != null) name = info.getName();
-		return name != null && !name.isEmpty() ? name : inferNameFromClassName();
-	}
-    
-    @Override
-    public AutoCompleter getAutoCompleter() {
-        return new DefaultAutoCompleter(getScriptEngine());
+    public AbstractAutoCompleter(ScriptEngine engine) {
+        this.engine = engine;
     }
 
-	// -- Helper methods --
+    @Override
+    public Map<String, Object> autocomplete(String code) {
+        return autocomplete(code, 0);
+    }
+    
+    @Override
+    public Map<String, Object> autocomplete(String code, int i) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("matches", new ArrayList<>());
+        result.put("startIndex", 0);
+        return result;
+    }
 
-	private String inferNameFromClassName() {
-		String className = getClass().getSimpleName();
-		if (className.endsWith("ScriptLanguage")) {
-			// strip off "ScriptLanguage" suffix
-			className = className.substring(0, className.length() - 14);
-		}
-		// replace underscores with spaces
-		className = className.replace('_', ' ');
-		return className;
-	}
-
+    @Override
+    public ScriptEngine getScriptEngine() {
+        return this.engine;
+    }
 }

--- a/src/main/java/org/scijava/script/autocompletion/AutoCompleter.java
+++ b/src/main/java/org/scijava/script/autocompletion/AutoCompleter.java
@@ -28,67 +28,20 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
+package org.scijava.script.autocompletion;
 
-package org.scijava.script;
-
-import javax.script.ScriptEngineFactory;
-
-import org.scijava.plugin.AbstractRichPlugin;
-import org.scijava.plugin.PluginInfo;
-import org.scijava.script.autocompletion.AutoCompleter;
-import org.scijava.script.autocompletion.DefaultAutoCompleter;
+import java.util.Map;
+import javax.script.ScriptEngine;
 
 /**
- * Abstract superclass for {@link ScriptLanguage} implementations.
- * <p>
- * This class implements dummy versions of {@link ScriptEngineFactory}'s methods
- * that are not needed by the SciJava scripting framework.
- * </p>
- * 
- * @author Johannes Schindelin
+ *
+ * @author Hadrien Mary
  */
-public abstract class AbstractScriptLanguage extends AbstractRichPlugin
-	implements ScriptLanguage
-{
+public interface AutoCompleter {
 
-	// -- Object methods --
+    public Map<String, Object> autocomplete(String code);
 
-	@Override
-	public String toString() {
-		return getLanguageName();
-	}
+    public Map<String, Object> autocomplete(String code, int i);
 
-	// -- Default implementations --
-
-	@Override
-	public String getEngineName() {
-		return inferNameFromClassName();
-	}
-
-	@Override
-	public String getLanguageName() {
-		String name = null;
-		final PluginInfo<?> info = getInfo();
-		if (info != null) name = info.getName();
-		return name != null && !name.isEmpty() ? name : inferNameFromClassName();
-	}
-    
-    @Override
-    public AutoCompleter getAutoCompleter() {
-        return new DefaultAutoCompleter(getScriptEngine());
-    }
-
-	// -- Helper methods --
-
-	private String inferNameFromClassName() {
-		String className = getClass().getSimpleName();
-		if (className.endsWith("ScriptLanguage")) {
-			// strip off "ScriptLanguage" suffix
-			className = className.substring(0, className.length() - 14);
-		}
-		// replace underscores with spaces
-		className = className.replace('_', ' ');
-		return className;
-	}
-
+    public ScriptEngine getScriptEngine();
 }

--- a/src/main/java/org/scijava/script/autocompletion/AutoCompleter.java
+++ b/src/main/java/org/scijava/script/autocompletion/AutoCompleter.java
@@ -30,7 +30,6 @@
  */
 package org.scijava.script.autocompletion;
 
-import java.util.Map;
 import javax.script.ScriptEngine;
 
 /**
@@ -39,9 +38,7 @@ import javax.script.ScriptEngine;
  */
 public interface AutoCompleter {
 
-    public Map<String, Object> autocomplete(String code);
+    public AutoCompletionResult autocomplete(String code, ScriptEngine engine);
 
-    public Map<String, Object> autocomplete(String code, int i);
-
-    public ScriptEngine getScriptEngine();
+    public AutoCompletionResult autocomplete(String code, int startIndex, ScriptEngine engine);
 }

--- a/src/main/java/org/scijava/script/autocompletion/AutoCompletionResult.java
+++ b/src/main/java/org/scijava/script/autocompletion/AutoCompletionResult.java
@@ -1,0 +1,36 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.scijava.script.autocompletion;
+
+import java.util.List;
+
+/**
+ *
+ * @author hadim
+ */
+public class AutoCompletionResult {
+
+    protected List<String> matches;
+    protected int startIndex;
+
+    public AutoCompletionResult(List<String> matches) {
+        this(matches, 0);
+    }
+
+    public AutoCompletionResult(List<String> matches, int startIndex) {
+        this.matches = matches;
+        this.startIndex = startIndex;
+    }
+
+    public int getStartIndex() {
+        return this.startIndex;
+    }
+
+    public List<String> getMatches() {
+        return this.matches;
+    }
+
+}

--- a/src/main/java/org/scijava/script/autocompletion/DefaultAutoCompleter.java
+++ b/src/main/java/org/scijava/script/autocompletion/DefaultAutoCompleter.java
@@ -30,7 +30,7 @@
  */
 package org.scijava.script.autocompletion;
 
-import javax.script.ScriptEngine;
+import org.scijava.script.ScriptLanguage;
 
 /**
  *
@@ -38,8 +38,8 @@ import javax.script.ScriptEngine;
  */
 public class DefaultAutoCompleter extends AbstractAutoCompleter {
 
-    public DefaultAutoCompleter(ScriptEngine engine) {
-        super(engine);
+    public DefaultAutoCompleter(ScriptLanguage scriptLanguage) {
+        super(scriptLanguage);
     }
 
 }

--- a/src/main/java/org/scijava/script/autocompletion/DefaultAutoCompleter.java
+++ b/src/main/java/org/scijava/script/autocompletion/DefaultAutoCompleter.java
@@ -28,67 +28,18 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
+package org.scijava.script.autocompletion;
 
-package org.scijava.script;
-
-import javax.script.ScriptEngineFactory;
-
-import org.scijava.plugin.AbstractRichPlugin;
-import org.scijava.plugin.PluginInfo;
-import org.scijava.script.autocompletion.AutoCompleter;
-import org.scijava.script.autocompletion.DefaultAutoCompleter;
+import javax.script.ScriptEngine;
 
 /**
- * Abstract superclass for {@link ScriptLanguage} implementations.
- * <p>
- * This class implements dummy versions of {@link ScriptEngineFactory}'s methods
- * that are not needed by the SciJava scripting framework.
- * </p>
- * 
- * @author Johannes Schindelin
+ *
+ * @author Hadrien Mary
  */
-public abstract class AbstractScriptLanguage extends AbstractRichPlugin
-	implements ScriptLanguage
-{
+public class DefaultAutoCompleter extends AbstractAutoCompleter {
 
-	// -- Object methods --
-
-	@Override
-	public String toString() {
-		return getLanguageName();
-	}
-
-	// -- Default implementations --
-
-	@Override
-	public String getEngineName() {
-		return inferNameFromClassName();
-	}
-
-	@Override
-	public String getLanguageName() {
-		String name = null;
-		final PluginInfo<?> info = getInfo();
-		if (info != null) name = info.getName();
-		return name != null && !name.isEmpty() ? name : inferNameFromClassName();
-	}
-    
-    @Override
-    public AutoCompleter getAutoCompleter() {
-        return new DefaultAutoCompleter(getScriptEngine());
+    public DefaultAutoCompleter(ScriptEngine engine) {
+        super(engine);
     }
-
-	// -- Helper methods --
-
-	private String inferNameFromClassName() {
-		String className = getClass().getSimpleName();
-		if (className.endsWith("ScriptLanguage")) {
-			// strip off "ScriptLanguage" suffix
-			className = className.substring(0, className.length() - 14);
-		}
-		// replace underscores with spaces
-		className = className.replace('_', ' ');
-		return className;
-	}
 
 }

--- a/src/test/java/org/scijava/script/ScriptEngineTest.java
+++ b/src/test/java/org/scijava/script/ScriptEngineTest.java
@@ -31,6 +31,8 @@
 
 package org.scijava.script;
 
+import org.scijava.script.autocompletion.DefaultAutoCompleter;
+import org.scijava.script.autocompletion.AutoCompleter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -99,6 +101,11 @@ public class ScriptEngineTest {
 		public List<String> getExtensions() {
 			return Arrays.asList("rot13");
 		}
+
+        @Override
+        public AutoCompleter getAutoCompleter() {
+            return new DefaultAutoCompleter(getScriptEngine());
+        }
 	}
 
 	private static class Rot13Engine extends AbstractScriptEngine {

--- a/src/test/java/org/scijava/script/ScriptEngineTest.java
+++ b/src/test/java/org/scijava/script/ScriptEngineTest.java
@@ -101,11 +101,6 @@ public class ScriptEngineTest {
 		public List<String> getExtensions() {
 			return Arrays.asList("rot13");
 		}
-
-        @Override
-        public AutoCompleter getAutoCompleter() {
-            return new DefaultAutoCompleter(getScriptEngine());
-        }
 	}
 
 	private static class Rot13Engine extends AbstractScriptEngine {

--- a/src/test/java/org/scijava/script/ScriptFinderTest.java
+++ b/src/test/java/org/scijava/script/ScriptFinderTest.java
@@ -31,6 +31,8 @@
 
 package org.scijava.script;
 
+import org.scijava.script.autocompletion.DefaultAutoCompleter;
+import org.scijava.script.autocompletion.AutoCompleter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -240,6 +242,11 @@ public class ScriptFinderTest {
 			// NB: Should never be called by the unit tests.
 			throw new IllegalStateException();
 		}
+
+        @Override
+        public AutoCompleter getAutoCompleter() {
+            return new DefaultAutoCompleter(getScriptEngine());
+        }
 
 	}
 

--- a/src/test/java/org/scijava/script/ScriptFinderTest.java
+++ b/src/test/java/org/scijava/script/ScriptFinderTest.java
@@ -243,11 +243,6 @@ public class ScriptFinderTest {
 			throw new IllegalStateException();
 		}
 
-        @Override
-        public AutoCompleter getAutoCompleter() {
-            return new DefaultAutoCompleter(getScriptEngine());
-        }
-
 	}
 
 }

--- a/src/test/java/org/scijava/script/ScriptInfoTest.java
+++ b/src/test/java/org/scijava/script/ScriptInfoTest.java
@@ -31,6 +31,8 @@
 
 package org.scijava.script;
 
+import org.scijava.script.autocompletion.DefaultAutoCompleter;
+import org.scijava.script.autocompletion.AutoCompleter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -285,6 +287,11 @@ public class ScriptInfoTest {
 		public List<String> getExtensions() {
 			return Arrays.asList("bsizes");
 		}
+
+        @Override
+        public AutoCompleter getAutoCompleter() {
+            return new DefaultAutoCompleter(getScriptEngine());
+        }
 	}
 
 	// -- Test script langauge --

--- a/src/test/java/org/scijava/script/ScriptInfoTest.java
+++ b/src/test/java/org/scijava/script/ScriptInfoTest.java
@@ -287,11 +287,6 @@ public class ScriptInfoTest {
 		public List<String> getExtensions() {
 			return Arrays.asList("bsizes");
 		}
-
-        @Override
-        public AutoCompleter getAutoCompleter() {
-            return new DefaultAutoCompleter(getScriptEngine());
-        }
 	}
 
 	// -- Test script langauge --


### PR DESCRIPTION
Add a framework for an autocompletion framework. Each scripting language is free to implement an `AutoCompleter` to provide autocompletion.

If they don't the default `AdaptedAutoCompleter` will just return no results when an autocompletion is asked.