### PR TITLE
FileHandle: don't unnecessarily init a RandomAccessFile on close

### DIFF
--- a/src/main/java/org/scijava/io/handle/FileHandle.java
+++ b/src/main/java/org/scijava/io/handle/FileHandle.java
@@ -55,6 +55,9 @@ public class FileHandle extends AbstractDataHandle<FileLocation> {
 	/** The mode of the {@link RandomAccessFile}. */
 	private String mode = "rw";
 
+	/** True iff the {@link #close()} has already been called. */
+	private boolean closed;
+
 	// -- FileHandle methods --
 
 	/** Gets the random access file object backing this FileHandle. */
@@ -289,8 +292,9 @@ public class FileHandle extends AbstractDataHandle<FileLocation> {
 	// -- Closeable methods --
 
 	@Override
-	public void close() throws IOException {
+	public synchronized void close() throws IOException {
 		if (raf != null) raf().close();
+		closed = true;
 	}
 
 	// -- Typed methods --
@@ -308,6 +312,7 @@ public class FileHandle extends AbstractDataHandle<FileLocation> {
 	}
 
 	private synchronized void initRAF() throws IOException {
+		if (closed) throw new IOException("Handle already closed");
 		if (raf != null) return;
 		raf = new RandomAccessFile(get().getFile(), getMode());
 	}

--- a/src/main/java/org/scijava/io/handle/FileHandle.java
+++ b/src/main/java/org/scijava/io/handle/FileHandle.java
@@ -290,7 +290,7 @@ public class FileHandle extends AbstractDataHandle<FileLocation> {
 
 	@Override
 	public void close() throws IOException {
-		raf().close();
+		if (raf != null) raf().close();
 	}
 
 	// -- Typed methods --

--- a/src/test/java/org/scijava/io/handle/FileHandleTest.java
+++ b/src/test/java/org/scijava/io/handle/FileHandleTest.java
@@ -89,4 +89,23 @@ public class FileHandleTest extends DataHandleTest {
 		// Clean up.
 		assertTrue(nonExistentFile.delete());
 	}
+
+	@Test
+	public void testNotCreatedByClose() throws IOException {
+		final Context ctx = new Context();
+		final DataHandleService dhs = ctx.service(DataHandleService.class);
+
+		final File nonExistentFile = //
+			File.createTempFile("FileHandleTest", "nonexistent-file");
+		assertTrue(nonExistentFile.delete());
+		assertFalse(nonExistentFile.exists());
+
+		final FileLocation loc = new FileLocation(nonExistentFile);
+		final DataHandle<?> handle = dhs.create(loc);
+		assertTrue(handle instanceof FileHandle);
+		assertFalse(handle.exists());
+
+		handle.close();
+		assertFalse(nonExistentFile.exists());
+	}
 }


### PR DESCRIPTION
If we close a handle on a file that does not exist, we do not need to
initialize the RandomAccessFile, just to close it again. This fixes the problem of
empty files appearing when closing a FileHandle to a file that does not exist.