### PR TITLE
Fix NullPointerException in LoggerPreprocessor

### DIFF
--- a/src/main/java/org/scijava/module/process/LoggerPreprocessor.java
+++ b/src/main/java/org/scijava/module/process/LoggerPreprocessor.java
@@ -66,7 +66,7 @@ public class LoggerPreprocessor extends AbstractPreprocessorPlugin {
 		if (loggerInput == null || !loggerInput.isAutoFill()) return;
 
 		String loggerName = loggerInput.getLabel();
-		if(loggerName.isEmpty())
+		if(loggerName == null || loggerName.isEmpty())
 			loggerName = module.getDelegateObject().getClass().getSimpleName();
 		Logger logger = logService.subLogger(loggerName);
 


### PR DESCRIPTION
This handles the case of `loggerName` being `null` when running scripts that contain a `#@ Logger` parameter.