### PR TITLE
LogMessage: Do not print null message

### DIFF
--- a/src/main/java/org/scijava/log/LogMessage.java
+++ b/src/main/java/org/scijava/log/LogMessage.java
@@ -132,7 +132,7 @@ public class LogMessage {
 		final StringWriter sw = new StringWriter();
 		final PrintWriter printer = new PrintWriter(sw);
 		printer.print("[" + LogLevel.prefix(level()) + "] ");
-		printer.println(text());
+		if(text() != null) printer.println(text());
 		if (throwable() != null) {
 			throwable().printStackTrace(printer);
 		}


### PR DESCRIPTION
* Prevent printing of log message if message is null

How to reproduce:
```
DefaultLogger log = new DefaultLogger(System.out::println, LogSource.newRoot(), LogLevel.INFO);
try {
	((Object)null).equals(null);
} catch (NullPointerException e) {
	log.error(e);
}
```
.. prints:
```
[ERROR] null
java.lang.NullPointerException
	at org.scijava.log.LogTest.run(LogTest.java:12)
```

With this PR, it prints
```
[ERROR] java.lang.NullPointerException
	at org.scijava.log.LogTest.run(LogTest.java:12)
```