### PR TITLE
Type service: Types.satisfies() and other useful methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>scijava-common</artifactId>
-	<version>2.70.0-SNAPSHOT</version>
+	<version>2.75.0-SNAPSHOT</version>
 
 	<name>SciJava Common</name>
 	<description>SciJava Common is a shared library for SciJava software. It provides a plugin framework, with an extensible mechanism for service discovery, backed by its own annotation processor, so that plugins can be loaded dynamically. It is used by downstream projects in the SciJava ecosystem, such as ImageJ and SCIFIO.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,10 @@ Konstanz, and KNIME GmbH.</license.copyrightOwners>
 
 		<!-- Third-party dependencies -->
 		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.bushe</groupId>
 			<artifactId>eventbus</artifactId>
 			<version>1.4</version>

--- a/src/main/java/org/scijava/convert/NilConverter.java
+++ b/src/main/java/org/scijava/convert/NilConverter.java
@@ -34,8 +34,6 @@ package org.scijava.convert;
 import java.lang.reflect.Type;
 
 import org.scijava.Priority;
-import org.scijava.convert.AbstractConverter;
-import org.scijava.convert.Converter;
 import org.scijava.plugin.Plugin;
 import org.scijava.types.Nil;
 import org.scijava.util.Types;

--- a/src/main/java/org/scijava/convert/NilConverter.java
+++ b/src/main/java/org/scijava/convert/NilConverter.java
@@ -1,0 +1,105 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.convert;
+
+import java.lang.reflect.Type;
+
+import org.scijava.Priority;
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Plugin;
+import org.scijava.types.Nil;
+import org.scijava.util.Types;
+
+/**
+ * {@link Converter} implementation for handling {@link Nil} values.
+ *
+ * @author Curtis Rueden
+ */
+@Plugin(type = Converter.class, priority = Priority.VERY_HIGH_PRIORITY)
+public class NilConverter extends AbstractConverter<Nil<?>, Object> {
+
+	@Override
+	public boolean canConvert(final Object src, final Type dest) {
+		return src instanceof Nil && dest != null;
+	}
+
+	@Override
+	public boolean canConvert(final Object src, final Class<?> dest) {
+		return src instanceof Nil && dest != null;
+	}
+
+	@Override
+	public boolean canConvert(final Class<?> src, final Class<?> dest) {
+		return Nil.class.isAssignableFrom(src) && dest != null;
+	}
+
+	@Override
+	public Object convert(final Object src, final Type dest) {
+		if (!(src instanceof Nil)) return null;
+		final Nil<?> nil = (Nil<?>) src;
+
+		// special case for conversion to Nil of another type
+		final Class<?> destClass = Types.raw(dest);
+		if (destClass == Nil.class) {
+			// convert to target Nil type, preserving the source's callbacks
+			return Nil.of(((Nil<?>) dest).getType(), src);
+		}
+
+		// Return a proxy object of the destination type,
+		// with callbacks from the source Nil.
+		// NB: The proxy might not _actually_ be of the requested type,
+		// although it will implement all the same interfaces as that type.
+		// CTR TODO: Consider whether to fail the conversion in this case.
+		return Nil.of(dest, nil).proxy();
+	}
+
+	@Override
+	public Class<Object> getOutputType() {
+		return Object.class;
+	}
+
+	@Override
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public Class<Nil<?>> getInputType() {
+		return (Class) Nil.class;
+	}
+
+	@Override
+	public <T> T convert(final Object src, final Class<T> dest) {
+		final Type type = dest;
+		@SuppressWarnings("unchecked")
+		final T result = (T) convert(src, type);
+		return result;
+	}
+
+}

--- a/src/main/java/org/scijava/types/DefaultTypeService.java
+++ b/src/main/java/org/scijava/types/DefaultTypeService.java
@@ -1,0 +1,81 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.scijava.plugin.AbstractSingletonService;
+import org.scijava.plugin.Plugin;
+import org.scijava.service.Service;
+
+/**
+ * Default {@link TypeService} implementation.
+ *
+ * @author Curtis Rueden
+ */
+@Plugin(type = Service.class)
+public class DefaultTypeService extends
+	AbstractSingletonService<TypeExtractor<?>> implements TypeService
+{
+
+	private Map<Class<?>, TypeExtractor<?>> extractors;
+
+	// -- TypeService methods --
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> TypeExtractor<T> getExtractor(final Class<T> c) {
+		return (TypeExtractor<T>) extractors().get(c);
+	}
+
+	// -- Helper methods --
+
+	private Map<Class<?>, TypeExtractor<?>> extractors() {
+		if (extractors == null) initExtractors();
+		return extractors;
+	}
+
+	private synchronized void initExtractors() {
+		if (extractors != null) return;
+
+		final HashMap<Class<?>, TypeExtractor<?>> map = new HashMap<>();
+
+		for (final TypeExtractor<?> typeExtractor : getInstances()) {
+			final Class<?> key = typeExtractor.getRawType();
+			if (!map.containsKey(key)) map.put(key, typeExtractor);
+		}
+
+		extractors = map;
+	}
+
+}

--- a/src/main/java/org/scijava/types/GenericTyped.java
+++ b/src/main/java/org/scijava/types/GenericTyped.java
@@ -1,0 +1,43 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.types;
+
+import java.lang.reflect.Type;
+
+/**
+ * An object which knows its generic type.
+ *
+ * @author Curtis Rueden
+ */
+public interface GenericTyped {
+
+	Type getType();
+}

--- a/src/main/java/org/scijava/types/IterableTypeExtractor.java
+++ b/src/main/java/org/scijava/types/IterableTypeExtractor.java
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.types;
+
+import java.lang.reflect.Type;
+import java.util.Iterator;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * {@link TypeExtractor} plugin which operates on {@link Iterable} objects.
+ * <p>
+ * For performance reasons, we examine only the first element of the iteration,
+ * which may be a more specific type than later elements. Hence the generic type
+ * given by this extraction may be overly constrained.
+ * </p>
+ *
+ * @author Curtis Rueden
+ */
+@Plugin(type = TypeExtractor.class, priority = Priority.LOW_PRIORITY)
+public class IterableTypeExtractor implements TypeExtractor<Iterable<?>> {
+
+	@Parameter
+	private TypeService typeService;
+
+	@Override
+	public Type reify(final Iterable<?> o, final int n) {
+		if (n != 0) throw new IndexOutOfBoundsException();
+
+		final Iterator<?> iterator = o.iterator();
+		if (!iterator.hasNext()) return null;
+
+		// Obtain the element type using the TypeService.
+		final Object element = iterator.next();
+		return typeService.reify(element);
+
+		// TODO: Avoid infinite recursion when the list references itself.
+	}
+
+	@Override
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public Class<Iterable<?>> getRawType() {
+		return (Class) Iterable.class;
+	}
+
+}

--- a/src/main/java/org/scijava/types/MapTypeExtractor.java
+++ b/src/main/java/org/scijava/types/MapTypeExtractor.java
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.types;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * {@link TypeExtractor} plugin which operates on {@link Map} objects.
+ * <p>
+ * For performance reasons, we examine only one entry of the map, which may be
+ * more specifically typed than later entries. Hence the generic types given by
+ * this extraction may be overly constrained.
+ * </p>
+ *
+ * @author Curtis Rueden
+ */
+@Plugin(type = TypeExtractor.class, priority = Priority.LOW_PRIORITY)
+public class MapTypeExtractor implements TypeExtractor<Map<?, ?>> {
+
+	@Parameter
+	private TypeService typeService;
+
+	@Override
+	public Type reify(final Map<?, ?> o, final int n) {
+		if (n < 0 || n > 1) throw new IndexOutOfBoundsException("" + n);
+
+		if (o.isEmpty()) return null;
+
+		final Entry<?, ?> entry = o.entrySet().iterator().next();
+		if (n == 0) return typeService.reify(entry.getKey());
+		return typeService.reify(entry.getValue());
+
+		// TODO: Avoid infinite recursion when the map references itself.
+	}
+
+	@Override
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public Class<Map<?, ?>> getRawType() {
+		return (Class) Map.class;
+	}
+
+}

--- a/src/main/java/org/scijava/types/Nil.java
+++ b/src/main/java/org/scijava/types/Nil.java
@@ -1,0 +1,209 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.types;
+
+import com.google.common.reflect.TypeToken;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Set;
+
+import org.scijava.util.Types;
+
+/**
+ * A "typed null" which knows its generic type, and can generate proxy objects
+ * implementing that type's interfaces, with customizable behavior per interface
+ * method via callbacks.
+ * <p>
+ * The term "nil" was chosen, despite lots of possibility for confusion with
+ * related paradigms such as the Scala language, because it is very short while
+ * loosely meaning the same thing as {@code null}, {@code None}, etc.
+ * </p>
+ *
+ * @author Curtis Rueden
+ */
+public abstract class Nil<T> implements GenericTyped, Proxyable<T>,
+	InvocationHandler
+{
+
+	/** Generic type of the object. */
+	private final TypeToken<?> typeToken;
+
+	/** An object which holds any method callbacks. */
+	private final Object callbacks;
+
+	/**
+	 * Creates a new {@code Nil} whose generic type (returned by
+	 * {@link #getType()}) is the one specified by the generic parameters used at
+	 * construction.
+	 * <p>
+	 * For example:
+	 * </p>
+	 * 
+	 * <pre>
+	 * 
+	 * Nil&lt;List&lt;Map&lt;K, V&gt;&gt;&gt; nil = new Nil&lt;List&lt;Map&lt;K, V&gt;&gt;&gt;() {};
+	 * </pre>
+	 * <p>
+	 * Subsequent calls to {@code nil.getType()} will return the proper
+	 * generically typed result&mdash;in the above example, a
+	 * {@link ParameterizedType} whose raw type is {@code List}, and whose single
+	 * type parameter is a {@link ParameterizedType} with raw type of {@code Map}
+	 * and {@link TypeVariable} type parameters of {@code K} and {@code V}
+	 * respectively, including their bounds inferred by the compiler in the
+	 * context where the expression was written.
+	 * </p>
+	 */
+	public Nil() {
+		typeToken = new TypeToken<T>(getClass()) {};
+		callbacks = this;
+	}
+
+	public Nil(final Object callbacks) {
+		typeToken = new TypeToken<T>(getClass()) {};
+		this.callbacks = callbacks(callbacks);
+	}
+
+	/**
+	 * Creates a {@code Nil} wrapping the given generic {@link Type}.
+	 * <p>
+	 * This method is intentionally private; use {@link Nil#of(Type)} to create
+	 * such a {@code Nil} from calling code.
+	 * </p>
+	 */
+	private Nil(final Type type) {
+		typeToken = TypeToken.of(type);
+		callbacks = this;
+	}
+
+	/**
+	 * Creates a {@code Nil} wrapping the given generic {@link Type}, and
+	 * possessing the specified method callbacks.
+	 * <p>
+	 * This method is intentionally private; use {@link Nil#of(Type, Object)} to
+	 * create such a {@code Nil} from calling code.
+	 * </p>
+	 */
+	private Nil(final Type type, final Object callbacks) {
+		typeToken = TypeToken.of(type);
+		this.callbacks = callbacks(callbacks);
+	}
+
+	// -- Static utility methods --
+
+	/**
+	 * Creates a {@code Nil} of the given generic {@link Type}, with no extra
+	 * method callbacks.
+	 */
+	public static Nil<?> of(final Type type) {
+		return new Nil<Object>(type) {};
+	}
+
+	/**
+	 * Creates a {@code Nil} of the given {@link Type}, with extra method
+	 * callbacks contained in the specified object.
+	 */
+	public static Nil<?> of(final Type type, final Object callbacks) {
+		return new Nil<Object>(type, callbacks) {};
+	}
+
+	// -- Object methods --
+
+	@Override
+	public String toString() {
+		return typeToken.toString();
+	}
+
+	// -- GenericTyped methods --
+
+	@Override
+	public Type getType() {
+		return typeToken.getType();
+	}
+
+	// -- GenericProxy methods --
+
+	/**
+	 * Create a proxy which implements all the same interfaces as this object's
+	 * generic type.
+	 * <p>
+	 * CTR FIXME - write up how method delegation works.
+	 * </p>
+	 */
+	@Override
+	public T proxy() {
+		final ClassLoader loader = Thread.currentThread().getContextClassLoader();
+
+		// extract the generic type's interfaces
+		final Set<?> ifaceSet = typeToken.getTypes().interfaces().rawTypes();
+		final boolean appendGT = !ifaceSet.contains(GenericTyped.class);
+		final int ifaceCount = ifaceSet.size() + (appendGT ? 1 : 0);
+		final Class<?>[] interfaces = new Class<?>[ifaceCount];
+		ifaceSet.toArray(interfaces);
+		if (appendGT) interfaces[ifaceCount - 1] = GenericTyped.class;
+
+		// NB: Technically, this cast is not safe, because T might not be
+		// an interface, and thus might not be one of the proxy's types.
+		@SuppressWarnings("unchecked")
+		final T proxy = (T) Proxy.newProxyInstance(loader, interfaces, this);
+		return proxy;
+	}
+
+	// -- InvocationHandler methods --
+
+	@Override
+	public Object invoke(final Object proxy, final Method method,
+		final Object[] args) throws Throwable
+	{
+		try {
+			// Look for a Nil subclass method of the same signature.
+			final Method m = callbacks.getClass().getMethod(method.getName(), //
+				method.getParameterTypes());
+			return m.invoke(callbacks, args);
+		}
+		catch (final NoSuchMethodException exc) {
+			// NB: Default behavior is to do nothing and return null.
+			return Types.nullValue(method.getReturnType());
+		}
+	}
+
+	// -- Helper methods --
+
+	/** Unwraps the given callbacks object. */
+	private Object callbacks(final Object o) {
+		return o instanceof Nil ? ((Nil<?>) o).callbacks : o;
+	}
+
+}

--- a/src/main/java/org/scijava/types/Proxyable.java
+++ b/src/main/java/org/scijava/types/Proxyable.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.types;
+
+/**
+ * An object which knows how to generate proxy objects of a particular type.
+ *
+ * @author Curtis Rueden
+ */
+public interface Proxyable<T> {
+
+	/** Generates a proxy object of the associated type. */
+	T proxy();
+}

--- a/src/main/java/org/scijava/types/TypeExtractor.java
+++ b/src/main/java/org/scijava/types/TypeExtractor.java
@@ -1,0 +1,102 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.types;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+
+import org.scijava.plugin.Plugin;
+import org.scijava.plugin.SingletonPlugin;
+import org.scijava.util.Types;
+
+/**
+ * A plugin for extracting generic {@link Type} from instances at runtime.
+ * <p>
+ * This is an extensible way to achieve quasi-preservation of generic types at
+ * runtime, for types which do not normally support it.
+ * </p>
+ * <p>
+ * Type extractor plugins discoverable at runtime must implement this interface
+ * and be annotated with @{@link Plugin} with attribute {@link Plugin#type()
+ * type} = {@link TypeExtractor}.class.
+ * </p>
+ * 
+ * @author Curtis Rueden
+ */
+public interface TypeExtractor<T> extends SingletonPlugin {
+
+	/**
+	 * Extracts the generic type of the given object.
+	 * 
+	 * @return The object's generic {@link Type}, or {@code null} if the object is
+	 *         not supported by this extractor.
+	 */
+	default ParameterizedType reify(final T o) {
+		final TypeVariable<Class<T>>[] typeVars = getRawType().getTypeParameters();
+		if (typeVars.length == 0) {
+			throw new IllegalStateException("Class " + getRawType().getName() +
+				" is not a parameterized type");
+		}
+		final Type[] types = new Type[typeVars.length];
+		for (int i = 0; i < types.length; i++) {
+			types[i] = reify(o, i);
+			if (types[i] == null) types[i] = Types.wildcard();
+		}
+		return Types.parameterize(getRawType(), types);
+	}
+
+	/**
+	 * Extracts the generic type of the given object's Nth type parameter, with
+	 * respect to the class handled by this type extractor.
+	 * 
+	 * @param o Object for which the type should be reified.
+	 * @param n Index of the type parameter whose type should be extracted.
+	 * @return The reified Nth type parameter, or {@code null} if the extractor
+	 *         cannot process the object.
+	 * @throws IndexOutOfBoundsException if {@code n} is less than 0, or greater
+	 *           than {@code getType().getTypeParameters().length}.
+	 * @throws UnsupportedOperationException if the supported class does not have
+	 *           any type parameters.
+	 */
+	default Type reify(final T o, final int n) {
+		final Type type = reify(o);
+		if (!(type instanceof ParameterizedType)) {
+			throw new UnsupportedOperationException("Not a parameterized type");
+		}
+		final ParameterizedType pType = (ParameterizedType) type;
+		return pType.getActualTypeArguments()[n];
+	}
+
+	/** Gets the {@link Class} handled by this type extractor. */
+	Class<T> getRawType();
+}

--- a/src/main/java/org/scijava/types/TypeService.java
+++ b/src/main/java/org/scijava/types/TypeService.java
@@ -1,0 +1,217 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.types;
+
+import com.google.common.reflect.TypeToken;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.scijava.plugin.SingletonService;
+import org.scijava.service.SciJavaService;
+import org.scijava.util.Types;
+
+/**
+ * Service for working with generic {@link Type}s. This service can extract
+ * generic types from objects in an extensible way, via {@link TypeExtractor}
+ * plugins. It also provides some methods for reasoning about generic types in
+ * general.
+ * 
+ * @author Curtis Rueden
+ */
+public interface TypeService extends
+	SingletonService<TypeExtractor<?>>, SciJavaService
+{
+
+	/** Gets the type extractor which handles the given class, or null if none. */
+	<T> TypeExtractor<T> getExtractor(Class<T> c);
+
+	/**
+	 * Extracts the generic {@link Type} of the given {@link Object}.
+	 * <p>
+	 * The ideal goal of the extraction is to reconstitute a fully concrete
+	 * generic type, with all type variables fully resolved&mdash;e.g.:
+	 * {@code ArrayList<Integer>} rather than a raw {@code ArrayList} class or
+	 * even {@code ArrayList<N extends Number>}. Failing that, though, type
+	 * variables which are still unknown after analysis will be replaced with
+	 * wildcards&mdash;e.g., {@code HashMap} might become
+	 * {@code HashMap<String, ?>} if a concrete type for the map values cannot be
+	 * determined.
+	 * </p>
+	 * <p>
+	 * For objects whose concrete type has no parameters, this method simply
+	 * returns {@code o.getClass()}. For example:
+	 * 
+	 * <pre>
+	 *      StringList implements List&lt;String&gt;
+	 * </pre>
+	 * 
+	 * will return {@code StringList.class}.
+	 * <p>
+	 * The interesting case is for objects whose concrete class <em>does</em> have
+	 * type parameters. E.g.:
+	 * 
+	 * <pre>
+	 *      NumberList&lt;N extends Number&gt; implements List&lt;N&gt;
+	 *      ListMap&lt;K, V, T&gt; implements Map&lt;K, V&gt;, List&lt;T&gt;
+	 * </pre>
+	 * 
+	 * For such types, we try to fill the type parameters recursively, using
+	 * {@link TypeExtractor} plugins that know how to glean types at runtime from
+	 * specific sorts of objects.
+	 * </p>
+	 * <p>
+	 * For example, {@link IterableTypeExtractor} knows how to guess a {@code T}
+	 * for any {@code Iterable<T>} by examining the type of the elements in its
+	 * iteration. (Of course, this may be inaccurate if the elements in the
+	 * iteration are heterogeneously typed, but for many use cases this guess is
+	 * better than nothing.)
+	 * </p>
+	 * <p>
+	 * In this way, the behavior of the generic type extraction is fully
+	 * extensible, since additional {@link TypeExtractor} plugins can always be
+	 * introduced which extract types more intelligently in cases where more
+	 * <em>a priori</em> knowledge about that type is available at runtime.
+	 * </p>
+	 */
+	default Type reify(final Object o) {
+		if (o == null) return null;
+		
+		if (o instanceof GenericTyped) {
+			// Object implements the GenericTyped interface; it explicitly declares
+			// the generic type by which it wants to be known. This makes life easy!
+			return ((GenericTyped) o).getType();
+		}
+
+		final Class<?> c = o.getClass();
+		final TypeVariable<?>[] typeVars = c.getTypeParameters();
+		final int numVars = typeVars.length;
+
+		if (numVars == 0) {
+			// Object has no generic parameters; we are done!
+			return c;
+		}
+
+		// Object has parameters which need to be resolved. Let's do it.
+
+		// Here we will store all of our object's resolved type variables.
+		final Map<TypeVariable<?>, Type> resolved = new HashMap<>();
+
+		for (final TypeToken<?> token : TypeToken.of(c).getTypes()) {
+			if (resolved.size() == numVars) break; // Got 'em all!
+
+			final Type type = token.getType();
+			if (!Types.containsTypeVars(type)) {
+				// No type variables are buried in this type; it is useless to us!
+				continue;
+			}
+
+			// Populate relevant type variables from the reified supertype!
+			final Map<TypeVariable<?>, Type> vars = //
+				args(o, token.getRawType());
+
+			if (vars != null) {
+				// Remember any resolved type variables.
+				// Note that vars may contain other type variables from other layers
+				// of the generic type hierarchy, which we don't care about here.
+				for (final TypeVariable<?> typeVar : typeVars) {
+					if (vars.containsKey(typeVar)) {
+						resolved.putIfAbsent(typeVar, vars.get(typeVar));
+					}
+				}
+			}
+		}
+
+		// fill in any remaining unresolved type parameters with wildcards
+		for (final TypeVariable<?> typeVar : typeVars) {
+			resolved.putIfAbsent(typeVar, Types.wildcard());
+		}
+
+		// now apply all the type variables we resolved
+		return Types.parameterize(c, resolved);
+	}
+
+	/**
+	 * Extracts the resolved type variables of the given {@link Object}, as viewed
+	 * through the specified supertype.
+	 * <p>
+	 * For example, if you call:
+	 * </p>
+	 * 
+	 * <pre>
+	 * args(Collections.singleton("Hi"), Iterable.class)
+	 * </pre>
+	 * <p>
+	 * Then it returns a map with contents <code>{T: String}</code> by using the
+	 * {@link IterableTypeExtractor} to analyze the object.
+	 * </p>
+	 * <p>
+	 * Note that this method only provides results if there is a
+	 * {@link TypeExtractor} plugin which handles <em>exactly</em> the given
+	 * supertype.
+	 * </p>
+	 * 
+	 * @see #reify(Object)
+	 */
+	default <T> Map<TypeVariable<?>, Type> args(final Object o,
+		final Class<T> superType)
+	{
+		final Class<?> c = o.getClass();
+
+		final TypeExtractor<T> extractor = getExtractor(superType);
+		if (extractor == null) return null; // No plugin for this specific class.
+
+		if (!superType.isInstance(o)) {
+			throw new IllegalStateException("'" + o.getClass() +
+				"' is not an instance of '" + superType.getName() + "'");
+		}
+		@SuppressWarnings("unchecked")
+		final T t = (T) o;
+
+		final ParameterizedType extractedType = extractor.reify(t);
+
+		// Populate type variables to fully populate the supertype.
+		return Types.args(c, extractedType);
+	}
+
+	// -- PTService methods --
+
+	@Override
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	default Class<TypeExtractor<?>> getPluginType() {
+		return (Class) TypeExtractor.class;
+	}
+
+}

--- a/src/main/java/org/scijava/types/package-info.java
+++ b/src/main/java/org/scijava/types/package-info.java
@@ -1,0 +1,86 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+/**
+ * This package provides support for reasoning about types, including generic
+ * types, at runtime. It has many features similar to {@link java.lang.reflect},
+ * but not limited to only raw types.
+ * <h2>Features</h2>
+ * <ul>
+ * <li>Reason about whether a collection of arguments (object instances, generic
+ * types, or a mixture thereof) are assignable to a given list of generic types,
+ * such as those of a particular method signature.</li>
+ * <li>Create {@link org.scijava.types.Nil} objects, which act as "typed null"
+ * placeholders, and support generation of proxy instances of their associated
+ * generic type, similar to (but less featureful than) how mocking frameworks
+ * create mock objects.</li>
+ * <li>Recover erased generic type information from object instances at runtime,
+ * in an extensible way, via {@link org.scijava.types.TypeExtractor} plugins and
+ * the {@link TypeService#reify} method. E.g., you can learn that an object of
+ * class {@link java.util.HashMap} is actually (or at least functionally) a
+ * {@code HashMap<String, Integer>}.</li>
+ * </ul>
+ * <h2>Credits and History</h2>
+ * <p>
+ * There are three excellent libraries with generics-related functionality, from
+ * which this package draws logic and inspiration:
+ * </p>
+ * <ol>
+ * <li><a href="https://github.com/coekie/gentyref">GenTyRef</a>, the Generic
+ * Type Reflector, by Wouter Coekaerts. While {@link org.scijava.types} uses no
+ * code from GenTyRef directly, it was a substantial source of inspiration and
+ * education.</li>
+ * <li>The <a href="https://github.com/google/guava/wiki/ReflectionExplained">
+ * <code>com.google.commons.reflect</code></a> package of
+ * <a href="https://github.com/google/guava">Google Guava</a>. In particular,
+ * the {@link org.scijava.types.Nil} class uses the Guava library's fabulous
+ * {@link com.google.common.reflect.TypeToken} class.</li>
+ * <li>The <a href=
+ * "https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/reflect/TypeUtils.html">
+ * <code>org.apache.commons.reflect.TypeUtils</code></a> class of
+ * <a href="https://commons.apache.org/proper/commons-lang/">Apache Commons
+ * Lang</a> version 3.4. This class is forked internally within SciJava's
+ * {@link org.scijava.types.Types} utility class; we did this for two reasons:
+ * 1) to avoid bringing in the whole of Apache Commons Lang as a dependency; and
+ * 2) to fix an infinite recursion bug in the {@code TypeUtils.toString(Type)}
+ * method.</li>
+ * </ol>
+ * <p>
+ * All three of these libraries contain fantastic generics-related logic, but
+ * none of the three contained everything that SciJava needed for all its use
+ * cases. Hence, we have drawn from all three sources as needed to create a
+ * unified generics API for use from SciJava applications. See in particular
+ * the <a href="https://github.com/scijava/scijava-ops">SciJava Ops</a>
+ * project, which utilizes these features heavily.
+ * </p>
+ */
+
+package org.scijava.types;

--- a/src/main/java/org/scijava/util/ClassUtils.java
+++ b/src/main/java/org/scijava/util/ClassUtils.java
@@ -352,6 +352,7 @@ public final class ClassUtils {
 
 	// -- Comparison --
 
+	// START HERE: Migrate remaining methods to Types, then deprecate this class.
 	/**
 	 * Compares two {@link Class} objects using their fully qualified names.
 	 * <p>

--- a/src/main/java/org/scijava/util/Types.java
+++ b/src/main/java/org/scijava/util/Types.java
@@ -322,7 +322,7 @@ public final class Types {
 	public static String name(final Type t) {
 		if (t instanceof Class) {
 			final Class<?> c = (Class<?>) t;
-			return c.isArray() ? (name(component(c)) + "[]") : c.getName();
+			return c.isArray() ? name(component(c)) + "[]" : c.getName();
 		}
 		return t.toString();
 	}
@@ -521,7 +521,7 @@ public final class Types {
 	 * use {@link Field#setAccessible(boolean)} in order to manipulate the field's
 	 * contents.
 	 * </p>
-	 * 
+	 *
 	 * @param c The class (or subclass thereof) containing the desired field.
 	 * @param name
 	 * @return The first field with the given name in the class's superclass
@@ -553,7 +553,7 @@ public final class Types {
 	 * accessible; if the method is not {@code public}, calling code will need to
 	 * use {@link Method#setAccessible(boolean)} in order to invoke the method.
 	 * </p>
-	 * 
+	 *
 	 * @param c The class (or subclass thereof) containing the desired method.
 	 * @param name Name of the method.
 	 * @param parameterTypes Types of the method parameters.
@@ -1435,7 +1435,7 @@ public final class Types {
 			@Override
 			public boolean equals(final Object obj) {
 				return obj == this || obj instanceof ParameterizedType && TypeUtils
-					.equals(this, ((ParameterizedType) obj));
+					.equals(this, (ParameterizedType) obj);
 			}
 
 			@Override
@@ -3405,7 +3405,7 @@ public final class Types {
 
 		/**
 		 * Maps type parameters in a type to their values.
-		 * 
+		 *
 		 * @param toMapType Type possibly containing type arguments
 		 * @param typeAndParams must be either ParameterizedType, or (in case there
 		 *          are no type arguments, or it's a raw type) Class
@@ -3457,7 +3457,7 @@ public final class Types {
 		 * unbound wildcard ("?"). For example,
 		 * <tt>addWildcardParameters(Map.class)</tt> returns a type representing
 		 * <tt>Map&lt;?,?&gt;</tt>.
-		 * 
+		 *
 		 * @return
 		 *         <ul>
 		 *         <li>If clazz is a class or interface without type parameters,
@@ -3538,7 +3538,7 @@ public final class Types {
 		 * <tt>class StringList implements List&lt;String&gt;</tt>,
 		 * <tt>getTypeParameter(StringList.class, Collection.class.getTypeParameters()[0])</tt>
 		 * returns <tt>String</tt>.
-		 * 
+		 *
 		 * @param type The type to inspect.
 		 * @param variable The type variable to find the value for.
 		 * @return The type parameter for the given variable. Or null if type is not
@@ -3877,7 +3877,7 @@ public final class Types {
 		 * different sorts of types, and you are only really interested in concrete
 		 * classes and interfaces.
 		 * </p>
-		 * 
+		 *
 		 * @return A List of classes, each of them a supertype of the given type. If
 		 *         the given type is a class or interface itself, returns a List
 		 *         with just the given type. The list contains no duplicates, and is
@@ -3946,7 +3946,7 @@ public final class Types {
 		/**
 		 * Creates an uninitialized CaptureTypeImpl. Before using this type,
 		 * {@link #init(VarMap)} must be called.
-		 * 
+		 *
 		 * @param wildcard The wildcard this is a capture of
 		 * @param variable The type variable where the wildcard is a parameter for.
 		 */
@@ -4007,8 +4007,7 @@ public final class Types {
 	 */
 	private static class VarMap {
 
-		private final Map<TypeVariable<?>, Type> map =
-			new HashMap<>();
+		private final Map<TypeVariable<?>, Type> map = new HashMap<>();
 
 		/**
 		 * Creates an empty VarMap

--- a/src/main/java/org/scijava/util/Types.java
+++ b/src/main/java/org/scijava/util/Types.java
@@ -784,8 +784,8 @@ public final class Types {
 			if (!satisfiesRawTypes(args[i], params[i])) return false;
 
 			if (params[i] instanceof ParameterizedType) {
-				if (!satisfiesParameterizedTypes((ParameterizedType) args[i],
-					(ParameterizedType) params[i], typeBounds)) return false;
+				if (!satisfiesParameterizedTypes(args[i], (ParameterizedType) params[i],
+					typeBounds)) return false;
 			}
 			else if (params[i] instanceof TypeVariable) {
 				if (!satisfiesTypeVariable(args[i], (TypeVariable<?>) params[i],
@@ -828,14 +828,18 @@ public final class Types {
 		return true;
 	}
 
-	private static boolean satisfiesParameterizedTypes(
-		final ParameterizedType arg, final ParameterizedType param,
+	private static boolean satisfiesParameterizedTypes(final Type arg,
+		final ParameterizedType param,
 		final HashMap<TypeVariable<?>, TypeVarInfo> typeBounds)
 	{
-		// get an array of the source parameter types
-		final Type[] srcTypes = arg.getActualTypeArguments();
 		// get an array of the destination parameter types
 		final Type[] destTypes = param.getActualTypeArguments();
+
+		// get an array of the source argument types
+		final Type[] srcTypes = new Type[destTypes.length];
+		for (int i = 0; i < srcTypes.length; i++) {
+			srcTypes[i] = Types.param(arg, Types.raw(arg), i);
+		}
 		// check to see if any of the Types of this ParameterizedType are
 		// TypeVariables, if so restrict them to the type parameter of the argument.
 		for (int i = 0; i < destTypes.length; i++) {

--- a/src/main/java/org/scijava/util/Types.java
+++ b/src/main/java/org/scijava/util/Types.java
@@ -749,6 +749,238 @@ public final class Types {
 	}
 
 	/**
+	 * Discerns whether it would be legal to pass a sequence of references of the
+	 * given source types to a method with parameters typed according to the
+	 * specified sequence of destination types.
+	 * <p>
+	 * An example: suppose you have a method
+	 * {@code <T extends Number> mergeLists(List<T> list1, List<T> list2)}. It is
+	 * legal to pass two {@code List<Integer>} instances to the method, but
+	 * illegal to pass a {@code List<Integer>} and {@code List<Double>} because
+	 * {@code T} cannot be both {@code Integer} and {@code Double} simultaneously.
+	 * </p>
+	 *
+	 * @param src
+	 * @param dest
+	 * @return True iff
+	 */
+	public static boolean satisfies(final Type[] args, final Type[] params) {
+		// create a HashMap to monitor the restrictions of the type variables.
+		final HashMap<TypeVariable<?>, TypeVarInfo> typeBounds = new HashMap<>();
+
+		return satisfies(args, params, typeBounds);
+
+	}
+
+	public static boolean satisfies(final Type[] args, final Type[] params,
+		final HashMap<TypeVariable<?>, TypeVarInfo> typeBounds)
+	{
+		if (args.length != params.length) {
+			throw new IllegalArgumentException("src and dest lengths differ");
+		}
+
+		for (int i = 0; i < params.length; i++) {
+			// First, check raw type assignability.
+			if (!satisfiesRawTypes(args[i], params[i])) return false;
+
+			if (params[i] instanceof ParameterizedType) {
+				if (!satisfiesParameterizedTypes((ParameterizedType) args[i],
+					(ParameterizedType) params[i], typeBounds)) return false;
+			}
+			else if (params[i] instanceof TypeVariable) {
+				if (!satisfiesTypeVariable(args[i], (TypeVariable<?>) params[i],
+					typeBounds)) return false;
+			}
+			else if (params[i] instanceof WildcardType) {
+				if (!satisfiesWildcardType(args[i], (WildcardType) params[i]))
+					return false;
+			}
+			else if (params[i] instanceof GenericArrayType) {
+				if (!satisfiesGenericArrayType(args[i], (GenericArrayType) params[i],
+					typeBounds)) return false;
+			}
+			final Type t = TypeToken.of(params[i]).resolveType(args[i]).getType();
+//			System.out.println("src[" + i + "] = " + t);
+		}
+		return true;
+	}
+
+	public static boolean satisfies(
+		final Map<TypeVariable<?>, Type> typeVarAssigns)
+	{
+		return TypeUtils.typesSatisfyVariables(typeVarAssigns);
+	}
+
+	private static boolean satisfiesRawTypes(final Type arg, final Type param) {
+		final List<Class<?>> srcClasses = Types.raws(arg);
+		final List<Class<?>> destClasses = Types.raws(param);
+		for (final Class<?> destClass : destClasses) {
+			final Optional<Class<?>> first = srcClasses.stream().filter(
+				srcClass -> destClass.isAssignableFrom(srcClass)).findFirst();
+			if (!first.isPresent()) {
+				// TODO can we remove this?
+//				throw new IllegalArgumentException("Argument #" + i + //
+//					" (" + Types.name(src[i]) + ") is not assignable to " + //
+//					"destination type (" + Types.name(dest[i]) + ")");
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static boolean satisfiesParameterizedTypes(
+		final ParameterizedType arg, final ParameterizedType param,
+		final HashMap<TypeVariable<?>, TypeVarInfo> typeBounds)
+	{
+		// get an array of the source parameter types
+		final Type[] srcTypes = arg.getActualTypeArguments();
+		// get an array of the destination parameter types
+		final Type[] destTypes = param.getActualTypeArguments();
+		// check to see if any of the Types of this ParameterizedType are
+		// TypeVariables, if so restrict them to the type parameter of the argument.
+		for (int i = 0; i < destTypes.length; i++) {
+			final Type destType = destTypes[i];
+			if (destType instanceof TypeVariable<?>) {
+				final Type srcType = srcTypes[i];
+				final TypeVariable<?> destTypeVar = (TypeVariable<?>) destType;
+				if (!satisfiesTypeParameter(srcType, destTypeVar, typeBounds))
+					return false;
+			}
+		}
+		// recursively run satisfies on these arrays
+		return satisfies(srcTypes, destTypes, typeBounds);
+
+	}
+
+	/**
+	 * Determines whether or not the {@link Type} {@code arg} can satisfy the
+	 * {@link TypeVariable} {@code param} given the preexisting limitations of
+	 * {@code param}. If it is determined that this replacement is allowed the
+	 * {@link TypeVariable} is then restriced to the {@link Type} of {@code arg}
+	 * (if this is not desired use {@link #satisfiesTypeVariable} instead}.
+	 *
+	 * @param arg - a Type Parameter for a given {@link ParameterizedType}
+	 * @param param - a {@link TypeVariable} that could potentially be replaced
+	 *          with {@code arg}
+	 * @param typeBounds - a {@link HashMap} containing the current restrictions
+	 *          of the {@link TypeVariable}s
+	 * @return {@code boolean} - true if the replacement of {@code param} with
+	 *         {@code arg} is allowed.
+	 */
+	private static boolean satisfiesTypeParameter(final Type arg,
+		final TypeVariable<?> param,
+		final HashMap<TypeVariable<?>, TypeVarInfo> typeBounds)
+	{
+		// add the type variable to the HashMap if it does not yet exist.
+		if (!typeBounds.containsKey(param)) {
+			final TypeVariable<?> newTypeVar = param;
+			typeBounds.put(newTypeVar, new TypeVarInfo(newTypeVar));
+		}
+		// attempt to restrict the bounds of the type variable to the argument.
+		if (!typeBounds.get(param).fixBounds(arg)) return false;
+
+		// TODO do we need type parameter recursion here as we do in
+		// satisfiesTypeVariable?
+
+		return true;
+	}
+
+	/**
+	 * @param arg
+	 * @param param
+	 * @param typeBounds
+	 * @return
+	 */
+	private static boolean satisfiesTypeVariable(final Type arg,
+		final TypeVariable<?> param,
+		final HashMap<TypeVariable<?>, TypeVarInfo> typeBounds)
+	{
+		// if the TypeVariable is not already in the hashMap add it.
+		if (!typeBounds.containsKey(param)) typeBounds.put(param, new TypeVarInfo(
+			param));
+		// check to make sure that arg is a viable replacement for the type
+		// variable.
+		if (!typeBounds.get(param).allowType(arg)) return false;
+
+		// if the type variable refers to some parameterized type (e.g. T extends
+		// List<?>), call satisfiesTypeParameters on the bounds of param that
+		// are ParameterizedTypes.
+		final Type[] paramBounds = typeBounds.get(param).upperBounds;
+		for (final Type paramBound : paramBounds) {
+			// only have to check the bounds of the
+			if (paramBound instanceof ParameterizedType) {
+
+				final ParameterizedType paramBoundType = (ParameterizedType) paramBound;
+				final Type[] paramBoundTypes = paramBoundType.getActualTypeArguments();
+				for (int i = 0; i < paramBoundTypes.length; i++) {
+					final Type argType = Types.param(arg, Types.raw(param), i);
+					if (paramBoundTypes[i] instanceof TypeVariable<?> &&
+						!satisfiesTypeParameter(argType,
+							(TypeVariable<?>) paramBoundTypes[i], typeBounds)) return false;
+					else if (!satisfies(new Type[] { argType }, new Type[] {
+						paramBoundTypes[i] }, typeBounds)) return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	private static boolean satisfiesWildcardType(final Type arg,
+		final WildcardType param)
+	{
+		final Type[] upperBounds = param.getUpperBounds();
+		final Type[] lowerBounds = param.getLowerBounds();
+		final Class<?> argType = Types.raw(arg);
+		for (final Type upperBound : upperBounds) {
+			// check that the argument can satisfy the parameter
+			final Class<?> upperType = Types.raw(upperBound);
+			if (!upperType.isAssignableFrom(argType)) return false;
+		}
+		for (final Type lowerBound : lowerBounds) {
+			final Class<?> lowerType = Types.raw(lowerBound);
+			// check that the argument can satisfy the parameter
+			if (!argType.isAssignableFrom(lowerType)) return false;
+		}
+
+		return true;
+	}
+
+	private static boolean satisfiesGenericArrayType(final Type arg,
+		final GenericArrayType param,
+		final HashMap<TypeVariable<?>, TypeVarInfo> typeBounds)
+	{
+		// get a class object of the component type of each array
+		final Type argComponent = Types.component(arg);
+		final Type paramComponent = Types.component(param);
+
+		if (paramComponent instanceof ParameterizedType) {
+			// TODO are these casts safe?
+			final ParameterizedType argType = (ParameterizedType) argComponent;
+			final ParameterizedType paramType = (ParameterizedType) paramComponent;
+
+			if (!satisfiesParameterizedTypes(argType, paramType, typeBounds))
+				return false;
+		}
+
+		else if (paramComponent instanceof TypeVariable) {
+			// TODO are these casts safe?
+			final TypeVariable<?> paramType = (TypeVariable<?>) paramComponent;
+
+			if (!satisfiesTypeVariable(argComponent, paramType, typeBounds))
+				return false;
+		}
+
+		// TODO is this necessary? It is only necessary if the component is allowed
+		// to be
+		// something other than a ParameterizedType or a TypeVariable.
+		final Class<?> argClass = Types.raw(argComponent);
+		final Class<?> paramClass = Types.raw(paramComponent);
+		if (!paramClass.isAssignableFrom(argClass)) return false;
+		return true;
+	}
+
+	/**
 	 * Casts the given object to the specified type, or null if the types are
 	 * incompatible.
 	 */
@@ -965,6 +1197,73 @@ public final class Types {
 		}
 		catch (final IllegalArgumentException exc) {
 			return null;
+		}
+	}
+
+	/**
+	 * maintains info about an {@link TypeVariable}.
+	 */
+	private static class TypeVarInfo {
+
+		private final TypeVariable<?> var;
+		private final Type[] upperBounds;
+		private List<Type> types;
+
+		public TypeVarInfo(final TypeVariable<?> var) {
+			this.var = var;
+			this.upperBounds = var.getBounds();
+			this.types = new ArrayList<>();
+		}
+
+		/**
+		 * Sets the type of this {@link TypeVarInfo} to the type parameter, if it is
+		 * allowed. If the type parameter is not contained within the bounds of the
+		 * {@link TypeVariable}, then we return false, and the type of the
+		 * {@code TypeVariable} is not changed. N.B. if this {@code TypeVariable} is
+		 * being used in an {@link ParameterizedType} then
+		 * {@link TypeVarInfo#fixBounds} should be used instead.
+		 *
+		 * @param type - the {@link Type} we are trying to assign to this
+		 *          {@link TypeVarInfo}.
+		 * @return {@code boolean} - false if the {@code Type} is not assignable to
+		 *         this {@code TypeVarInfo}
+		 */
+		public boolean allowType(final Type type) {
+			final Class<?> typeClass = Types.raw(type);
+			// make sure that type extends all of the bounds of the type variable
+			for (final Type upperBound : upperBounds) {
+				if (!Types.raw(upperBound).isAssignableFrom(typeClass)) return false;
+			}
+
+			types.add(type);
+			return true;
+		}
+
+		/**
+		 * If a {@link TypeVariable} is used in a {@link ParameterizedType}, the
+		 * bounds have to be fixed such that the upperBound is the {@link Type}
+		 * parameterizing that {@link ParameterizedType}.
+		 *
+		 * @param bound
+		 * @return
+		 */
+		public boolean fixBounds(final Type bound) {
+			for (int i = 0; i < upperBounds.length; i++) {
+				if (Types.raw(upperBounds[i]).isAssignableFrom(Types.raw(bound)))
+					upperBounds[i] = bound;
+				else return false;
+			}
+
+			// make sure that all of the types that already fit in this variable
+			// before the variable was fixed still are allowed by the type variable.
+			final List<Type> temp = types;
+			temp.add(bound);
+			types = new ArrayList<>();
+			for (final Type type : temp) {
+				if (!allowType(type)) return false;
+			}
+
+			return true;
 		}
 	}
 

--- a/src/main/java/org/scijava/util/Types.java
+++ b/src/main/java/org/scijava/util/Types.java
@@ -31,6 +31,8 @@
 
 package org.scijava.util;
 
+import com.google.common.reflect.TypeToken;
+
 import java.io.File;
 
 // Portions of this class were adapted from the
@@ -68,9 +70,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
-
-import org.scijava.util.FileUtils;
 
 /**
  * Utility class for working with generic types, fields and methods.
@@ -86,6 +87,7 @@ import org.scijava.util.FileUtils;
  * </p>
  *
  * @author Curtis Rueden
+ * @author Gabe Selzer
  */
 public final class Types {
 
@@ -787,22 +789,22 @@ public final class Types {
 	public static ParameterizedType parameterize(final Class<?> rawType,
 		final Type... typeArgs)
 	{
-		return parameterize(rawType, rawType.getDeclaringClass(), typeArgs);
+		return parameterizeWithOwner(null, rawType, typeArgs);
 	}
 
 	/**
 	 * Creates a new {@link ParameterizedType} of the given class together with
 	 * the specified type arguments.
 	 *
-	 * @param rawType The class of the {@link ParameterizedType}.
 	 * @param ownerType The owner type of the parameterized class.
+	 * @param rawType The class of the {@link ParameterizedType}.
 	 * @param typeArgs The type arguments to use in parameterizing it.
 	 * @return The newly created {@link ParameterizedType}.
 	 */
-	public static ParameterizedType parameterize(final Class<?> rawType,
-		final Type ownerType, final Type... typeArgs)
+	public static ParameterizedType parameterizeWithOwner(final Type ownerType,
+		final Class<?> rawType, final Type... typeArgs)
 	{
-		return new TypeUtils.ParameterizedTypeImpl(rawType, ownerType, typeArgs);
+		return TypeUtils.parameterizeWithOwner(ownerType, rawType, typeArgs);
 	}
 
 	/**
@@ -3177,7 +3179,7 @@ public final class Types {
 				Arrays.fill(arguments, UNBOUND_WILDCARD);
 				final Type owner = clazz.getDeclaringClass() == null ? null
 					: addWildcardParameters(clazz.getDeclaringClass());
-				return parameterize(clazz, owner, arguments);
+				return parameterizeWithOwner(owner, clazz, arguments);
 			}
 			else {
 				return clazz;
@@ -3555,9 +3557,9 @@ public final class Types {
 				for (final CaptureTypeImpl captured : toInit) {
 					captured.init(varMap);
 				}
-				final Type ownerType = (pType.getOwnerType() == null) ? null : capture(
+				final Type ownerType = pType.getOwnerType() == null ? null : capture(
 					pType.getOwnerType());
-				return parameterize(clazz, ownerType, capturedArguments);
+				return parameterizeWithOwner(ownerType, clazz, capturedArguments);
 			}
 			return type;
 		}
@@ -3735,9 +3737,10 @@ public final class Types {
 			}
 			else if (type instanceof ParameterizedType) {
 				final ParameterizedType pType = (ParameterizedType) type;
-				return parameterize((Class<?>) pType.getRawType(), pType
-					.getOwnerType() == null ? pType.getOwnerType() : map(pType
-						.getOwnerType()), map(pType.getActualTypeArguments()));
+				final Type ownerType = pType.getOwnerType() == null ? //
+					pType.getOwnerType() : map(pType.getOwnerType());
+				return parameterizeWithOwner(ownerType, (Class<?>) pType.getRawType(),
+					map(pType.getActualTypeArguments()));
 			}
 			else if (type instanceof WildcardType) {
 				final WildcardType wType = (WildcardType) type;

--- a/src/main/java/org/scijava/util/Types.java
+++ b/src/main/java/org/scijava/util/Types.java
@@ -1412,7 +1412,7 @@ public final class Types {
 				// parameters must either be absent from the subject type, within
 				// the bounds of the wildcard type, or be an exact match to the
 				// parameters of the target type.
-				if (fromTypeArg != null && !toTypeArg.equals(fromTypeArg) &&
+				if (fromTypeArg != null && !fromTypeArg.equals(toTypeArg) &&
 					!(toTypeArg instanceof WildcardType && isAssignable(fromTypeArg,
 						toTypeArg, typeVarAssigns)))
 				{

--- a/src/test/java/org/scijava/ContextCreationTest.java
+++ b/src/test/java/org/scijava/ContextCreationTest.java
@@ -118,6 +118,7 @@ public class ContextCreationTest {
 				org.scijava.text.DefaultTextService.class,
 				org.scijava.thread.DefaultThreadService.class,
 				org.scijava.tool.DefaultToolService.class,
+				org.scijava.types.DefaultTypeService.class,
 				org.scijava.ui.DefaultUIService.class,
 				org.scijava.ui.dnd.DefaultDragAndDropService.class,
 				org.scijava.welcome.DefaultWelcomeService.class,

--- a/src/test/java/org/scijava/convert/NilConverterTest.java
+++ b/src/test/java/org/scijava/convert/NilConverterTest.java
@@ -1,0 +1,119 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.convert;
+
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.Observer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.types.Nil;
+import org.scijava.util.Types;
+
+/**
+ * Tests {@link NilConverter}.
+ *
+ * @author Curtis Rueden
+ */
+public class NilConverterTest {
+
+	private ConvertService convert;
+
+	/** Sets up a SciJava context and injects needed services. */
+	@Before
+	public void setUp() {
+		convert = new Context(ConvertService.class).service(ConvertService.class);
+	}
+
+	/**
+	 * Disposes of the {@link Context} that was initialized in {@link #setUp()}.
+	 */
+	@After
+	public synchronized void cleanUp() {
+		if (convert != null) {
+			convert.context().dispose();
+			convert = null;
+		}
+	}
+
+	@Test
+	public void testCanConvert() {
+		final Nil<?> nil = Nil.of(Observer.class);
+		assertCanConvert(nil, Observer.class);
+		assertCanConvert(nil, List.class);
+		assertCanConvert(nil, new Nil<Map<?, ?>>() {}.getType());
+		// TODO: Enable after ConvertService is rewritten to fully
+		// support generic types. Right now, CastingConverter steals this.
+//		assertCanConvert(nil, new Nil<Nil<Map<?, ?>>>() {}.getType());
+	}
+
+	@SuppressWarnings("cast")
+	@Test
+	public void testConvert() {
+		final Nil<?> nil = Nil.of(Observer.class);
+		assertConvert(nil, Observer.class);
+		assertConvert(nil, List.class);
+		assertConvert(nil, new Nil<Map<?, ?>>() {}.getType());
+		// TODO: Enable after ConvertService is rewritten to fully
+		// support generic types. Right now, CastingConverter steals this.
+//		assertConvert(nil, new Nil<Nil<Map<?, ?>>>() {}.getType());
+		final Converter<?, ?> converter = convert.getHandler(nil, Observer.class);
+		assertTrue(converter instanceof NilConverter);
+		// TODO: Enable after Nil proxying is improved to support non-interfaces.
+//		assertTrue(converter.convert(nil, String.class) instanceof String);
+		assertTrue(converter.convert(nil, List.class) instanceof List);
+		assertTrue(converter.convert(nil, new Nil<Map<?, ?>>() {}.getType()) instanceof Map);
+		// TODO: Enable after ConvertService is rewritten to fully
+		// support generic types. Right now, CastingConverter steals this.
+//		assertTrue(converter.convert(nil, new Nil<Nil<Map<?, ?>>>() {}.getType()) instanceof Nil);
+	}
+
+	private void assertCanConvert(final Nil<?> nil, final Type destType) {
+		final Converter<?, ?> converter = convert.getHandler(nil, destType);
+		assertTrue(converter instanceof NilConverter);
+		assertTrue(converter.canConvert(nil, destType));
+	}
+
+	private void assertConvert(final Nil<?> nil, final Type destType) {
+		final Converter<?, ?> converter = convert.getHandler(nil, destType);
+		assertTrue(converter instanceof NilConverter);
+		final Object o = converter.convert(nil, destType);
+		assertTrue(Types.raw(destType).isAssignableFrom(o.getClass()));
+	}
+
+}

--- a/src/test/java/org/scijava/types/ExampleTypes.java
+++ b/src/test/java/org/scijava/types/ExampleTypes.java
@@ -32,6 +32,9 @@
 package org.scijava.types;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Helper classes for {@link org.scijava.types} tests.
@@ -71,4 +74,9 @@ public final class ExampleTypes {
 
 	public static class Bag<T extends Thing<T>> extends ArrayList<T> {}
 
+	public interface Data<K, V> {
+		Map<K, V> map();
+		Set<K> keySet();
+		List<V> values();
+	}
 }

--- a/src/test/java/org/scijava/types/ExampleTypes.java
+++ b/src/test/java/org/scijava/types/ExampleTypes.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.types;
+
+import java.util.ArrayList;
+
+/**
+ * Helper classes for {@link org.scijava.types} tests.
+ *
+ * @author Curtis Rueden
+ */
+public final class ExampleTypes {
+
+	public ExampleTypes() {
+		// NB: Prevent instantiation of utility class.
+	}
+
+	public interface Thing<T extends Thing<T>> {
+
+		T thing();
+
+		default int size() {
+			return 1;
+		}
+	}
+
+	public static class BlueThing implements Thing<BlueThing> {
+
+		@Override
+		public BlueThing thing() {
+			return this;
+		}
+	}
+
+	public static class RedThing implements Thing<RedThing> {
+
+		@Override
+		public RedThing thing() {
+			return this;
+		}
+	}
+
+	public static class Bag<T extends Thing<T>> extends ArrayList<T> {}
+
+}

--- a/src/test/java/org/scijava/types/NilTest.java
+++ b/src/test/java/org/scijava/types/NilTest.java
@@ -1,0 +1,122 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.types;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.scijava.types.ExampleTypes.Bag;
+import org.scijava.types.ExampleTypes.Thing;
+
+/**
+ * Tests {@link Nil}.
+ *
+ * @author Curtis Rueden
+ */
+public class NilTest {
+
+	@Test
+	public <Q extends Thing<Q>> void testType() {
+		final Nil<Bag<Q>> nilBag = new Nil<Bag<Q>>() {};
+
+		// Bag<Q>
+		final ParameterizedType pType = (ParameterizedType) nilBag.getType();
+		assertSame(Bag.class, pType.getRawType());
+		final Type pBound = extractSingleBound(pType);
+
+		// Q extends Thing<Q>
+		final ParameterizedType qType = (ParameterizedType) pBound;
+		final Type qBound = extractSingleBound(qType);
+		assertSame(qType, qBound); // recursive type!
+	}
+
+	@SuppressWarnings("cast")
+	@Test
+	public <N extends Number> void testProxy() {
+		final List<N> listProxy = new Nil<List<N>>() {}.proxy();
+		assertTrue(listProxy instanceof Iterable);
+		assertTrue(listProxy instanceof Collection);
+		assertTrue(listProxy instanceof List);
+		assertTrue(listProxy instanceof GenericTyped);
+		final GenericTyped genericTyped = (GenericTyped) listProxy;
+
+		// List<N>
+		final ParameterizedType pType = (ParameterizedType) genericTyped.getType();
+		assertSame(List.class, pType.getRawType());
+		final Type pBound = extractSingleBound(pType);
+
+		// N extends Number
+		assertSame(Number.class, pBound);
+	}
+
+	@Test
+	public <N extends Number> void testCallbacks() {
+		final Nil<List<N>> listNil = new Nil<List<N>>() {};
+		final List<N> listProxy = listNil.proxy();
+		assertEquals(0, listProxy.size()); // default method return value is 0/null
+		assertNull(listProxy.iterator());
+
+		final Nil<List<N>> listNil2 = new Nil<List<N>>() {
+
+			@SuppressWarnings("unused")
+			public int size() {
+				return 21;
+			}
+		};
+		final List<N> listProxy2 = listNil2.proxy();
+		assertEquals(21, listProxy2.size()); // overridden method behavior
+
+		final Collection<?> cProxy2 = new Nil<Collection<?>>(listProxy2) {}.proxy();
+		assertEquals(21, cProxy2.size()); // behavior preserved by wrapping proxy
+
+		final Collection<?> cProxy3 = new Nil<Collection<?>>(listNil2) {}.proxy();
+		assertEquals(21, cProxy3.size()); // behavior preserved by wrapping nil
+	}
+
+	// -- Helper methods --
+
+	private Type extractSingleBound(final ParameterizedType pType) {
+		final Type[] typeArgs = pType.getActualTypeArguments();
+		assertEquals(1, typeArgs.length);
+		final Type[] bounds = ((TypeVariable<?>) typeArgs[0]).getBounds();
+		assertEquals(1, bounds.length);
+		return bounds[0];
+	}
+}

--- a/src/test/java/org/scijava/types/TypeServiceTest.java
+++ b/src/test/java/org/scijava/types/TypeServiceTest.java
@@ -1,0 +1,169 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.types;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.types.ExampleTypes.Bag;
+import org.scijava.types.ExampleTypes.BlueThing;
+import org.scijava.types.ExampleTypes.RedThing;
+
+/**
+ * Tests {@link TypeService}, including core {@link TypeExtractor}
+ * implementations.
+ *
+ * @author Curtis Rueden
+ */
+public class TypeServiceTest {
+
+	private TypeService types;
+
+	@Before
+	public void setUp() {
+		types = new Context(TypeService.class).service(TypeService.class);
+	}
+
+	@After
+	public void tearDown() {
+		if (types != null) {
+			types.context().dispose();
+			types = null;
+		}
+	}
+
+	/** Tests type extraction for non-generic objects. */
+	@Test
+	public void testClass() {
+		final Type stringType = types.reify("Hello");
+		assertEquals(String.class, stringType);
+	}
+
+	/** Tests type extraction for {@code null} objects. */
+	@Test
+	public void testNull() {
+		final Type nullType = types.reify(null);
+		assertNull(nullType);
+	}
+
+	/** Tests type extraction for {@link Nil} objects. */
+	@Test
+	public void testNil() {
+		final Nil<List<Float>> nilFloatList = new Nil<List<Float>>() {};
+		final Type nilFloatListType = types.reify(nilFloatList);
+		assertEquals(nilFloatList.getType(), nilFloatListType);
+	}
+
+	/** Tests type extraction for {@link GenericTyped} objects. */
+	@Test
+	public void testGenericTyped() {
+		final Object numberThing = new GenericTyped() {
+
+			@Override
+			public Type getType() {
+				return Number.class;
+			}
+		};
+		assertEquals(Number.class, types.reify(numberThing));
+	}
+
+	/** Tests type extraction for {@link Iterable} objects. */
+	@Test
+	public void testIterable() {
+		final List<String> stringList = //
+			new ArrayList<>(Collections.singletonList("Hi"));
+		final Type stringListType = types.reify(stringList);
+		assertEquals(new Nil<ArrayList<String>>() {}.getType(), stringListType);
+	}
+
+	/** Tests type extraction for {@link Map} objects. */
+	@Test
+	public void testMap() {
+		final Map<String, Integer> mapSI = //
+			new HashMap<>(Collections.singletonMap("Curtis", 37));
+		final Type mapSIType = types.reify(mapSI);
+		assertEquals(new Nil<HashMap<String, Integer>>() {}.getType(), mapSIType);
+	}
+
+	/** Tests nested type extraction of a complex object. */
+	@Test
+	public void testNested() {
+		// List of organization test scores.
+		// For each organization, we have a table of students by name.
+		final List<Map<String, List<Integer>>> testScores = new ArrayList<>();
+
+		final Map<String, List<Integer>> hogwarts = new HashMap<>();
+		hogwarts.put("Hermione", new ArrayList<>(Arrays.asList(100, 99, 101)));
+		hogwarts.put("Ron", new ArrayList<>(Arrays.asList(45, 56, 82)));
+		testScores.add(hogwarts);
+
+		final Map<String, List<Integer>> highlights = new HashMap<>();
+		highlights.put("Goofus", new ArrayList<>(Arrays.asList(12, 0, 23)));
+		highlights.put("Gallant", new ArrayList<>(Arrays.asList(87, 92, 96)));
+		testScores.add(highlights);
+
+		final Type testScoresType = types.reify(testScores);
+		assertEquals(new Nil<ArrayList<HashMap<String, ArrayList<Integer>>>>() {}
+			.getType(), testScoresType);
+	}
+
+	/**
+	 * Tests type extraction for recursively typed objects (e.g.,
+	 * {@code F extends Foo<F>}.
+	 */
+	@Test
+	public void testRecursiveTyping() {
+		final Bag<BlueThing> blueBag = new Bag<>();
+		blueBag.add(new BlueThing());
+
+		final Type blueBagType = types.reify(blueBag);
+		assertEquals(new Nil<Bag<BlueThing>>() {}.getType(), blueBagType);
+
+		final Bag<RedThing> redBag = new Bag<>();
+		redBag.add(new RedThing());
+
+		final Type redBagType = types.reify(redBag);
+		assertEquals(new Nil<Bag<RedThing>>() {}.getType(), redBagType);
+	}
+}

--- a/src/test/java/org/scijava/util/TypesTest.java
+++ b/src/test/java/org/scijava/util/TypesTest.java
@@ -310,6 +310,12 @@ public class TypesTest {
 		}
 	}
 
+	/** Tests [@link Types#unbox(Class)}. */
+	@Test
+	public void testUnbox() {
+		// TODO
+	}
+
 	/** Tests {@link Types#nullValue(Class)}. */
 	@Test
 	public void testNullValue() {
@@ -597,11 +603,30 @@ public class TypesTest {
 		Types.enumValue("HOOYAH", String.class);
 	}
 
+	/** Tests {@link Types#parameterize(Class, Map)}. */
+	@Test
+	public void testParameterizeMap() {
+		// TODO
+	}
+
+	/** Tests {@link Types#parameterize(Class, Type...)}. */
+	@Test
+	public void testParameterizeTypes() {
+		// TODO
+	}
+
+	/** Tests {@link Types#parameterizeWithOwner(Type, Class, Type...)}. */
+	@Test
+	public void testParameterizeWithOwner() {
+		// TODO
+	}
+
 	// -- Helper classes --
 
 	// TODO: Migrate these helper classes into ExampleTypes.
 
 	private static class Thing<T> {
+
 		@SuppressWarnings("unused")
 		private T thing;
 	}

--- a/src/test/java/org/scijava/util/TypesTest.java
+++ b/src/test/java/org/scijava/util/TypesTest.java
@@ -34,6 +34,7 @@ package org.scijava.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -567,12 +568,12 @@ public class TypesTest {
 		// f(Double, Integer)
 		// [OK] Double -> Number
 		final Type[] srcOK = { Double.class, Integer.class };
-		assertTrue(Types.satisfies(srcOK, dest));
+		assertEquals(Types.satisfies(srcOK, dest), -1);
 
 		// f(String, Integer)
 		// [MISS] String is not assignable to Number
 		final Type[] srcMiss = { String.class, Integer.class };
-		assertFalse(Types.satisfies(srcMiss, dest));
+		assertNotEquals(Types.satisfies(srcMiss, dest), -1);
 
 	}
 
@@ -584,12 +585,12 @@ public class TypesTest {
 		final Type u = new Nil<U>() {}.getType();
 		final Type[] tDest = { t };
 
-		assertTrue(Types.satisfies(new Type[] { Double.class }, tDest));
-		assertTrue(Types.satisfies(new Type[] { Number.class }, tDest));
-		assertTrue(Types.satisfies(new Type[] { t }, tDest));
-		assertTrue(Types.satisfies(new Type[] { u }, tDest));
+		assertEquals(Types.satisfies(new Type[] { Double.class }, tDest), -1);
+		assertEquals(Types.satisfies(new Type[] { Number.class }, tDest), -1);
+		assertEquals(Types.satisfies(new Type[] { t }, tDest), -1);
+		assertEquals(Types.satisfies(new Type[] { u }, tDest), -1);
 		// String does not extend Number
-		assertFalse(Types.satisfies(new Type[] { String.class }, tDest));
+		assertNotEquals(Types.satisfies(new Type[] { String.class }, tDest), -1);
 
 		// -SINGLY RECURSIVE CALLS-
 
@@ -610,18 +611,18 @@ public class TypesTest {
 			.getType();
 		final Type[] listExtendsNumberDest = { listExtendsNumber };
 
-		assertTrue(Types.satisfies(new Type[] { listT }, listTDest));
-		assertTrue(Types.satisfies(listUDest, listTDest));
+		assertEquals(Types.satisfies(new Type[] { listT }, listTDest), -1);
+		assertEquals(Types.satisfies(listUDest, listTDest), -1);
 		// not all Numbers are BigIntegers.
-		assertFalse(Types.satisfies(listTDest, listUDest));
-		assertTrue(Types.satisfies(listTDest, listExtendsNumberDest));
-		assertTrue(Types.satisfies(listUDest, listExtendsNumberDest));
-		assertTrue(Types.satisfies(listTDest, listSuperNumberDest));
+		assertNotEquals(Types.satisfies(listTDest, listUDest), -1);
+		assertEquals(Types.satisfies(listTDest, listExtendsNumberDest), -1);
+		assertEquals(Types.satisfies(listUDest, listExtendsNumberDest), -1);
+		assertEquals(Types.satisfies(listTDest, listSuperNumberDest), -1);
 		// BigInteger extends Number, not the other way around.
-		assertFalse(Types.satisfies(listUDest, listSuperNumberDest));
-		assertTrue(Types.satisfies(listDoubleDest, listExtendsNumberDest));
+		assertNotEquals(Types.satisfies(listUDest, listSuperNumberDest), -1);
+		assertEquals(Types.satisfies(listDoubleDest, listExtendsNumberDest), -1);
 		// Double extends Number, not the other way around.
-		assertFalse(Types.satisfies(listDoubleDest, listSuperNumberDest));
+		assertNotEquals(Types.satisfies(listDoubleDest, listSuperNumberDest), -1);
 
 		// -MULTIPLY RECURSIVE CALLS-
 
@@ -639,32 +640,32 @@ public class TypesTest {
 			.getType();
 
 		// T might not always extend BigInteger(U)
-		assertFalse(Types.satisfies(new Type[] { MapListTT }, new Type[] {
-			MapListTU }));
+		assertNotEquals(Types.satisfies(new Type[] { MapListTT }, new Type[] {
+			MapListTU }), -1);
 		// T might not always be the same as U
-		assertFalse(Types.satisfies(new Type[] { MapListTU }, new Type[] {
-			MapListTT }));
-		assertTrue(Types.satisfies(new Type[] { MapListUU }, new Type[] {
-			MapListTT }));
+		assertNotEquals(Types.satisfies(new Type[] { MapListTU }, new Type[] {
+			MapListTT }), -1);
+		assertEquals(Types.satisfies(new Type[] { MapListUU }, new Type[] {
+			MapListTT }), -1);
 		// T might not always extend BigInteger(U)
-		assertFalse(Types.satisfies(new Type[] { MapListTT }, new Type[] {
-			MapListUU }));
+		assertNotEquals(Types.satisfies(new Type[] { MapListTT }, new Type[] {
+			MapListUU }), -1);
 		// T might not always be Double
-		assertFalse(Types.satisfies(new Type[] { MapListTDouble }, new Type[] {
-			MapListTT }));
+		assertNotEquals(Types.satisfies(new Type[] { MapListTDouble }, new Type[] {
+			MapListTT }), -1);
 		// T does not extend String.
-		assertFalse(Types.satisfies(new Type[] { MapListDoubleString }, new Type[] {
-			MapListTT }));
-		assertTrue(Types.satisfies(new Type[] { MapListDoubleDouble }, new Type[] {
-			MapListTT }));
+		assertNotEquals(Types.satisfies(new Type[] { MapListDoubleString },
+			new Type[] { MapListTT }), -1);
+		assertEquals(Types.satisfies(new Type[] { MapListDoubleDouble },
+			new Type[] { MapListTT }), -1);
 		// T is already fixed to Double (in a parameterized Map), cannot accomodate
 		// Nubmer.
-		assertFalse(Types.satisfies(new Type[] { MapListNumberDouble }, new Type[] {
-			MapListTT }));
+		assertNotEquals(Types.satisfies(new Type[] { MapListNumberDouble },
+			new Type[] { MapListTT }), -1);
 		// T is already fixed to Double (in a parameterized List) , cannot
 		// accomodate Number
-		assertFalse(Types.satisfies(new Type[] { MapListDoubleNumber }, new Type[] {
-			MapListTT }));
+		assertNotEquals(Types.satisfies(new Type[] { MapListDoubleNumber },
+			new Type[] { MapListTT }), -1);
 	}
 
 	@Test
@@ -677,45 +678,48 @@ public class TypesTest {
 		final Type arrayV = new Nil<V[]>() {}.getType();
 		final Type arrayDouble = new Nil<Double[]>() {}.getType();
 
-		assertTrue(Types.satisfies(new Type[] { arrayDouble }, new Type[] {
-			arrayT }));
+		assertEquals(Types.satisfies(new Type[] { arrayDouble }, new Type[] {
+			arrayT }), -1);
 		// Double does not extend String
-		assertFalse(Types.satisfies(new Type[] { arrayDouble }, new Type[] {
-			arrayU }));
-		assertTrue(Types.satisfies(new Type[] { arrayT }, new Type[] { arrayT }));
-		assertTrue(Types.satisfies(new Type[] { arrayV }, new Type[] { arrayT }));
+		assertNotEquals(Types.satisfies(new Type[] { arrayDouble }, new Type[] {
+			arrayU }), -1);
+		assertEquals(Types.satisfies(new Type[] { arrayT }, new Type[] { arrayT }),
+			-1);
+		assertEquals(Types.satisfies(new Type[] { arrayV }, new Type[] { arrayT }),
+			-1);
 		// Number does not extend BigInteger
-		assertFalse(Types.satisfies(new Type[] { arrayT }, new Type[] { arrayV }));
+		assertNotEquals(Types.satisfies(new Type[] { arrayT }, new Type[] {
+			arrayV }), -1);
 
 		// generic multi-dimensional arrays
 		final Type arrayT2D = new Nil<T[][]>() {}.getType();
 		final Type arrayV2D = new Nil<V[][]>() {}.getType();
 		final Type arrayDouble2D = new Nil<Double[][]>() {}.getType();
 
-		assertTrue(Types.satisfies(new Type[] { arrayDouble2D }, new Type[] {
-			arrayT2D }));
-		assertTrue(Types.satisfies(new Type[] { arrayV2D }, new Type[] {
-			arrayT2D }));
+		assertEquals(Types.satisfies(new Type[] { arrayDouble2D }, new Type[] {
+			arrayT2D }), -1);
+		assertEquals(Types.satisfies(new Type[] { arrayV2D }, new Type[] {
+			arrayT2D }), -1);
 		// A 2D array does not satisfy a 1D array
-		assertFalse(Types.satisfies(new Type[] { arrayT2D }, new Type[] {
-			arrayT }));
+		assertNotEquals(Types.satisfies(new Type[] { arrayT2D }, new Type[] {
+			arrayT }), -1);
 		// A 1D array does not satisfy a 2D array
-		assertFalse(Types.satisfies(new Type[] { arrayT }, new Type[] {
-			arrayT2D }));
+		assertNotEquals(Types.satisfies(new Type[] { arrayT }, new Type[] {
+			arrayT2D }), -1);
 
 		// generic parameterized type arrays
 		final Type arrayListT = new Nil<List<T>[]>() {}.getType();
 		final Type arrayListDouble = new Nil<List<Double>[]>() {}.getType();
 		final Type arrayListString = new Nil<List<String>[]>() {}.getType();
 
-		assertTrue(Types.satisfies(new Type[] { arrayListDouble }, new Type[] {
-			arrayListT }));
+		assertEquals(Types.satisfies(new Type[] { arrayListDouble }, new Type[] {
+			arrayListT }), -1);
 		// String does not extend Number
-		assertFalse(Types.satisfies(new Type[] { arrayListString }, new Type[] {
-			arrayListT }));
+		assertNotEquals(Types.satisfies(new Type[] { arrayListString }, new Type[] {
+			arrayListT }), -1);
 		// Number does not extend BigInteger
-		assertFalse(Types.satisfies(new Type[] { arrayListT }, new Type[] {
-			arrayU }));
+		assertNotEquals(Types.satisfies(new Type[] { arrayListT }, new Type[] {
+			arrayU }), -1);
 
 	}
 
@@ -734,19 +738,19 @@ public class TypesTest {
 			.getType();
 		final Type integerThing = new Nil<IntegerThing>() {}.getType();
 
-		assertTrue(Types.satisfies(new Type[] { thingInt, thingInt, numberThingInt,
-			integerThing }, new Type[] { t, t, t, t }));
-		assertTrue(Types.satisfies(new Type[] { thingInt, numberThingInt,
-			strangerThingString }, new Type[] { t, t, t }));
-		assertTrue(Types.satisfies(new Type[] { thingInt, numberThingInt,
-			integerThing }, new Type[] { t, t, t }));
-		assertTrue(Types.satisfies(new Type[] { numberThingInt,
-			strangeThingDouble }, new Type[] { t, t }));
+		assertEquals(Types.satisfies(new Type[] { thingInt, thingInt,
+			numberThingInt, integerThing }, new Type[] { t, t, t, t }), -1);
+		assertEquals(Types.satisfies(new Type[] { thingInt, numberThingInt,
+			strangerThingString }, new Type[] { t, t, t }), -1);
+		assertEquals(Types.satisfies(new Type[] { thingInt, numberThingInt,
+			integerThing }, new Type[] { t, t, t }), -1);
+		assertEquals(Types.satisfies(new Type[] { numberThingInt,
+			strangeThingDouble }, new Type[] { t, t }), -1);
 		// S cannot accommodate a Double since S is already locked to Integer from
 		// the first argument.
-		assertFalse(Types.satisfies(new Type[] { thingInt, numberThingInt,
-			numberThingDouble }, new Type[] { t, t, t }));
-		assertTrue(Types.satisfies(new Type[] { u }, new Type[] { t }));
+		assertNotEquals(Types.satisfies(new Type[] { thingInt, numberThingInt,
+			numberThingDouble }, new Type[] { t, t, t }), -1);
+		assertEquals(Types.satisfies(new Type[] { u }, new Type[] { t }), -1);
 
 		// recursive Type Variables
 		final Type circularThing = new Nil<CircularThing>() {}.getType();
@@ -758,33 +762,33 @@ public class TypesTest {
 		final Type w = new Nil<W>() {}.getType();
 		final Type x = new Nil<X>() {}.getType();
 
-		assertTrue(Types.satisfies(new Type[] { circularThing, circularThing,
-			loopingThing }, new Type[] { t, t, t }));
+		assertEquals(Types.satisfies(new Type[] { circularThing, circularThing,
+			loopingThing }, new Type[] { t, t, t }), -1);
 		// V cannot accommodate LoopingThing since V is already locked to
 		// CircularThing
-		assertFalse(Types.satisfies(new Type[] { circularThing, circularThing,
-			loopingThing }, new Type[] { v, v, v }));
+		assertNotEquals(Types.satisfies(new Type[] { circularThing, circularThing,
+			loopingThing }, new Type[] { v, v, v }), -1);
 		// V cannot accommodate RecursiveThing since V is already locked to
 		// CircularThing (V has to extend RecursiveThing<itself>, not
 		// RecursiveThing<not itself>).
-		assertFalse(Types.satisfies(new Type[] { circularThing, circularThing,
-			recursiveThingCircular }, new Type[] { v, v, v }));
+		assertNotEquals(Types.satisfies(new Type[] { circularThing, circularThing,
+			recursiveThingCircular }, new Type[] { v, v, v }), -1);
 		// V cannot accommodate RecursiveThing<CircularThing> since V must extend
 		// RecursiveThing<V> (it cannot extend RecursiveThing<not V>)
-		assertFalse(Types.satisfies(new Type[] { recursiveThingCircular,
-			recursiveThingCircular, recursiveThingCircular }, new Type[] { v, v,
-				v }));
-		assertTrue(Types.satisfies(new Type[] { recursiveThingCircular,
-			recursiveThingCircular, recursiveThingCircular }, new Type[] { t, t,
-				t }));
-		assertTrue(Types.satisfies(new Type[] { circularThing, circularThing,
-			circularThing }, new Type[] { w, w, w }));
+		assertNotEquals(Types.satisfies(new Type[] { recursiveThingCircular,
+			recursiveThingCircular, recursiveThingCircular }, new Type[] { v, v, v }),
+			-1);
+		assertEquals(Types.satisfies(new Type[] { recursiveThingCircular,
+			recursiveThingCircular, recursiveThingCircular }, new Type[] { t, t, t }),
+			-1);
+		assertEquals(Types.satisfies(new Type[] { circularThing, circularThing,
+			circularThing }, new Type[] { w, w, w }), -1);
 		// W cannot accommodate LoopingThing since W is already
 		// fixed to CircularThing
-		assertFalse(Types.satisfies(new Type[] { circularThing, loopingThing,
-			circularThing }, new Type[] { w, w, w }));
-		assertTrue(Types.satisfies(new Type[] { circularThing, loopingThing,
-			circularThing }, new Type[] { x, x, x }));
+		assertNotEquals(Types.satisfies(new Type[] { circularThing, loopingThing,
+			circularThing }, new Type[] { w, w, w }), -1);
+		assertEquals(Types.satisfies(new Type[] { circularThing, loopingThing,
+			circularThing }, new Type[] { x, x, x }), -1);
 
 	}
 
@@ -809,7 +813,7 @@ public class TypesTest {
 			{}.getType(), //
 			new Nil<List<Integer>>()
 			{}.getType() };
-		assertTrue(Types.satisfies(argsOK, params));
+		assertEquals(Types.satisfies(argsOK, params), -1);
 
 		// f(List<String>, List<Number>)
 		// [MISS] T cannot be both String and Number
@@ -819,7 +823,7 @@ public class TypesTest {
 			new Nil<List<Number>>()
 			{}.getType() //
 		};
-		assertFalse(Types.satisfies(argsMiss, params));
+		assertNotEquals(Types.satisfies(argsMiss, params), -1);
 
 	}
 

--- a/src/test/java/org/scijava/util/TypesTest.java
+++ b/src/test/java/org/scijava/util/TypesTest.java
@@ -510,6 +510,31 @@ public class TypesTest {
 		Types.isAssignable(Object.class, null);
 	}
 
+	/** Tests {@link Types#isAssignable(Type, Type)} with type variable. */
+	@Test
+	public <T extends Number> void testIsAssignableT() {
+		final Type t = new Nil<T>() {}.getType();
+		final Type listT = new Nil<List<T>>() {}.getType();
+		final Type listNumber = new Nil<List<Number>>() {}.getType();
+		final Type listInteger = new Nil<List<Integer>>() {}.getType();
+		final Type listExtendsNumber = new Nil<List<? extends Number>>() {}.getType();
+
+		assertTrue(Types.isAssignable(t, t));
+		assertTrue(Types.isAssignable(listT, listT));
+		assertTrue(Types.isAssignable(listNumber, listNumber));
+		assertTrue(Types.isAssignable(listInteger, listInteger));
+		assertTrue(Types.isAssignable(listExtendsNumber, listExtendsNumber));
+
+		assertTrue(Types.isAssignable(listT, listExtendsNumber));
+		assertTrue(Types.isAssignable(listNumber, listExtendsNumber));
+		assertTrue(Types.isAssignable(listInteger, listExtendsNumber));
+
+		assertFalse(Types.isAssignable(listNumber, listT));
+		assertFalse(Types.isAssignable(listInteger, listT));
+		assertFalse(Types.isAssignable(listExtendsNumber, listT));
+		assertFalse(Types.isAssignable(listExtendsNumber, listNumber));
+	}
+
 	/** Tests {@link Types#isInstance(Object, Class)}. */
 	@Test
 	public void testIsInstance() {

--- a/src/test/java/org/scijava/util/TypesTest.java
+++ b/src/test/java/org/scijava/util/TypesTest.java
@@ -9,13 +9,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -157,13 +157,13 @@ public class TypesTest {
 		final File tmpDir = createTemporaryDirectory("class-utils-test-");
 		final String path = getClass().getName().replace('.', '/') + ".class";
 		final File classFile = new File(tmpDir, path);
-		assertTrue(classFile.getParentFile().exists() ||
-			classFile.getParentFile().mkdirs());
-		copy(getClass().getResource("/" + path).openStream(),
-			new FileOutputStream(classFile), true);
+		assertTrue(classFile.getParentFile().exists() || classFile.getParentFile()
+			.mkdirs());
+		copy(getClass().getResource("/" + path).openStream(), new FileOutputStream(
+			classFile), true);
 
-		final ClassLoader classLoader =
-			new URLClassLoader(new URL[] { tmpDir.toURI().toURL() }, null);
+		final ClassLoader classLoader = new URLClassLoader(new URL[] { tmpDir
+			.toURI().toURL() }, null);
 		final Class<?> c = Types.load(getClass().getName(), classLoader);
 		final URL location = Types.location(c);
 		assertEquals(tmpDir, FileUtils.urlToFile(location));
@@ -180,8 +180,8 @@ public class TypesTest {
 		out.putNextEntry(new ZipEntry(path));
 		copy(getClass().getResource("/" + path).openStream(), out, true);
 
-		final ClassLoader classLoader =
-			new URLClassLoader(new URL[] { jar.toURI().toURL() }, null);
+		final ClassLoader classLoader = new URLClassLoader(new URL[] { jar.toURI()
+			.toURL() }, null);
 		final Class<?> c = Types.load(getClass().getName(), classLoader);
 		final URL location = Types.location(c);
 		assertEquals(jar, FileUtils.urlToFile(location));
@@ -243,7 +243,8 @@ public class TypesTest {
 		final Field field = Types.field(Thing.class, "thing");
 
 		// Object
-		assertAllTheSame(Types.raws(Types.fieldType(field, Thing.class)), Object.class);
+		assertAllTheSame(Types.raws(Types.fieldType(field, Thing.class)),
+			Object.class);
 
 		// N extends Number
 		assertAllTheSame(Types.raws(Types.fieldType(field, NumberThing.class)),
@@ -290,22 +291,22 @@ public class TypesTest {
 
 		final Class<?>[] types = { //
 			Boolean.class, Byte.class, Character.class, Double.class, //
-				Float.class, Integer.class, Long.class, Short.class, //
-				Void.class, //
-				String.class, //
-				Number.class, BigInteger.class, BigDecimal.class, //
-				boolean[].class, byte[].class, char[].class, double[].class, //
-				float[].class, int[].class, long[].class, short[].class, //
-				Boolean[].class, Byte[].class, Character[].class, Double[].class, //
-				Float[].class, Integer[].class, Long[].class, Short[].class, //
-				Void[].class, //
-				Object.class, Object[].class, String[].class, //
-				Object[][].class, String[][].class, //
-				Collection.class, //
-				List.class, ArrayList.class, LinkedList.class, //
-				Set.class, HashSet.class, //
-				Map.class, HashMap.class, //
-				Collection[].class, List[].class, Set[].class, Map[].class };
+			Float.class, Integer.class, Long.class, Short.class, //
+			Void.class, //
+			String.class, //
+			Number.class, BigInteger.class, BigDecimal.class, //
+			boolean[].class, byte[].class, char[].class, double[].class, //
+			float[].class, int[].class, long[].class, short[].class, //
+			Boolean[].class, Byte[].class, Character[].class, Double[].class, //
+			Float[].class, Integer[].class, Long[].class, Short[].class, //
+			Void[].class, //
+			Object.class, Object[].class, String[].class, //
+			Object[][].class, String[][].class, //
+			Collection.class, //
+			List.class, ArrayList.class, LinkedList.class, //
+			Set.class, HashSet.class, //
+			Map.class, HashMap.class, //
+			Collection[].class, List[].class, Set[].class, Map[].class };
 		for (final Class<?> c : types) {
 			final Class<?> type = Types.box(c);
 			assertSame(c, type);
@@ -418,7 +419,7 @@ public class TypesTest {
 			Types.array(void.class);
 			fail("Unexpected success creating void[]");
 		}
-		catch (final IllegalArgumentException exc) { }
+		catch (final IllegalArgumentException exc) {}
 
 		// multidimensional cases
 		assertSame(Number[][].class, Types.array(Number.class, 2));
@@ -428,7 +429,7 @@ public class TypesTest {
 			Types.array(char.class, -1);
 			fail("Unexpected success creating negative dimensional array");
 		}
-		catch (final IllegalArgumentException exc) { }
+		catch (final IllegalArgumentException exc) {}
 	}
 
 	/** Tests {@link Types#component(Type)}. */
@@ -525,7 +526,8 @@ public class TypesTest {
 		final Type listT = new Nil<List<T>>() {}.getType();
 		final Type listNumber = new Nil<List<Number>>() {}.getType();
 		final Type listInteger = new Nil<List<Integer>>() {}.getType();
-		final Type listExtendsNumber = new Nil<List<? extends Number>>() {}.getType();
+		final Type listExtendsNumber = new Nil<List<? extends Number>>() {}
+			.getType();
 
 		assertTrue(Types.isAssignable(t, t));
 		assertTrue(Types.isAssignable(listT, listT));
@@ -946,14 +948,14 @@ public class TypesTest {
 
 	/** Enumeration for testing conversion to enum types. */
 	public static enum Words {
-		FOO, BAR, FUBAR
+			FOO, BAR, FUBAR
 	}
 
 	// -- Helper methods --
 
 	/**
 	 * Copies bytes from an {@link InputStream} to an {@link OutputStream}.
-	 * 
+	 *
 	 * @param in the source
 	 * @param out the sink
 	 * @param closeOut whether to close the sink after we're done
@@ -975,7 +977,7 @@ public class TypesTest {
 	private Class<?> loadCustomClass() {
 		// NB: The bytecode below was compiled from the following source:
 		//
-		//     public class Hello {}
+		// public class Hello {}
 		//
 		final byte[] bytecode = { -54, -2, -70, -66, 0, 0, 0, 52, 0, 13, 10, 0, 3,
 			0, 10, 7, 0, 11, 7, 0, 12, 1, 0, 6, 60, 105, 110, 105, 116, 62, 1, 0, 3,
@@ -989,6 +991,7 @@ public class TypesTest {
 			0, 1, 0, 0, 0, 1, 0, 1, 0, 8, 0, 0, 0, 2, 0, 9 };
 
 		class BytesClassLoader extends ClassLoader {
+
 			public Class<?> load(final String name, final byte[] b) {
 				return defineClass(name, b, 0, b.length);
 			}

--- a/src/test/java/org/scijava/util/TypesTest.java
+++ b/src/test/java/org/scijava/util/TypesTest.java
@@ -599,6 +599,8 @@ public class TypesTest {
 
 	// -- Helper classes --
 
+	// TODO: Migrate these helper classes into ExampleTypes.
+
 	private static class Thing<T> {
 		@SuppressWarnings("unused")
 		private T thing;


### PR DESCRIPTION
This PR adds a `Types.satisfies()`, a method to determine whether or not a set of arguments to a method can satisfy the method's parameters.  `Types.satisfies()` monitors the bounds and restrictions of any generic parameters and returns false if any argument, generic or not, does not satisfy the parameter list. This PR also adds many other methods created by @ctrueden used to manipulate various `Types`.