### PR TITLE
ConsoleService: initialize MultiplePrintStream correctly, add bypass

### DIFF
--- a/src/main/java/org/scijava/console/DefaultConsoleService.java
+++ b/src/main/java/org/scijava/console/DefaultConsoleService.java
@@ -33,7 +33,6 @@
 package org.scijava.console;
 
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -66,7 +65,6 @@ public class DefaultConsoleService extends
 	@Parameter
 	private LogService log;
 
-	private MultiPrintStream sysout, syserr;
 	private OutputStreamReporter out, err;
 
 	/** List of listeners for {@code stdout} and {@code stderr} output. */
@@ -135,8 +133,8 @@ public class DefaultConsoleService extends
 
 	@Override
 	public void dispose() {
-		if (out != null) sysout.getParent().removeOutputStream(out);
-		if (err != null) syserr.getParent().removeOutputStream(err);
+		if(out != null) ListenableSystemStreams.out().removeOutputStream(out);
+		if(err != null) ListenableSystemStreams.err().removeOutputStream(err);
 	}
 
 	// -- Helper methods - lazy initialization --
@@ -145,25 +143,15 @@ public class DefaultConsoleService extends
 	private synchronized void initListeners() {
 		if (listeners != null) return; // already initialized
 
-		sysout = multiPrintStream(System.out);
-		if (System.out != sysout) System.setOut(sysout);
 		out = new OutputStreamReporter(Source.STDOUT);
-		sysout.getParent().addOutputStream(out);
-
-		syserr = multiPrintStream(System.err);
-		if (System.err != syserr) System.setErr(syserr);
+		ListenableSystemStreams.out().addOutputStream(out);
 		err = new OutputStreamReporter(Source.STDERR);
-		syserr.getParent().addOutputStream(err);
+		ListenableSystemStreams.err().addOutputStream(err);
 
 		listeners = new CopyOnWriteArrayList<>();
 	}
 
 	// -- Helper methods --
-
-	private MultiPrintStream multiPrintStream(final PrintStream ps) {
-		if (ps instanceof MultiPrintStream) return (MultiPrintStream) ps;
-		return new MultiPrintStream(ps);
-	}
 
 	/**
 	 * Gets whether two lists have exactly the same elements in them.

--- a/src/test/java/org/scijava/console/ListenableSystemStreamsTest.java
+++ b/src/test/java/org/scijava/console/ListenableSystemStreamsTest.java
@@ -1,0 +1,70 @@
+
+package org.scijava.console;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link ListenableSystemStreams}
+ *
+ * @author Matthias Arzt
+ */
+public class ListenableSystemStreamsTest {
+
+	private final String TEXT = "Hello World!\n";
+
+	private static PrintStream bufferingPrintStream() {
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+		return new PrintStream(buffer) {
+
+			@Override
+			public String toString() {
+				return buffer.toString();
+			}
+		};
+	}
+
+	@Test
+	public void testListenerSystemOut() {
+		OutputStream listener = new ByteArrayOutputStream();
+		ListenableSystemStreams.out().addOutputStream(listener);
+		System.out.print(TEXT);
+		ListenableSystemStreams.out().removeOutputStream(listener);
+		System.out.print(TEXT);
+		assertEquals(TEXT, listener.toString());
+	}
+
+	@Test
+	public void testListening() {
+		// setup
+		PrintStream output = bufferingPrintStream();
+		OutputStream listener = new ByteArrayOutputStream();
+		MultiPrintStream multiPrintStream = new MultiPrintStream(output);
+		// process
+		multiPrintStream.addOutputStream(listener);
+		multiPrintStream.print(TEXT);
+		// test
+		assertEquals(TEXT, listener.toString());
+		assertEquals(TEXT, output.toString());
+	}
+
+	@Test
+	public void testBypass() {
+		// setup
+		PrintStream output = bufferingPrintStream();
+		OutputStream listener = new ByteArrayOutputStream();
+		MultiPrintStream multiPrintStream = new MultiPrintStream(output);
+		multiPrintStream.addOutputStream(listener);
+		// process
+		multiPrintStream.bypass().print(TEXT);
+		// test
+		assertTrue(listener.toString().isEmpty());
+		assertEquals(TEXT, output.toString());
+	}
+}


### PR DESCRIPTION
The initialization of MultiplePrintStream in DefaultConsoleService
was not synchronized correctly. The global resources System.out and
System.err where modified like this: read, modify, write. This can
fail if two DefaultConsoleServices (in two scijava contexts) are
initialized in parallel.

The problem is solved in ListenableSystemStreams by using singletons.