### PR TITLE
DataHandleService: better handling of failure states

### DIFF
--- a/src/main/java/org/scijava/io/handle/DataHandleService.java
+++ b/src/main/java/org/scijava/io/handle/DataHandleService.java
@@ -71,8 +71,9 @@ public interface DataHandleService extends
 	 *
 	 * @param location the location to test
 	 * @return The result of {@link DataHandle#exists()} on a newly created handle
-	 *         on this location
-	 * @throws IOException
+	 *         on this location. Also returns {@code false} if the handle can not
+	 *         be created.
+	 * @throws IOException if the creation of the handle fails exceptionally
 	 */
 	default boolean exists(final Location location) throws IOException {
 		try (DataHandle<Location> handle = create(location)) {
@@ -85,6 +86,8 @@ public interface DataHandleService extends
 	 * reading.
 	 *
 	 * @param handle the handle to wrap
+	 * @return The handle wrapped in a read-only buffer, or {@code null} if the
+	 *         input handle is {@code null}
 	 * @see ReadBufferDataHandle#ReadBufferDataHandle(DataHandle)
 	 */
 	default DataHandle<Location> readBuffer(final DataHandle<Location> handle) {
@@ -95,7 +98,10 @@ public interface DataHandleService extends
 	 * Creates a {@link DataHandle} on the provided {@link Location} wrapped in a
 	 * read-only buffer for accelerated reading.
 	 *
-	 * @param location the handle to wrap
+	 * @param location the Location to create a buffered handle on.
+	 * @return A {@link DataHandle} on the provided location wrapped in a
+	 *         read-only buffer, or {@code null} if no handle could be created for
+	 *         the location.
 	 * @see ReadBufferDataHandle#ReadBufferDataHandle(DataHandle)
 	 */
 	default DataHandle<Location> readBuffer(final Location location) {
@@ -108,6 +114,8 @@ public interface DataHandleService extends
 	 * accelerated writing.
 	 *
 	 * @param handle the handle to wrap
+	 * @return the handle wrapped in a write-only buffer or {@code null} if the
+	 *         provided handle is {@code null}
 	 * @see WriteBufferDataHandle#WriteBufferDataHandle(DataHandle)
 	 */
 	default DataHandle<Location> writeBuffer(final DataHandle<Location> handle) {

--- a/src/main/java/org/scijava/io/handle/DataHandleService.java
+++ b/src/main/java/org/scijava/io/handle/DataHandleService.java
@@ -33,7 +33,6 @@
 package org.scijava.io.handle;
 
 import java.io.IOException;
-import java.util.Objects;
 
 import org.scijava.io.IOService;
 import org.scijava.io.location.Location;
@@ -77,7 +76,7 @@ public interface DataHandleService extends
 	 */
 	default boolean exists(final Location location) throws IOException {
 		try (DataHandle<Location> handle = create(location)) {
-			return handle.exists();
+			return handle == null ? false : handle.exists();
 		}
 	}
 
@@ -89,8 +88,7 @@ public interface DataHandleService extends
 	 * @see ReadBufferDataHandle#ReadBufferDataHandle(DataHandle)
 	 */
 	default DataHandle<Location> readBuffer(final DataHandle<Location> handle) {
-		Objects.nonNull(handle);
-		return new ReadBufferDataHandle(handle);
+		return handle == null ? null : new ReadBufferDataHandle(handle);
 	}
 
 	/**
@@ -113,7 +111,6 @@ public interface DataHandleService extends
 	 * @see WriteBufferDataHandle#WriteBufferDataHandle(DataHandle)
 	 */
 	default DataHandle<Location> writeBuffer(final DataHandle<Location> handle) {
-		Objects.nonNull(handle);
-		return new WriteBufferDataHandle(handle);
+		return handle == null ? null : new WriteBufferDataHandle(handle);
 	}
 }


### PR DESCRIPTION
No longer throws a NullPointerException when a handle can not be created