### PR TITLE
Always use UTF-8 when loading scripts from URL

### DIFF
--- a/src/main/java/org/scijava/script/ScriptInfo.java
+++ b/src/main/java/org/scijava/script/ScriptInfo.java
@@ -40,6 +40,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -132,7 +133,7 @@ public class ScriptInfo extends AbstractModuleInfo implements Contextual {
 	public ScriptInfo(final Context context, final URL url, final String path)
 		throws IOException
 	{
-		this(context, url, path, new InputStreamReader(url.openStream()));
+		this(context, url, path, new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
 	}
 
 	/**


### PR DESCRIPTION
I noticed that scripts containing non-ASCII characters (such as `äöü`) are not loaded correctly on Windows when they are loaded from within a jar file.

See https://github.com/imagej/example-script-collection/commit/fb9757428fc17b0b6bf4fb89f4ea1a23fbdd60ac for some example scripts that currently fail (on Windows).

With this PR, the above scripts work as expected.

@ctrueden do you think it is safe to always use UTF-8 here, or are there cases of other URLs where we need to allow different encodings? In that case, we should make sure to use the _correct_ encoding in all situations.
