### PR TITLE
Add file list converters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>13.1.0</version>
+		<version>16.2.0</version>
 		<relativePath />
 	</parent>
 
@@ -172,6 +172,10 @@ Konstanz, and KNIME GmbH.</license.copyrightOwners>
 		</dependency>
 
 		<!-- Third-party dependencies -->
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>com.googlecode.gentyref</groupId>
 			<artifactId>gentyref</artifactId>

--- a/src/main/java/org/scijava/convert/FileListConverters.java
+++ b/src/main/java/org/scijava/convert/FileListConverters.java
@@ -1,0 +1,125 @@
+package org.scijava.convert;
+
+import com.google.common.base.Splitter;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+public class FileListConverters {
+	// -- String to File (list) converters --
+
+	@Plugin(type = Converter.class, priority = Priority.NORMAL)
+	public static class StringToFileConverter extends
+			AbstractConverter<String, File> {
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T convert(Object src, Class<T> dest) {
+			return (T) new File((String) src);
+		}
+
+		@Override
+		public Class<File> getOutputType() {
+			return File.class;
+		}
+
+		@Override
+		public Class<String> getInputType() {
+			return String.class;
+		}
+
+	}
+
+	@Plugin(type = Converter.class, priority = Priority.NORMAL)
+	public static class StringToFileArrayConverter extends
+			AbstractConverter<String, File[]> {
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T convert(Object src, Class<T> dest) {
+			// split string src only at non-quoted commas
+			// see https://stackoverflow.com/a/1757107/1919049
+			Iterable<String> list = Splitter.onPattern(
+					",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)").split((String) src);
+			List<File> fileList = new ArrayList<>();
+			for (String filePath : list) {
+				fileList.add(new File(filePath.replaceAll("^\"|\"$", "")));
+			}
+			return (T) fileList.toArray(new File[fileList.size()]);
+		}
+
+		@Override
+		public Class<File[]> getOutputType() {
+			return File[].class;
+		}
+
+		@Override
+		public Class<String> getInputType() {
+			return String.class;
+		}
+
+	}
+
+	// TODO add StringToFileListConverter
+
+	// -- File (list) to String converters --
+
+	@Plugin(type = Converter.class, priority = Priority.NORMAL)
+	public static class FileToStringConverter extends
+			AbstractConverter<File, String> {
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T convert(Object src, Class<T> dest) {
+			return (T) ((File) src).getAbsolutePath();
+		}
+
+		@Override
+		public Class<String> getOutputType() {
+			return String.class;
+		}
+
+		@Override
+		public Class<File> getInputType() {
+			return File.class;
+		}
+
+	}
+
+	@Plugin(type = Converter.class, priority = Priority.NORMAL)
+	public static class FileArrayToStringConverter extends
+			AbstractConverter<File[], String> {
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T convert(Object src, Class<T> dest) {
+			List<String> result = Arrays.asList((File[]) src)
+					.stream()
+					.map(f -> {
+						String path = f.getAbsolutePath();
+						return path.contains(",") ? "\"" + path + "\"": path;
+					})
+					.collect(Collectors.toList());
+			return (T) String.join(",", result);
+		}
+
+		@Override
+		public Class<String> getOutputType() {
+			return String.class;
+		}
+
+		@Override
+		public Class<File[]> getInputType() {
+			return File[].class;
+		}
+
+	}
+
+	// TODO add FileListToStringConverter
+}

--- a/src/main/java/org/scijava/module/DefaultModuleService.java
+++ b/src/main/java/org/scijava/module/DefaultModuleService.java
@@ -297,9 +297,7 @@ public class DefaultModuleService extends AbstractService implements
 			return;
 		}
 
-		// FIXME: Convert to string, instead of just calling toString.
-		// Otherwise many things (e.g. File[]) are persisted improperly.
-		final String sValue = value == null ? "" : value.toString();
+		final String sValue = value == null ? "" : convertService.convert(value, String.class);
 
 		// do not persist if object cannot be converted back from a string
 		if (!convertService.supports(sValue, item.getType())) return;

--- a/src/test/java/org/scijava/convert/FileListConverterTest.java
+++ b/src/test/java/org/scijava/convert/FileListConverterTest.java
@@ -1,0 +1,71 @@
+package org.scijava.convert;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.scijava.convert.FileListConverters.FileArrayToStringConverter;
+import org.scijava.convert.FileListConverters.FileToStringConverter;
+import org.scijava.convert.FileListConverters.StringToFileArrayConverter;
+import org.scijava.convert.FileListConverters.StringToFileConverter;
+
+public class FileListConverterTest {
+
+	@Test
+	public void testStringToFileConverter() {
+		final StringToFileConverter conv = new StringToFileConverter();
+		final String path = "C:\\temp\\f,i;l-ename.txt";
+		assertTrue("Cannot convert from String to File",
+				conv.canConvert(String.class, File.class));
+		assertFalse("Can erroneously convert from String to File[]",
+				conv.canConvert(String.class, File[].class));
+		assertEquals(new File(path),
+				conv.convert(path, File.class));
+	}
+
+	@Test
+	public void testStringToFileArrayConverter() {
+		final StringToFileArrayConverter conv = new StringToFileArrayConverter();
+		final String path = "\"C:\\temp\\f,i;l-ename.txt\",C:\\temp";
+		assertTrue("Cannot convert from String to File[]",
+				conv.canConvert(String.class, File[].class));
+		assertFalse("Can erroneously convert from String to File",
+				conv.canConvert(String.class, File.class));
+		assertEquals("Wrong array length", 2,
+				conv.convert(path, File[].class).length);
+		assertEquals("Wrong file name", new File("C:\\temp\\f,i;l-ename.txt"),
+				conv.convert(path, File[].class)[0]);
+		assertEquals("Wrong file name", new File("C:\\temp"),
+				conv.convert(path, File[].class)[1]);
+	}
+
+	@Test
+	public void testFileToStringConverter() {
+		final FileToStringConverter conv = new FileToStringConverter();
+		final File file = new File("C:\\temp\\f,i;l-ename.txt");
+		assertTrue("Cannot convert from File to String",
+				conv.canConvert(File.class, String.class));
+		assertFalse("Can erroneously convert from File[] to String",
+				conv.canConvert(File[].class, String.class));
+		assertEquals(file.getAbsolutePath(),
+				conv.convert(file, String.class));
+	}
+
+	@Test
+	public void testFileArrayToStringConverter() {
+		final FileArrayToStringConverter conv = new FileArrayToStringConverter();
+		final File[] fileArray = new File[2];
+		fileArray[0] = new File("C:\\temp\\f,i;l-ename.txt");
+		fileArray[1] = new File("C:\\temp");
+		final String expected = "\"" + fileArray[0].getAbsolutePath() + "\"," + fileArray[1].getAbsolutePath();
+		assertTrue("Cannot convert from File[] to String",
+				conv.canConvert(File[].class, String.class));
+		assertFalse("Can erroneously convert from File to String",
+				conv.canConvert(File.class, String.class));
+		assertEquals("Wrong output string", expected,
+				conv.convert(fileArray, String.class));
+	}
+}


### PR DESCRIPTION
This PR builds on top of https://github.com/scijava/scijava-common/pull/276.

It will allow to correctly persist values from module inputs of type `File[]` that are stored in a comma-separated (and optionally quoted) `String` values.

Note that this introduces a new dependency on Google Guava.