### PR TITLE
Fix javadoc of ObjectIndex

### DIFF
--- a/src/main/java/org/scijava/object/ObjectIndex.java
+++ b/src/main/java/org/scijava/object/ObjectIndex.java
@@ -63,11 +63,6 @@ import org.scijava.util.ClassUtils;
  * added to the index more than once, in which case it will appear on relevant
  * type lists multiple times.
  * </p>
- * <p>
- * Note that similar to {@link List}, it is possible for the same object to be
- * added to the index more than once, in which case it will appear on compatible
- * type lists multiple times.
- * </p>
  * 
  * @author Curtis Rueden
  */


### PR DESCRIPTION
I love the implicit irony of this (almost) duplicated paragraph, but it is indeed redundant. So let's remove it to be more concise.
