### PR TITLE
Clarify missing input message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,10 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 
 		<!-- Third-party dependencies -->
 		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.googlecode.gentyref</groupId>
 			<artifactId>gentyref</artifactId>
 			<version>1.1.0</version>

--- a/src/main/java/org/scijava/widget/AbstractInputHarvester.java
+++ b/src/main/java/org/scijava/widget/AbstractInputHarvester.java
@@ -34,6 +34,8 @@ package org.scijava.widget;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.imglib2.img.Img;
+
 import org.scijava.AbstractContextual;
 import org.scijava.convert.ConvertService;
 import org.scijava.log.LogService;
@@ -119,8 +121,15 @@ public abstract class AbstractInputHarvester<P, W> extends AbstractContextual
 		}
 
 		if (item.isRequired()) {
-			throw new ModuleException("A " + type.getSimpleName() +
-				" is required but none exist.");
+			final String message;
+			if (Img.class.isAssignableFrom(type)) {
+				message = "An image is required, but there are none";
+			}
+			else {
+				message = String.join(" ", "An item of type", type.getSimpleName() +
+					"is required but none exist. ");
+			}
+			throw new ModuleException(message);
 		}
 
 		// item is not required; we can skip it


### PR DESCRIPTION
Make the message about missing inputs clearer in case of images. An ImagePlus won't be
considered an image, but referencing the class would create a circular dependency.