### PR TITLE
Add Tests to Ensure Proper Converter Chosen

### DIFF
--- a/src/main/java/org/scijava/convert/CastingConverter.java
+++ b/src/main/java/org/scijava/convert/CastingConverter.java
@@ -42,7 +42,7 @@ import org.scijava.util.GenericUtils;
  *
  * @author Mark Hiner
  */
-@Plugin(type = Converter.class, priority = Priority.FIRST)
+@Plugin(type = Converter.class, priority = Priority.EXTREMELY_HIGH)
 public class CastingConverter extends AbstractConverter<Object, Object> {
 
 	@SuppressWarnings("deprecation")

--- a/src/main/java/org/scijava/convert/DefaultConverter.java
+++ b/src/main/java/org/scijava/convert/DefaultConverter.java
@@ -80,15 +80,8 @@ public class DefaultConverter extends AbstractConverter<Object, Object> {
 
 	@Override
 	public <T> T convert(final Object src, final Class<T> dest) {
-		if (dest == null) return null;
-		if (src == null) return ConversionUtils.getNullValue(dest);
-
 		// ensure type is well-behaved, rather than a primitive type
 		final Class<T> saneDest = ConversionUtils.getNonprimitiveType(dest);
-
-		// cast the existing object, if possible
-		if (ConversionUtils.canCast(src, saneDest)) return ConversionUtils.cast(
-			src, saneDest);
 
 		// Handle array types
 		if (isArray(dest)) {
@@ -302,15 +295,9 @@ public class DefaultConverter extends AbstractConverter<Object, Object> {
 	@Override
 	@Deprecated
 	public boolean canConvert(final Class<?> src, final Class<?> dest) {
-
-		if (src == null || dest == null) return true;
-
 		// ensure type is well-behaved, rather than a primitive type
 		final Class<?> saneDest = ConversionUtils.getNonprimitiveType(dest);
-		
-		// OK if the existing object can be casted
-		if (ConversionUtils.canCast(src, saneDest)) return true;
-		
+
 		// OK for numerical conversions
 		if (ConversionUtils.canCast(ConversionUtils.getNonprimitiveType(src),
 			Number.class) &&

--- a/src/main/java/org/scijava/convert/DefaultConverter.java
+++ b/src/main/java/org/scijava/convert/DefaultConverter.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 import org.scijava.util.ArrayUtils;
 import org.scijava.util.ClassUtils;
@@ -55,7 +56,7 @@ import org.scijava.util.GenericUtils;
  *
  * @author Mark Hiner
  */
-@Plugin(type = Converter.class)
+@Plugin(type = Converter.class, priority = Priority.EXTREMELY_LOW)
 public class DefaultConverter extends AbstractConverter<Object, Object> {
 
 	// -- ConversionHandler methods --

--- a/src/main/java/org/scijava/convert/DefaultConverter.java
+++ b/src/main/java/org/scijava/convert/DefaultConverter.java
@@ -53,6 +53,20 @@ import org.scijava.util.GenericUtils;
 /**
  * Default {@link Converter} implementation. Provides useful conversion
  * functionality for many common conversion cases.
+ * <p>
+ * Supported conversions include:
+ * </p>
+ * <ul>
+ * <li>Object to Array</li>
+ * <li>Object to Collection</li>
+ * <li>Number to Number</li>
+ * <li>Object to String</li>
+ * <li>String to Character</li>
+ * <li>String to Enum</li>
+ * <li>Objects where the destination Class has a constructor which takes that
+ * Object
+ * </li>
+ * </ul>
  *
  * @author Mark Hiner
  */

--- a/src/main/java/org/scijava/convert/NullConverter.java
+++ b/src/main/java/org/scijava/convert/NullConverter.java
@@ -60,23 +60,24 @@ public class NullConverter extends AbstractConverter<Object, Object> {
 	@Override
 	public boolean canConvert(final ConversionRequest request) {
 		if (request == null) return false;
-		if (request.destType() == null && request.destClass() == null) return false;
-		return request.sourceObject() == null && request.sourceClass() == null;
+		return (request.destType() == null && request.destClass() == null) ||
+			(request.sourceObject() == null && request.sourceClass() == null);
 	}
 
 	@Override
 	public boolean canConvert(final Object src, final Type dest) {
-		return src == null && dest != null;
+		return src == null || dest == null;
 	}
 
 	@Override
 	public boolean canConvert(final Object src, final Class<?> dest) {
-		return src == null && dest != null;
+		return src == null || dest == null;
 	}
 
 	@Override
 	public boolean canConvert(final Class<?> src, final Class<?> dest) {
-		return src == null && dest != null;
+		if (src == null) return false;
+		return dest == null;
 	}
 
 	@Override

--- a/src/main/java/org/scijava/convert/NullConverter.java
+++ b/src/main/java/org/scijava/convert/NullConverter.java
@@ -40,8 +40,8 @@ import org.scijava.util.ConversionUtils;
 
 /**
  * {@link Converter} implementation for handling {@code null} values. Performs
- * basic casting when given a {@code null} source and returns {@code} null
- * directly when given a {@code} null destination.
+ * basic casting when given a {@code null} source and returns {@code null}
+ * directly when given a {@code null} destination.
  * <p>
  * By running at {@link Priority#FIRST}, other converters should
  * not need to worry about {@code null} source or destination parameters.

--- a/src/test/java/org/scijava/convert/ConvertServiceTest.java
+++ b/src/test/java/org/scijava/convert/ConvertServiceTest.java
@@ -147,7 +147,7 @@ public class ConvertServiceTest {
 	 */
 	@Test
 	public void testArrays() {
-		// Test that each primitive [] is compatible in either direciton with its
+		// Test that each primitive [] is compatible in either direction with its
 		// paired PrimitiveArray
 		testIntechangeable(int[].class, IntArray.class);
 		testIntechangeable(long[].class, LongArray.class);
@@ -157,7 +157,7 @@ public class ConvertServiceTest {
 		testIntechangeable(char[].class, CharArray.class);
 		testIntechangeable(boolean[].class, BoolArray.class);
 
-		// Test that primitive [] can not be convertied to mismatched PrimitiveArray
+		// Test that primitive [] can not be converted to mismatched PrimitiveArray
 		assertFalse(convertService.supports(int[].class, LongArray.class));
 
 		// Test that lists can be converted to any primitive []
@@ -883,7 +883,7 @@ public class ConvertServiceTest {
 	// -- Helper methods --
 
 	/**
-	 * Verify bi-direciotnal conversion is supported between the two classes
+	 * Verify bi-directional conversion is supported between the two classes
 	 */
 	private void testIntechangeable(final Class<?> c1, final Class<?> c2) {
 		assertTrue(convertService.supports(c1, c2));

--- a/src/test/java/org/scijava/convert/ConverterTest.java
+++ b/src/test/java/org/scijava/convert/ConverterTest.java
@@ -67,7 +67,7 @@ public class ConverterTest {
 		final NullConverter nc = new NullConverter();
 		assertFalse(nc.canConvert(Object.class, Object.class));
 		assertFalse(nc.canConvert(Object.class, (Type) Object.class));
-		assertTrue(nc.canConvert((Class<?>) null, Object.class));
+		assertFalse(nc.canConvert((Class<?>) null, Object.class));
 		assertTrue(nc.canConvert((Object) null, Object.class));
 		assertTrue(nc.canConvert((ConverterTest) null, ArrayList.class));
 		assertNull(nc.convert((Object) null, Object.class));

--- a/src/test/java/org/scijava/convert/ConverterTest.java
+++ b/src/test/java/org/scijava/convert/ConverterTest.java
@@ -94,11 +94,11 @@ public class ConverterTest {
 
 	@Test
 	public void testCanConvertToGenericCollection() {
-		final DefaultConverter dc = new DefaultConverter();
+		final CastingConverter cc = new CastingConverter();
 
 		final Field destField = ClassUtils.getField(getClass(), "collection");
 		final Type destType = GenericUtils.getFieldType(destField, getClass());
-		assertTrue(dc.canConvert(ArrayList.class, destType));
+		assertTrue(cc.canConvert(ArrayList.class, destType));
 	}
 
 	private static class NumberConverter extends AbstractConverter<Number, Number> {


### PR DESCRIPTION
Hello,

This branch makes the following changes:
* Switches `DefaultConverter` to `VERY_LOW_PRIORITY - 1000`, `NullConverter` to `VERY_HIGH_PRIORITY + 1000`, and `CastingConverter` to `VERY_HIGH_PRIORITY`
* Adds down the middle tests to ensure basic converters are matched appropriately
* Fixes the `NullConverter` to handle both `null` source and destination
* Removes redundant functionality from `DefaultConverter`

Question:
* Do we want the `NullConverter` to accept `null` for destination `Class` or `Type`?

I simply made the `NullConverter` do what its javadoc says it should do. Previously, it did not support `null` destination parameters and instead all requests with `null` destination parameters fell to the `DefaultConverter` which handled them. 

Below is just a list of conversions that should be handled by the `DefaultConverter` and some of the oddities I noticed with it.
* Object to Array
   * While it could handle SciJava Arrays to primitive arrays, it shouldn't since there are converters for that which are a higher priority
* Object to parameterized Collection
  * Provided the destination `Type` was an interface/abstract class which could be cast to `List` or `Set`, or it was a concrete `Type`
  * The below returns `null`, since `Collection<Number>` is an interface but cannot be cast to `List` or `Set`
```java
@SuppressWarnings("unused")
private Collection<Number> collection;

@Test
public void testDefaultConverterObjectToCollection() {
	final Field destField = ClassUtils.getField(getClass(), "collection");
	final Type destType = GenericUtils.getFieldType(destField, getClass());
	final Converter<?, ?> oc = convertService.getHandler(new Object(),
		destType);
	assertNull(oc);
}
``` 
* Number to Number
  * Though it will only handle the narrowing conversions, the `NumberToNumberConverter` handles widening conversions
* Object to String
* String to Character
* String to Enum
* Objects where the destination Class has a constructor which takes that Object

I added a short version of this list to the javadoc of `DefaultConverter`, to clarify what the `DefaultConverter` actually supports.

Please feel free to let me know if you have any questions/concerns regarding these changes, or if any additional changes are needed.

Thanks, 

Alison
