### PR TITLE
BytesHandle: return -1 on EOF

### DIFF
--- a/src/main/java/org/scijava/io/handle/BytesHandle.java
+++ b/src/main/java/org/scijava/io/handle/BytesHandle.java
@@ -87,8 +87,12 @@ public class BytesHandle extends AbstractDataHandle<BytesLocation> {
 
 	@Override
 	public int read(final byte[] b, final int off, int len) throws IOException {
+		if(len == 0) return 0;
 		if (offset + len > length()) {
 			len = (int) (length() - offset);
+		}
+		if(len == 0) { // EOF
+			return -1;
 		}
 		bytes().getBytes(offset, b, off, len);
 		offset += len;


### PR DESCRIPTION
`BytesHandle` did not return -1 when when at the end of the stream, this is not expected behavior and additionally broke the compatibility of `BytesHandle` with other stream reading APIs (e.g. when wrapped in a `DataHandleInputStream`).