### PR TITLE
Add WidgetStyle utility class to centralize style logic

### DIFF
--- a/src/main/java/org/scijava/widget/DefaultWidgetModel.java
+++ b/src/main/java/org/scijava/widget/DefaultWidgetModel.java
@@ -129,12 +129,7 @@ public class DefaultWidgetModel extends AbstractContextual implements WidgetMode
 
 	@Override
 	public boolean isStyle(final String style) {
-		final String widgetStyle = getItem().getWidgetStyle();
-		if (widgetStyle == null) return style == null;
-		for (final String s : widgetStyle.split(",")) {
-			if (s.equals(style)) return true;
-		}
-		return false;
+		return WidgetStyle.isStyle(getItem(), style);
 	}
 
 	@Override

--- a/src/main/java/org/scijava/widget/WidgetStyle.java
+++ b/src/main/java/org/scijava/widget/WidgetStyle.java
@@ -1,0 +1,35 @@
+package org.scijava.widget;
+
+import org.scijava.module.ModuleItem;
+
+public class WidgetStyle {
+	private WidgetStyle() {
+		// prevent instantiation of utility class
+	}
+
+	public static boolean isStyle(String widgetStyle, String target) {
+		if (widgetStyle == null || target == null)
+			return widgetStyle == target;
+		for (final String s : widgetStyle.split(",")) {
+			if (s.trim().toLowerCase().equals(target.toLowerCase())) return true;
+		}
+		return false;
+	}
+
+	public static boolean isStyle(ModuleItem<?> item, String target) {
+		return isStyle(item.getWidgetStyle(), target);
+	}
+
+	public static String[] getStyleModifiers(String widgetStyle, String target) {
+		if (widgetStyle == null || target == null)
+			return null;
+		String[] styles = widgetStyle.split(",");
+		for (String s : styles) {
+			if (s.trim().toLowerCase().startsWith(target.toLowerCase())) {
+				String suffix = s.split(":")[1];
+				return suffix.split("/");
+			}
+		}
+		return null;
+	}
+}

--- a/src/test/java/org/scijava/script/ScriptInfoTest.java
+++ b/src/test/java/org/scijava/script/ScriptInfoTest.java
@@ -65,6 +65,7 @@ import org.scijava.plugin.Plugin;
 import org.scijava.test.TestUtils;
 import org.scijava.util.DigestUtils;
 import org.scijava.util.FileUtils;
+import org.scijava.widget.WidgetStyle;
 
 /**
  * Tests {@link ScriptInfo}.
@@ -251,7 +252,7 @@ public class ScriptInfoTest {
 		final String script = "" + //
 			"#@ LogService (required = false) log\n" + //
 			"#@ int (label=\"Slider Value\", softMin=5, softMax=15, " + //
-			"stepSize=3, value=11, style=\"slider\") sliderValue\n" + //
+			"stepSize=3, value=11, style=\" slidEr,\") sliderValue\n" + //
 			"#@ String (persist = false, family='Carnivora', " + //
 			"choices={'quick brown fox', 'lazy dog'}) animal\n" + //
 			"#@ Double (autoFill = false) notAutoFilled\n" + //
@@ -269,7 +270,8 @@ public class ScriptInfoTest {
 
 		final ModuleItem<?> sliderValue = info.getInput("sliderValue");
 		assertItem("sliderValue", int.class, "Slider Value", ItemIO.INPUT, true,
-			true, null, "slider", 11, null, null, 5, 15, 3.0, noChoices, sliderValue);
+			true, null, " slidEr,", 11, null, null, 5, 15, 3.0, noChoices, sliderValue);
+		assertTrue("Case-insensitive trimmed style", WidgetStyle.isStyle(sliderValue, "slider"));
 
 		final ModuleItem<?> animal = info.getInput("animal");
 		final List<String> animalChoices = //

--- a/src/test/java/org/scijava/widget/WidgetStyleTest.java
+++ b/src/test/java/org/scijava/widget/WidgetStyleTest.java
@@ -1,0 +1,68 @@
+package org.scijava.widget;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Enclosed.class)
+public class WidgetStyleTest {
+
+	@RunWith(Parameterized.class)
+	public static class TestIsStyle {
+
+		static String[] styleStrings = { "foo, bar, someThing", " FOO, BAR, SOMEthing ", "foo  ", "  bar",
+				"trash, sOmEtHiNg", null };
+
+		static String[] stylesToTest = { "foo", "bar", "someThing", null };
+
+		static boolean[][] stylesToHave = { // foo, bar, someThing
+				new boolean[] { true, true, true, false }, new boolean[] { true, true, true, false },
+				new boolean[] { true, false, false, false }, new boolean[] { false, true, false, false },
+				new boolean[] { false, false, true, false }, new boolean[] { false, false, false, true } };
+
+		@Parameters(name = "{0}")
+		public static List<Object[]> params() {
+			return IntStream.range(0, styleStrings.length)
+					.mapToObj(i -> new Object[] { styleStrings[i], stylesToHave[i] }).collect(Collectors.toList());
+		}
+
+		@Parameter
+		public String styleString;
+
+		@Parameter(1)
+		public boolean[] targetStyles;
+
+		@Test
+		public void testSimpleStyles() {
+			for (int i = 0; i < stylesToTest.length; i++) {
+				assertEquals("style: " + stylesToTest[i], targetStyles[i],
+						WidgetStyle.isStyle(styleString, stylesToTest[i]));
+			}
+		}
+	}
+
+	public static class TestStyleModifiers {
+		@Test
+		public void testStyleModifiers() {
+			String style = "open, extensions:tiff/tif/jpeg/jpg";
+			Set<String> extensions = new HashSet<>(Arrays.asList(WidgetStyle.getStyleModifiers(style, "extensions")));
+			Set<String> expected = new HashSet<>(Arrays.asList("tiff", "jpg", "jpeg", "tif"));
+			assertEquals(expected, extensions);
+		}
+	}
+}


### PR DESCRIPTION
This pull request addresses #333 and is a first step toward fixing #197 and #382.

The methods in the new `WidgetStyle` utility class should replace `isStyle()` implementations and other case logic around (possibly multiple) style attributes of parameters in the following places:

* [ ] `scijava-ui-swing`:
  * [ ] `chooseFile` and `chooseFiles` in [`AbstractSwingUI`](https://github.com/scijava/scijava-ui-swing/blob/ac3cbb189749a3fc55d30034ba4a2f8270dcd069/src/main/java/org/scijava/ui/swing/AbstractSwingUI.java#L136-L213)
  * [ ] `createFileFilter` in [`SwingFileWidget`](https://github.com/scijava/scijava-ui-swing/blob/d0802b1a09d380898f77022b4010682cf330fc28/src/main/java/org/scijava/ui/swing/widget/SwingFileWidget.java#L195-L240)
  * [ ] some helper methods in [`SwingChoiceRadioWidget`](https://github.com/scijava/scijava-ui-swing/blob/557d79230d0f70eaae8573e242f0a02c66b07d62/src/main/java/org/scijava/ui/swing/widget/SwingChoiceRadioWidget.java#L112-L126)

* [ ] `batch-processor`:
  * [ ] `getTargetWidgetStyle` in [`FileBatchInputProvider`](https://github.com/scijava/batch-processor/blob/d5e1b3c33880014cdc907f9ebce452c795eec3f3/src/main/java/org/scijava/batch/input/FileBatchInputProvider.java#L65-L85)

* [ ] `imagej-plugins-batch`:
  * [ ] `getTargetWidgetStyle` in [`DatasetBatchInputProvider`](https://github.com/imagej/imagej-plugins-batch/blob/2d0ad6f3c87adb6bce7bc19ee9cea3f8c97e20ba/src/main/java/net/imagej/batch/input/DatasetBatchInputProvider.java#L92-L108)

* [ ] here in [`imagej-legacy`](https://github.com/imagej/imagej-legacy/blob/325fd0933778dabd6ee8c09867961c698ffe945c/src/main/java/net/imagej/legacy/plugin/MacroRecorderPostprocessor.java#L93-L98), and finally

* [ ] some places in [`scijava-ui-awt`](https://github.com/scijava/scijava-ui-awt/blob/aabb0f917069543a6f96b93c983db7cdec39932c/src/main/java/org/scijava/ui/awt/widget/AWTFileWidget.java#L110), and [three](https://github.com/scijava/scijava-ui-pivot/blob/9069fda303852da3c4a3d127b47e667350dbf391/src/main/java/org/scijava/ui/pivot/widget/PivotFileWidget.java#L103) [times](https://github.com/scijava/scijava-ui-pivot/blob/9069fda303852da3c4a3d127b47e667350dbf391/src/main/java/org/scijava/ui/pivot/widget/PivotNumberScrollBarWidget.java#L90) in [`scijava-ui-pivot`](https://github.com/scijava/scijava-ui-pivot/blob/9069fda303852da3c4a3d127b47e667350dbf391/src/main/java/org/scijava/ui/pivot/widget/PivotNumberSliderWidget.java#L88)

---

Remaining questions:

* I wasn't sure about the naming of `getStyleModifiers`. The intended use case is for styles like `"extensions:tiff/tif"` to get the list of allowed extensions, but there might be more general use cases.

* Should `getStyleModifiers` return an array of strings directly from `split("/")`? Or rather a `Set<String>` with trimmed, lower-case values?
