### PR TITLE
Safeguard against null style arg in UserInterface#chooseFile

### DIFF
--- a/src/main/java/org/scijava/ui/UserInterface.java
+++ b/src/main/java/org/scijava/ui/UserInterface.java
@@ -162,9 +162,12 @@ public interface UserInterface extends RichPlugin, Disposable {
 	 */
 	default File chooseFile(final File file, final String style) {
 		final String title;
-		if (style.equals(FileWidget.DIRECTORY_STYLE)) title = "Choose a directory";
-		else if (style.equals(FileWidget.OPEN_STYLE)) title = "Open";
-		else if (style.equals(FileWidget.SAVE_STYLE)) title = "Save";
+		// style can be a string with multiple comma-separated keywords
+		// TODO use a utility class for style handling, e.g. StyleUtils.isStyle(style, ...)
+		if (style == null) title = "Choose a file";
+		else if (style.toLowerCase().contains(FileWidget.DIRECTORY_STYLE)) title = "Choose a directory";
+		else if (style.toLowerCase().contains(FileWidget.OPEN_STYLE)) title = "Open";
+		else if (style.toLowerCase().contains(FileWidget.SAVE_STYLE)) title = "Save";
 		else title = "Choose a file";
 
 		return chooseFile(title, file, style);


### PR DESCRIPTION
This fixes the issue reported by @kephale [on the forum](https://forum.image.sc/t/error-for-file-type-imagej2-parameter/25585?u=imagejan), where the absence of a `style` attribute on a `File` parameter leads to a `NullPointerException`.

This PR is just a quick fix, the method should probably be rewritten when addressing #333.
