### PR TITLE
Add abstract delegate converter class

### DIFF
--- a/src/main/java/org/scijava/convert/AbstractDelegateConverter.java
+++ b/src/main/java/org/scijava/convert/AbstractDelegateConverter.java
@@ -1,0 +1,29 @@
+
+package org.scijava.convert;
+
+import org.scijava.plugin.Parameter;
+
+/**
+ * Abstract superclass for {@link Converter} plugins that delegate to other
+ * converters to chain two conversion steps together.
+ * 
+ * @author Jan Eglinger
+ * @param <I> the input type
+ * @param <D> the delegate type
+ * @param <O> the output type
+ */
+public abstract class AbstractDelegateConverter<I, D, O> extends
+	AbstractConverter<I, O>
+{
+
+	@Parameter
+	private ConvertService convertService;
+
+	@Override
+	public <T> T convert(Object src, Class<T> dest) {
+		D delegate = convertService.convert(src, getDelegateType());
+		return convertService.convert(delegate, dest);
+	}
+
+	protected abstract Class<D> getDelegateType();
+}

--- a/src/test/java/org/scijava/convert/DelegateConverterTest.java
+++ b/src/test/java/org/scijava/convert/DelegateConverterTest.java
@@ -1,0 +1,118 @@
+package org.scijava.convert;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.plugin.Plugin;
+
+
+public class DelegateConverterTest {
+	private Context context;
+
+	@Before
+	public void setUp() {
+		context = new Context();
+	}
+
+	@After
+	public void tearDown() {
+		context.dispose();
+		context = null;
+	}
+
+	@Test
+	public void testDelegateConverters() {
+		ConvertService convertService = context.getService(ConvertService.class);
+		
+		// Test conversion from AType to BType
+		AType a = new AType();
+		assertTrue(convertService.supports(a, BType.class));
+		BType b = convertService.convert(a, BType.class);
+		assertSame(BType.class, b.getClass());
+		
+		// Test conversion from BType to CType
+		assertTrue(convertService.supports(b, CType.class));
+		CType c = convertService.convert(b, CType.class);
+		assertSame(CType.class, c.getClass());
+
+		// Test chained conversion
+		assertTrue(convertService.supports(a, CType.class));
+		CType converted = convertService.convert(a, CType.class);
+		assertSame(c.getClass(), converted.getClass());
+	}
+
+	public static class AType {
+		// empty class
+	}
+
+	public static class BType {
+		// empty class
+	}
+
+	public static class CType {
+		// empty class
+	}
+
+	@Plugin(type=Converter.class)
+	public static class ABConverter extends AbstractConverter<AType, BType> {
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T convert(Object src, Class<T> dest) {
+			return (T) new BType();
+		}
+
+		@Override
+		public Class<BType> getOutputType() {
+			return BType.class;
+		}
+
+		@Override
+		public Class<AType> getInputType() {
+			return AType.class;
+		}		
+	}
+
+	@Plugin(type=Converter.class)
+	public static class BCConverter extends AbstractConverter<BType, CType> {
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T convert(Object src, Class<T> dest) {
+			return (T) new CType();
+		}
+
+		@Override
+		public Class<CType> getOutputType() {
+			return CType.class;
+		}
+
+		@Override
+		public Class<BType> getInputType() {
+			return BType.class;
+		}		
+	}
+
+	@Plugin(type=Converter.class)
+	public static class DelegateConverter extends AbstractDelegateConverter<AType, BType, CType> {
+
+		@Override
+		public Class<CType> getOutputType() {
+			return CType.class;
+		}
+
+		@Override
+		public Class<AType> getInputType() {
+			return AType.class;
+		}
+
+		@Override
+		protected Class<BType> getDelegateType() {
+			return BType.class;
+		}
+	}
+}


### PR DESCRIPTION
This PR closes #182 and adds `AbstractDelegateConverter` that allows to specify new converters that chain together two subsequent conversions like this:

```java
@Plugin(type = Converter.class)
public class StringToDatasetConverter extends
	AbstractDelegateConverter<String, File, Dataset>
{

	@Override
	public Class<Dataset> getOutputType() {
		return Dataset.class;
	}

	@Override
	public Class<String> getInputType() {
		return String.class;
	}

	@Override
	protected Class<File> getDelegateType() {
		return File.class;
	}
}
```

<s>I am not sure about how to implement the test: is it possible to create private nested classes that can be discovered as `Plugin`s during test time?</s>

<s>I'd appreciate some advice here if you have time, @ctrueden.</s>

**EDIT**: I think I figured it out. I force-pushed the latest commit, adding a test for the abstract class. This should now be ready for review.

Test coverage of the added classes: 100% 🙂 