### PR TITLE
Improved file inputs for scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>13.1.0</version>
+		<version>17.0.0</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/org/scijava/convert/FileListConverters.java
+++ b/src/main/java/org/scijava/convert/FileListConverters.java
@@ -1,0 +1,162 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, University of
+ * Konstanz, and KNIME GmbH.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.convert;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+import org.scijava.util.StringUtils;
+
+/**
+ * A collection of {@link Converter} plugins for going between {@link String},
+ * {@link File} and {@code File[]}.
+ *
+ * @author Jan Eglinger
+ * @author Curtis Rueden
+ */
+public class FileListConverters {
+	// -- String to File (list) converters --
+
+	@Plugin(type = Converter.class, priority = Priority.NORMAL)
+	public static class StringToFileConverter extends
+		AbstractConverter<String, File>
+	{
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T convert(final Object src, final Class<T> dest) {
+			return (T) new File((String) src);
+		}
+
+		@Override
+		public Class<File> getOutputType() {
+			return File.class;
+		}
+
+		@Override
+		public Class<String> getInputType() {
+			return String.class;
+		}
+
+	}
+
+	@Plugin(type = Converter.class, priority = Priority.NORMAL)
+	public static class StringToFileArrayConverter extends
+		AbstractConverter<String, File[]>
+	{
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T convert(final Object src, final Class<T> dest) {
+			final String[] tokens = StringUtils.splitUnquoted((String) src, ",");
+			final List<File> fileList = new ArrayList<>();
+			for (final String filePath : tokens) {
+				fileList.add(new File(filePath.replaceAll("^\"|\"$", "")));
+			}
+			return (T) fileList.toArray(new File[fileList.size()]);
+		}
+
+		@Override
+		public Class<File[]> getOutputType() {
+			return File[].class;
+		}
+
+		@Override
+		public Class<String> getInputType() {
+			return String.class;
+		}
+
+	}
+
+	// TODO add StringToFileListConverter
+
+	// -- File (list) to String converters --
+
+	@Plugin(type = Converter.class, priority = Priority.NORMAL)
+	public static class FileToStringConverter extends
+		AbstractConverter<File, String>
+	{
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T convert(final Object src, final Class<T> dest) {
+			return (T) ((File) src).getAbsolutePath();
+		}
+
+		@Override
+		public Class<String> getOutputType() {
+			return String.class;
+		}
+
+		@Override
+		public Class<File> getInputType() {
+			return File.class;
+		}
+
+	}
+
+	@Plugin(type = Converter.class, priority = Priority.NORMAL)
+	public static class FileArrayToStringConverter extends
+		AbstractConverter<File[], String>
+	{
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T convert(final Object src, final Class<T> dest) {
+			final List<String> result = Arrays.asList((File[]) src).stream().map(
+				f -> {
+					final String path = f.getAbsolutePath();
+					return path.contains(",") ? "\"" + path + "\"" : path;
+				}).collect(Collectors.toList());
+			return (T) String.join(",", result);
+		}
+
+		@Override
+		public Class<String> getOutputType() {
+			return String.class;
+		}
+
+		@Override
+		public Class<File[]> getInputType() {
+			return File[].class;
+		}
+
+	}
+
+	// TODO add FileListToStringConverter
+}

--- a/src/main/java/org/scijava/module/DefaultModuleService.java
+++ b/src/main/java/org/scijava/module/DefaultModuleService.java
@@ -297,9 +297,7 @@ public class DefaultModuleService extends AbstractService implements
 			return;
 		}
 
-		// FIXME: Convert to string, instead of just calling toString.
-		// Otherwise many things (e.g. File[]) are persisted improperly.
-		final String sValue = value == null ? "" : value.toString();
+		final String sValue = value == null ? "" : convertService.convert(value, String.class);
 
 		// do not persist if object cannot be converted back from a string
 		if (!convertService.supports(sValue, item.getType())) return;

--- a/src/main/java/org/scijava/ui/DefaultUIService.java
+++ b/src/main/java/org/scijava/ui/DefaultUIService.java
@@ -321,15 +321,15 @@ public final class DefaultUIService extends AbstractService implements
 	}
 
 	@Override
-	public File[] chooseFiles(File[] files, FileFilter filter) {
+	public File[] chooseFiles(File parent, File[] files, FileFilter filter, String style) {
 		final UserInterface ui = getDefaultUI();
-		return ui == null ? null : ui.chooseFiles(files, filter);
+		return ui == null ? null : ui.chooseFiles(parent, files, filter, style);
 	}
 	
 	@Override
-	public List<File> chooseFiles(List<File> fileList, FileFilter filter) {
+	public List<File> chooseFiles(File parent, List<File> fileList, FileFilter filter, String style) {
 		final UserInterface ui = getDefaultUI();
-		return ui == null ? null : ui.chooseFiles(fileList, filter);
+		return ui == null ? null : ui.chooseFiles(parent, fileList, filter, style);
 	}
 
 	@Override

--- a/src/main/java/org/scijava/ui/FileListPreprocessor.java
+++ b/src/main/java/org/scijava/ui/FileListPreprocessor.java
@@ -56,7 +56,9 @@ public class FileListPreprocessor extends AbstractPreprocessorPlugin {
 		final File[] files = fileInput.getValue(module);
 
 		// show file chooser dialog box
-		final File[] result = uiService.chooseFiles(files, null);
+		// TODO decide how to create filter from style attributes
+		// TODO retrieve parent folder??
+		final File[] result = uiService.chooseFiles(null, files, null, fileInput.getWidgetStyle());
 		if (result == null) {
 			cancel("");
 			return;

--- a/src/main/java/org/scijava/ui/UIService.java
+++ b/src/main/java/org/scijava/ui/UIService.java
@@ -304,7 +304,7 @@ public interface UIService extends SciJavaService {
 	 * @param files The initial value displayed in the file chooser prompt.
 	 * @param filter A filter allowing to restrict the choice of files
 	 */
-	File[] chooseFiles(File[] files, FileFilter filter);
+	File[] chooseFiles(File parent, File[] files, FileFilter filter, String style);
 
 	/**
 	 * Prompts the user to select one or multiple files.
@@ -315,7 +315,7 @@ public interface UIService extends SciJavaService {
 	 * @param fileList The initial value displayed in the file chooser prompt.
 	 * @param filter A filter allowing to restrict the choice of files
 	 */
-	List<File> chooseFiles(List<File> fileList, FileFilter filter);
+	List<File> chooseFiles(File parent, List<File> fileList, FileFilter filter, String style);
 
 	/**
 	 * Displays a popup context menu for the given display at the specified

--- a/src/main/java/org/scijava/ui/UserInterface.java
+++ b/src/main/java/org/scijava/ui/UserInterface.java
@@ -191,26 +191,30 @@ public interface UserInterface extends RichPlugin, Disposable {
 	/**
 	 * Prompts the user to choose a list of files.
 	 *
+	 * @param parent Parent folder for file selection
 	 * @param files The initial value displayed in the file chooser prompt.
 	 * @param filter A filter allowing to restrict file choice.
+	 * @param style File selection style (files, directories, or both) and optional filters
 	 * @return The selected {@link File}s chosen by the user, or null if the
 	 *         user cancels the prompt.
 	 */
-	default File[] chooseFiles(File[] files, FileFilter filter) {
+	default File[] chooseFiles(File parent, File[] files, FileFilter filter, String style) {
 		throw new UnsupportedOperationException();
 	}
 
 	/**
 	 * Prompts the user to choose a list of files.
 	 *
+	 * @param parent Parent folder for file selection
 	 * @param fileList The initial value displayed in the file chooser prompt.
 	 * @param filter A filter allowing to restrict file choice.
+	 * @param style File selection style (files, directories, or both) and optional filters
 	 * @return The selected {@link File}s chosen by the user, or null if the
 	 *         user cancels the prompt.
 	 */
-	default List<File> chooseFiles(List<File> fileList, FileFilter filter) {
+	default List<File> chooseFiles(File parent, List<File> fileList, FileFilter filter, String style) {
 		final File[] initialFiles = fileList.toArray(new File[fileList.size()]);
-		final File[] chosenFiles = chooseFiles(initialFiles, filter);
+		final File[] chosenFiles = chooseFiles(parent, initialFiles, filter, style);
 		return chosenFiles == null ? null : Arrays.asList(chosenFiles);
 	}
 

--- a/src/main/java/org/scijava/util/StringUtils.java
+++ b/src/main/java/org/scijava/util/StringUtils.java
@@ -63,6 +63,7 @@ package org.scijava.util;
 
 import java.io.File;
 import java.text.DecimalFormatSymbols;
+import java.util.regex.Pattern;
 
 /**
  * Useful methods for working with {@link String}s.
@@ -78,6 +79,16 @@ public final class StringUtils {
 
 	private StringUtils() {
 		// NB: prevent instantiation of utility class.
+	}
+
+	/**
+	 * Splits a string only at separators outside of quotation marks ({@code "}).
+	 * Does not handle escaped quotes.
+	 */
+	public static String[] splitUnquoted(final String s, final String separator) {
+		// See https://stackoverflow.com/a/1757107/1919049
+		return s.split(Pattern.quote(separator) +
+			"(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", -1);
 	}
 
 	/** Normalizes the decimal separator for the user's locale. */

--- a/src/main/java/org/scijava/widget/FileListWidget.java
+++ b/src/main/java/org/scijava/widget/FileListWidget.java
@@ -34,5 +34,24 @@ package org.scijava.widget;
 import java.io.File;
 
 public interface FileListWidget<U> extends InputWidget<File[], U> {
-	// NB: No changes to interface.
+	/**
+	 * Widget style to allow file selection only
+	 * 
+	 * @see org.scijava.plugin.Parameter#style()
+	 */
+	String FILES_ONLY = "files";
+
+	/**
+	 * Widget style to allow directory selection only
+	 * 
+	 * @see org.scijava.plugin.Parameter#style()
+	 */
+	String DIRECTORIES_ONLY = "directories";
+
+	/**
+	 * Widget style to allow selection of both files and directories
+	 * 
+	 * @see org.scijava.plugin.Parameter#style()
+	 */
+	String FILES_AND_DIRECTORIES = "both";
 }

--- a/src/test/java/org/scijava/convert/FileListConverterTest.java
+++ b/src/test/java/org/scijava/convert/FileListConverterTest.java
@@ -1,0 +1,103 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, University of
+ * Konstanz, and KNIME GmbH.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.convert;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.scijava.convert.FileListConverters.FileArrayToStringConverter;
+import org.scijava.convert.FileListConverters.FileToStringConverter;
+import org.scijava.convert.FileListConverters.StringToFileArrayConverter;
+import org.scijava.convert.FileListConverters.StringToFileConverter;
+
+public class FileListConverterTest {
+
+	@Test
+	public void testStringToFileConverter() {
+		final StringToFileConverter conv = new StringToFileConverter();
+		final String path = "C:\\temp\\f,i;l-ename.txt";
+		assertTrue("Cannot convert from String to File",
+				conv.canConvert(String.class, File.class));
+		assertFalse("Can erroneously convert from String to File[]",
+				conv.canConvert(String.class, File[].class));
+		assertEquals(new File(path),
+				conv.convert(path, File.class));
+	}
+
+	@Test
+	public void testStringToFileArrayConverter() {
+		final StringToFileArrayConverter conv = new StringToFileArrayConverter();
+		final String path = "\"C:\\temp\\f,i;l-ename.txt\",C:\\temp";
+		assertTrue("Cannot convert from String to File[]",
+				conv.canConvert(String.class, File[].class));
+		assertFalse("Can erroneously convert from String to File",
+				conv.canConvert(String.class, File.class));
+		assertEquals("Wrong array length", 2,
+				conv.convert(path, File[].class).length);
+		assertEquals("Wrong file name", new File("C:\\temp\\f,i;l-ename.txt"),
+				conv.convert(path, File[].class)[0]);
+		assertEquals("Wrong file name", new File("C:\\temp"),
+				conv.convert(path, File[].class)[1]);
+	}
+
+	@Test
+	public void testFileToStringConverter() {
+		final FileToStringConverter conv = new FileToStringConverter();
+		final File file = new File("C:\\temp\\f,i;l-ename.txt");
+		assertTrue("Cannot convert from File to String",
+				conv.canConvert(File.class, String.class));
+		assertFalse("Can erroneously convert from File[] to String",
+				conv.canConvert(File[].class, String.class));
+		assertEquals(file.getAbsolutePath(),
+				conv.convert(file, String.class));
+	}
+
+	@Test
+	public void testFileArrayToStringConverter() {
+		final FileArrayToStringConverter conv = new FileArrayToStringConverter();
+		final File[] fileArray = new File[2];
+		fileArray[0] = new File("C:\\temp\\f,i;l-ename.txt");
+		fileArray[1] = new File("C:\\temp");
+		final String expected = "\"" + fileArray[0].getAbsolutePath() + "\"," + fileArray[1].getAbsolutePath();
+		assertTrue("Cannot convert from File[] to String",
+				conv.canConvert(File[].class, String.class));
+		assertFalse("Can erroneously convert from File to String",
+				conv.canConvert(File.class, String.class));
+		assertEquals("Wrong output string", expected,
+				conv.convert(fileArray, String.class));
+	}
+}

--- a/src/test/java/org/scijava/util/StringUtilsTest.java
+++ b/src/test/java/org/scijava/util/StringUtilsTest.java
@@ -32,6 +32,7 @@
 
 package org.scijava.util;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -46,6 +47,21 @@ import org.junit.Test;
  * @author Richard Domander (Royal Veterinary College, London)
  */
 public class StringUtilsTest {
+
+	/** Tests {@link StringUtils#splitUnquoted}. */
+	@Test
+	public void testSplitUnquoted() {
+		// See https://stackoverflow.com/a/1757107/1919049
+		final String line = "foo,bar,c;qual=\"baz,blurb\",d;junk=\"quux,syzygy\"";
+		final String[] expected = {
+			"foo",
+			"bar",
+			"c;qual=\"baz,blurb\"",
+			"d;junk=\"quux,syzygy\""
+		};
+		final String[] actual = StringUtils.splitUnquoted(line, ",");
+		assertArrayEquals(expected, actual);
+	}
 
 	@Test
 	public void isNullOrEmptyFalseIfString() throws Exception {


### PR DESCRIPTION
This PR supersedes https://github.com/scijava/scijava-common/pull/276 and https://github.com/scijava/scijava-common/pull/285. (I created a new one because I made further changes to the `chooseFiles` method signature that can be discussed here.)

Together with the changes in https://github.com/scijava/scijava-ui-swing/compare/master...imagejan:file-input-enhanced and https://github.com/imagej/imagej-legacy/compare/master...imagejan:file-input-enhanced, this renders `File[]` inputs possible to be resolved interactively:

* Single inputs of type `File[]` will open a file chooser that allows multiple files/directories to be opened.
* When combined with other script parameters, a list widget is created, e.g. the following Groovy script will show the input dialog shown below:

  ```groovy
  #@ File[] (label = "Input files", style = "files,extensions:tif/png/jpg") fileList
  #@ String (label = "Other parameter") stringInput

  fileList.each {
  	println "$it is being processed."
  }
  ```

  ![image](https://user-images.githubusercontent.com/2033938/28659094-716f9b10-72ae-11e7-89e5-f9854432ee56.png)

* A simple filter for file extensions can be created via `style` attributes as shown in the example (keyword `extensions` followed by `:` and the desired extensions separated by `/`).
* Both `File` and `File[]` input widgets are now drag-and-drop targets.
* Double-clicking an item on the file list removes it from the list.

@ctrueden if you happen to have a look, feel free to force push changes to the `file-input-enhanced` branch on my fork (I checked *Allow edits from maintainers*, so you should be able to push to my fork?!). I'll be mostly offline next week, but would love to hear/read your opinion when I'm back in the office on August 7.