### PR TITLE
Gateway: implements Disposable

### DIFF
--- a/src/main/java/org/scijava/Gateway.java
+++ b/src/main/java/org/scijava/Gateway.java
@@ -120,7 +120,7 @@ import org.scijava.widget.WidgetService;
  * @author Mark Hiner
  * @author Curtis Rueden
  */
-public interface Gateway extends RichPlugin {
+public interface Gateway extends RichPlugin, Disposable {
 
 	/**
 	 * Perform launch operations associated with this gateway.
@@ -372,4 +372,8 @@ public interface Gateway extends RichPlugin {
 	/** @see org.scijava.app.App#getInfo(boolean) */
 	String getInfo(boolean mem);
 
+	@Override
+	default void dispose() {
+		context().dispose();
+	}
 }


### PR DESCRIPTION
* make `Gateway` implement `Disposable`
* delegate `dispose()` to `context` by default

Reason: It took me a while to figure out I have to call `ij.context().dispose()` to avoid memory leaks. This would make it a bit easier to find. It was also mentioned by @ctrueden in [this forum thread](https://forum.image.sc/t/how-to-find-memory-leaks-in-plugins-what-needs-to-get-disposed/10211/14?u=frauzufall).

Could this change have any implications which might not be covered by existing tests?