### PR TITLE
ReadBufferDataHandle: fixed calculating local offset

### DIFF
--- a/src/main/java/org/scijava/io/handle/ReadBufferDataHandle.java
+++ b/src/main/java/org/scijava/io/handle/ReadBufferDataHandle.java
@@ -185,7 +185,7 @@ public class ReadBufferDataHandle extends AbstractHigherOrderHandle<Location> {
 	 * Calculates the offset in the current page for the given global offset
 	 */
 	private int globalToLocalOffset(final long off) {
-		return (int) off % pageSize;
+		return (int) (off % pageSize);
 	}
 
 	@Override


### PR DESCRIPTION
offset should not be cast to int before modulo operation, otherwise it will return wrong value
