### PR TITLE
DefaultDisplayService: Choose matching display with highest priority

### DIFF
--- a/src/test/java/org/scijava/display/CustomTextDisplay.java
+++ b/src/test/java/org/scijava/display/CustomTextDisplay.java
@@ -1,0 +1,16 @@
+package org.scijava.display;
+
+public class CustomTextDisplay extends AbstractDisplay<String> implements
+		TextDisplay
+{
+
+	public CustomTextDisplay() {
+		super(String.class);
+	}
+
+	@Override
+	public void append(final String text) {
+		add(text);
+	}
+
+}

--- a/src/test/java/org/scijava/display/DisplayTest.java
+++ b/src/test/java/org/scijava/display/DisplayTest.java
@@ -39,6 +39,11 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.scijava.Context;
+import org.scijava.Priority;
+import org.scijava.plugin.PluginInfo;
+import org.scijava.plugin.PluginService;
+
+import java.util.List;
 
 /**
  * Unit tests for core {@link Display} classes.
@@ -132,4 +137,20 @@ public class DisplayTest {
 		assertEquals(value, result);
 	}
 
+	@Test
+	public void testMultipleDisplaysPriorityMatch() {
+		final Context context = new Context(DisplayService.class);
+		PluginInfo<Display> info = PluginInfo.create(CustomTextDisplay.class, Display.class);
+		info.setPriority(Priority.HIGH);
+		context.service(PluginService.class).addPlugin(info);
+		final DefaultDisplayService displayService =
+				context.getService(DefaultDisplayService.class);
+		final String name = "Text";
+		final String value = "Hello";
+		List<Display<?>> matchingDisplays = displayService.getMatchingDisplays(value);
+		assertNotNull(matchingDisplays);
+		assertTrue(matchingDisplays.size() > 1);
+		Display<?> display = displayService.createDisplay(name, value);
+		assertEquals(CustomTextDisplay.class, display.getClass());
+	}
 }


### PR DESCRIPTION
I ran into issue https://github.com/scijava/scijava-common/issues/48 and though this PR does not give the user a chance to choose which display to use, it at least makes the `DefaultDisplayService` choose the one with the highest priority. 

I also added a test, but could not yet test it myself, because I get a bunch of unrelated errors with this repo which I have to investigate. But if anyone already has an opinion on this in the meantime or can try it out, let me know.