### PR TITLE
Respect autoFill parameter in script parameters

### DIFF
--- a/src/main/java/org/scijava/module/DefaultMutableModuleItem.java
+++ b/src/main/java/org/scijava/module/DefaultMutableModuleItem.java
@@ -54,6 +54,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	private final Type genericType;
 	private ItemIO ioType;
 	private ItemVisibility visibility;
+	private boolean autoFill;
 	private boolean required;
 	private boolean persisted;
 	private String persistKey;
@@ -88,6 +89,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 		genericType = type;
 		ioType = super.getIOType();
 		visibility = super.getVisibility();
+		autoFill = super.isAutoFill();
 		required = super.isRequired();
 		persisted = super.isPersisted();
 		persistKey = super.getPersistKey();
@@ -115,6 +117,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 		genericType = item.getGenericType();
 		ioType = item.getIOType();
 		visibility = item.getVisibility();
+		autoFill = item.isAutoFill();
 		required = item.isRequired();
 		persisted = item.isPersisted();
 		persistKey = item.getPersistKey();
@@ -144,6 +147,11 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	@Override
 	public void setVisibility(final ItemVisibility visibility) {
 		this.visibility = visibility;
+	}
+
+	@Override
+	public void setAutoFill(final boolean autoFill) {
+		this.autoFill = autoFill;
 	}
 
 	@Override
@@ -242,6 +250,11 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	@Override
 	public ItemVisibility getVisibility() {
 		return visibility;
+	}
+
+	@Override
+	public boolean isAutoFill() {
+		return autoFill;
 	}
 
 	@Override

--- a/src/main/java/org/scijava/module/MutableModuleItem.java
+++ b/src/main/java/org/scijava/module/MutableModuleItem.java
@@ -49,6 +49,8 @@ public interface MutableModuleItem<T> extends ModuleItem<T> {
 
 	void setVisibility(ItemVisibility visibility);
 
+	void setAutoFill(boolean autoFill);
+
 	void setRequired(boolean required);
 
 	void setPersisted(boolean persisted);

--- a/src/main/java/org/scijava/script/process/ParameterScriptProcessor.java
+++ b/src/main/java/org/scijava/script/process/ParameterScriptProcessor.java
@@ -270,6 +270,7 @@ public class ParameterScriptProcessor implements ScriptProcessor {
 		else if (is(k, "max")) item.setMaximumValue(as(v, item.getType()));
 		else if (is(k, "min")) item.setMinimumValue(as(v, item.getType()));
 		else if (is(k, "name")) item.setName(as(v, String.class));
+		else if (is(k, "autoFill")) item.setAutoFill(as(v, boolean.class));
 		else if (is(k, "persist")) item.setPersisted(as(v, boolean.class));
 		else if (is(k, "persistKey")) item.setPersistKey(as(v, String.class));
 		else if (is(k, "required")) item.setRequired(as(v, boolean.class));

--- a/src/test/java/org/scijava/script/ScriptInfoTest.java
+++ b/src/test/java/org/scijava/script/ScriptInfoTest.java
@@ -252,13 +252,14 @@ public class ScriptInfoTest {
 	@Test
 	public void testParameters() {
 		final String script = "" + //
-			"% @LogService(required = false) log\n" + //
-			"% @int(label=\"Slider Value\", softMin=5, softMax=15, " + //
+			"#@ LogService (required = false) log\n" + //
+			"#@ int (label=\"Slider Value\", softMin=5, softMax=15, " + //
 			"stepSize=3, value=11, style=\"slider\") sliderValue\n" + //
-			"% @String(persist = false, family='Carnivora', " + //
+			"#@ String (persist = false, family='Carnivora', " + //
 			"choices={'quick brown fox', 'lazy dog'}) animal\n" + //
-			"% @String(visibility=MESSAGE) msg\n" + //
-			"% @BOTH java.lang.StringBuilder buffer";
+			"#@ Double (autoFill = false) notAutoFilled\n" + //
+			"#@ String (visibility=MESSAGE) msg\n" + //
+			"#@BOTH java.lang.StringBuilder buffer";
 
 		final ScriptInfo info =
 			new ScriptInfo(context, "params.bsizes", new StringReader(script));
@@ -280,6 +281,9 @@ public class ScriptInfoTest {
 			null, null, null, null, null, null, null, null, animalChoices, animal);
 		assertEquals(animal.get("family"), "Carnivora"); // test custom attribute
 
+		final ModuleItem<?> notAutoFilled = info.getInput("notAutoFilled");
+		assertFalse(notAutoFilled.isAutoFill());
+
 		final ModuleItem<?> msg = info.getInput("msg");
 		assertSame(ItemVisibility.MESSAGE, msg.getVisibility());
 
@@ -288,7 +292,7 @@ public class ScriptInfoTest {
 			null, null, null, null, null, null, null, null, noChoices, buffer);
 
 		int inputCount = 0;
-		final ModuleItem<?>[] inputs = { log, sliderValue, animal, msg, buffer };
+		final ModuleItem<?>[] inputs = { log, sliderValue, animal, notAutoFilled, msg, buffer };
 		for (final ModuleItem<?> inItem : info.inputs()) {
 			assertSame(inputs[inputCount++], inItem);
 		}
@@ -404,7 +408,7 @@ public class ScriptInfoTest {
 		}
 	}
 
-	// -- Test script langauge --
+	// -- Test script language --
 
 	private static class BindingSizesEngine extends AbstractScriptEngine {
 


### PR DESCRIPTION
This adds a new method `setAutoFill(boolean)` to `MutableModuleItem` and fixes `ParameterScriptProcessor` to set the `autoFill` value according to the parameter attribute.

`ScriptInfoTest` is updated with a parameter testing `autoFill=false` that fails without the changes in this commit.

Fixes #376.
