### PR TITLE
Logging, shorten console output, fix listeners

### DIFF
--- a/src/main/java/org/scijava/log/AbstractLogService.java
+++ b/src/main/java/org/scijava/log/AbstractLogService.java
@@ -90,6 +90,8 @@ public abstract class AbstractLogService extends AbstractService implements
 		rootLogger.getSource().subSource(source).setLogLevel(level);
 	}
 
+	abstract protected void messageLogged(LogMessage message);
+
 	// -- Logger methods --
 
 	@Override
@@ -184,7 +186,7 @@ public abstract class AbstractLogService extends AbstractService implements
 	private class RootLogger extends DefaultLogger {
 
 		public RootLogger() {
-			super(AbstractLogService.this::notifyListeners, LogSource.newRoot(),
+			super(AbstractLogService.this::messageLogged, LogSource.newRoot(),
 				LogLevel.NONE);
 		}
 

--- a/src/main/java/org/scijava/log/LogMessage.java
+++ b/src/main/java/org/scijava/log/LogMessage.java
@@ -129,20 +129,12 @@ public class LogMessage {
 
 	@Override
 	public String toString() {
-		return format(this);
-	}
-
-	// -- Utility methods --
-
-	public static String format(final LogMessage message) {
 		final StringWriter sw = new StringWriter();
 		final PrintWriter printer = new PrintWriter(sw);
-		printer.print("[" + message.time() + "] ");
-		printer.print("[" + LogLevel.prefix(message.level()) + "] ");
-		printer.print("[" + message.source() + "] ");
-		printer.println(message.text());
-		if (message.throwable() != null) {
-			message.throwable().printStackTrace(printer);
+		printer.print("[" + LogLevel.prefix(level()) + "] ");
+		printer.println(text());
+		if (throwable() != null) {
+			throwable().printStackTrace(printer);
 		}
 		return sw.toString();
 	}

--- a/src/main/java/org/scijava/log/StderrLogService.java
+++ b/src/main/java/org/scijava/log/StderrLogService.java
@@ -61,7 +61,7 @@ public class StderrLogService extends AbstractLogService {
 	}
 
 	@Override
-	public void notifyListeners(LogMessage message) {
+	protected void messageLogged(LogMessage message) {
 		final PrintStream out = levelToStream.apply(message.level());
 		out.print(message);
 	}

--- a/src/test/java/org/scijava/log/LogServiceTest.java
+++ b/src/test/java/org/scijava/log/LogServiceTest.java
@@ -2,6 +2,8 @@ package org.scijava.log;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -200,6 +202,15 @@ public class LogServiceTest {
 		listener.hasLogged(m -> msg2.equals(m.text()));
 	}
 
+	@Test
+	public void testLogListenerIsNotifiedOnce() {
+		List<LogMessage> list = new ArrayList<>();
+		LogService logService = new TestableLogService();
+		logService.addLogListener(list::add);
+		logService.error("dummy");
+		assertEquals(1, list.size());
+	}
+
 	// -- Helper classes --
 
 	private static class MyTestClass {
@@ -241,7 +252,7 @@ public class LogServiceTest {
 		}
 
 		@Override
-		public void notifyListeners(LogMessage message) {
+		protected void messageLogged(LogMessage message) {
 			this.message = message.toString();
 			this.exception = message.throwable();
 		}


### PR DESCRIPTION
This fixes to issues:

* Don't output too much meta information about log messages on the console
* AbstractLogService called the method notifyListeners in the wrong place, which might cause every LogListener to be called twice per log message.