### PR TITLE
Be defensive checking menu path

### DIFF
--- a/src/main/java/org/scijava/menu/ShadowMenu.java
+++ b/src/main/java/org/scijava/menu/ShadowMenu.java
@@ -493,7 +493,7 @@ public class ShadowMenu extends AbstractContextual implements
 	// -- Helper methods --
 
 	private ShadowMenu addInternal(final ModuleInfo o) {
-		if (o.getMenuPath().isEmpty()) return null; // no menu
+		if (o.getMenuPath() == null || o.getMenuPath().isEmpty()) return null; // no menu
 		return addChild(o, 0);
 	}
 


### PR DESCRIPTION
```
#@script (label='blah')
```
The above script generates an `NullPointerException`.
Can work around it with:
```
#@script (label='blah', menuPath='')
```
But the proposed fix is safer.