### PR TITLE
ReadBufferDataHandle: ensure pages are fully read

### DIFF
--- a/src/main/java/org/scijava/io/handle/ReadBufferDataHandle.java
+++ b/src/main/java/org/scijava/io/handle/ReadBufferDataHandle.java
@@ -167,7 +167,17 @@ public class ReadBufferDataHandle extends AbstractHigherOrderHandle<Location> {
 		if (handle().offset() != startOfPage) {
 			handle().seek(startOfPage);
 		}
-		handle().read(page);
+
+		// NB: we read repeatedly until the page is full or EOF is reached
+		// handle().read(..) might read less bytes than requested
+		int off = 0;
+		while (off < pageSize) {
+			final int read = handle().read(page, off, pageSize - off);
+			if (read == -1) { // EOF
+				break;
+			}
+			off += read;
+		}
 		return page;
 	}
 


### PR DESCRIPTION
Reading bytes with `DataHandle#read(bytes[], off, len)` results in *up
to* `len` bytes being read into the provided array.
In ReadBufferHandleDataHandle the number of read bytes was not checked,
this lead to partially filled pages resulting in read errors. Now the
reading is repeated until the page is either full or EOF is reached.