### PR TITLE
Fix NullPointerException when calling LogMessage::attachments()

### DIFF
--- a/src/main/java/org/scijava/log/LogMessage.java
+++ b/src/main/java/org/scijava/log/LogMessage.java
@@ -112,6 +112,7 @@ public class LogMessage {
 	 * {@link #attach(Object)}.
 	 */
 	public Collection<Object> attachments() {
+		if (attachments == null) return Collections.emptyList();
 		return Collections.unmodifiableCollection(attachments);
 	}
 

--- a/src/test/java/org/scijava/log/LogMessageTest.java
+++ b/src/test/java/org/scijava/log/LogMessageTest.java
@@ -34,6 +34,12 @@ package org.scijava.log;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
 /**
  * Tests {@link LogMessage}.
  * 
@@ -67,5 +73,14 @@ public class LogMessageTest {
 
 		// test
 		Assert.assertTrue("Log message contains level", s.contains(LogLevel.prefix(message.level())));
+	}
+
+	@Test
+	public void testAttachments() {
+		LogMessage message = new LogMessage(LogSource.newRoot(), LogLevel.ERROR, "Message")	;
+		assertTrue(message.attachments().isEmpty());
+		Object object = new Object();
+		message.attach(object);
+		assertEquals(Collections.singletonList(object), new ArrayList<>(message.attachments()));
 	}
 }


### PR DESCRIPTION
Fix the following bug: 

Calling `LogMessage::attachments()` raises a `NullPointerException`, if `LogMessage::attach(Object object)` has not been called before.