### PR TITLE
BytesLocation: Add method to set the name for the Location

### DIFF
--- a/src/main/java/org/scijava/io/location/BytesLocation.java
+++ b/src/main/java/org/scijava/io/location/BytesLocation.java
@@ -34,7 +34,6 @@ package org.scijava.io.location;
 
 import org.scijava.io.ByteArrayByteBank;
 import org.scijava.io.ByteBank;
-import org.scijava.io.handle.DataHandle;
 import org.scijava.util.ByteArray;
 
 /**
@@ -47,6 +46,8 @@ public class BytesLocation extends AbstractLocation {
 
 	private final ByteBank bytes;
 
+	private final String name;
+
 	/**
 	 * Creates a {@link BytesLocation} backed by the specified
 	 * {@link ByteBank}.
@@ -54,7 +55,18 @@ public class BytesLocation extends AbstractLocation {
 	 * @param bytes the {@link ByteBank} that will back this {@link Location}
 	 */
 	public BytesLocation(final ByteBank bytes) {
+		this(bytes, null);
+	}
+
+	/**
+	 * Creates a {@link BytesLocation} backed by the specified {@link ByteBank}.
+	 *
+	 * @param bytes the {@link ByteBank} that will back this {@link Location}
+	 * @param name the name of this {@link Location}
+	 */
+	public BytesLocation(final ByteBank bytes, final String name) {
 		this.bytes = bytes;
+		this.name = name;
 	}
 
 	/**
@@ -63,7 +75,19 @@ public class BytesLocation extends AbstractLocation {
 	 * can be used to avoid needing to grow the underlying {@link ByteBank}.
 	 */
 	public BytesLocation(final int initialCapacity) {
+		this(initialCapacity, null);
+	}
+
+	/**
+	 * Creates a {@link BytesLocation} backed by a {@link ByteArrayByteBank} with
+	 * the specified initial capacity, but with a reported size of 0. This method
+	 * can be used to avoid needing to grow the underlying {@link ByteBank}.
+	 *
+	 * @param name the name of this {@link Location}
+	 */
+	public BytesLocation(final int initialCapacity, final String name) {
 		this.bytes = new ByteArrayByteBank(initialCapacity);
+		this.name = name;
 	}
 
 	/**
@@ -71,7 +95,18 @@ public class BytesLocation extends AbstractLocation {
 	 * that wraps the specified {@link ByteArray}.
 	 */
 	public BytesLocation(final ByteArray bytes) {
+		this(bytes, null);
+	}
+
+	/**
+	 * Creates a {@link BytesLocation} backed by a {@link ByteArrayByteBank} that
+	 * wraps the specified {@link ByteArray}.
+	 *
+	 * @param name the name of this Location.
+	 */
+	public BytesLocation(final ByteArray bytes, final String name) {
 		this.bytes = new ByteArrayByteBank(bytes);
+		this.name = name;
 	}
 
 	/**
@@ -81,7 +116,19 @@ public class BytesLocation extends AbstractLocation {
 	 * @param bytes the array to wrap
 	 */
 	public BytesLocation(final byte[] bytes) {
+		this(bytes, null);
+	}
+
+	/**
+	 * Creates a {@link BytesLocation} backed by a {@link ByteArrayByteBank} which
+	 * wraps the specified array.
+	 *
+	 * @param bytes the array to wrap
+	 * @param name the name of this Location.
+	 */
+	public BytesLocation(final byte[] bytes, final String name) {
 		this.bytes = new ByteArrayByteBank(bytes);
+		this.name = name;
 	}
 
 	/**
@@ -92,11 +139,25 @@ public class BytesLocation extends AbstractLocation {
 	 * @param offset the offset in the bytes array to start copying from
 	 * @param length the number of bytes to copy, starting from the offset
 	 */
-	public BytesLocation(final byte[] bytes, final int offset,
-		final int length)
+	public BytesLocation(final byte[] bytes, final int offset, final int length) {
+		this(bytes, offset, length, null);
+	}
+
+	/**
+	 * Creates a {@link BytesLocation} backed by a {@link ByteArrayByteBank} with
+	 * the specified initial capacity and the provided data.
+	 *
+	 * @param bytes the bytes to copy into the new {@link BytesLocation}
+	 * @param offset the offset in the bytes array to start copying from
+	 * @param length the number of bytes to copy, starting from the offset
+	 * @param name the name of this Location.
+	 */
+	public BytesLocation(final byte[] bytes, final int offset, final int length,
+		final String name)
 	{
 		this.bytes = new ByteArrayByteBank(length);
 		this.bytes.setBytes(0l, bytes, offset, length);
+		this.name = name;
 	}
 
 	// -- BytesLocation methods --
@@ -104,6 +165,11 @@ public class BytesLocation extends AbstractLocation {
 	/** Gets the backing {@link ByteBank}. */
 	public ByteBank getByteBank() {
 		return bytes;
+	}
+
+	@Override
+	public String getName() {
+		return name != null ? name : defaultName();
 	}
 
 	// -- Object methods --

--- a/src/test/java/org/scijava/io/location/BytesLocationTest.java
+++ b/src/test/java/org/scijava/io/location/BytesLocationTest.java
@@ -9,13 +9,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,10 +36,12 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import org.scijava.io.ByteArrayByteBank;
+import org.scijava.util.ByteArray;
 
 /**
  * Tests {@link BytesLocation}.
- * 
+ *
  * @author Curtis Rueden
  */
 public class BytesLocationTest {
@@ -70,6 +72,33 @@ public class BytesLocationTest {
 		final byte[] expectedDigits = new byte[digits.length];
 		System.arraycopy(digits, offset, expectedDigits, 0, length);
 		assertArrayEquals(expectedDigits, testDigits);
+	}
+
+	/**
+	 * Tests getName()
+	 */
+	@Test
+	public void getNameTest() {
+
+		final BytesLocation loc1 = new BytesLocation(0);
+		assertEquals(loc1.defaultName(), loc1.getName());
+		assertEquals("Location.defaultName", loc1.defaultName());
+
+		final String expectedName = "test.name";
+		BytesLocation loc2 = new BytesLocation(0, expectedName);
+		assertEquals(expectedName, loc2.getName());
+
+		loc2 = new BytesLocation(new byte[0], expectedName);
+		assertEquals(expectedName, loc2.getName());
+
+		loc2 = new BytesLocation(new ByteArray(), expectedName);
+		assertEquals(expectedName, loc2.getName());
+
+		loc2 = new BytesLocation(new ByteArrayByteBank(), expectedName);
+		assertEquals(expectedName, loc2.getName());
+
+		loc2 = new BytesLocation(new byte[0], 0, 0, expectedName);
+		assertEquals(expectedName, loc2.getName());
 	}
 
 }


### PR DESCRIPTION
In some instances libarary users want to create a BytesLocation that has
a specific name, e.g. so that it is correctly detected by a Service that
performs a name based lookup.

This came up as a requirement several times during the fiji hackathon at it4inovations