### PR TITLE
DefaultRecentFileService: add dispose method

### DIFF
--- a/src/main/java/org/scijava/io/DefaultRecentFileService.java
+++ b/src/main/java/org/scijava/io/DefaultRecentFileService.java
@@ -175,6 +175,11 @@ public final class DefaultRecentFileService extends AbstractService implements
 		moduleService.addModules(recentModules.values());
 	}
 
+	@Override
+	public void dispose() {
+		clear();
+	}
+
 	// -- Event handlers --
 
 	@EventHandler


### PR DESCRIPTION
I ran this loop when working on memory issues in `SCIFIO`:
```
for (int i = 0; i < 1000; i++) {
	SCIFIO scifio = new SCIFIO(new Context());
	scifio.dispose();
}
```
It was very slow in comparison to creating the Context with specific services. I narrowed it down to `new Context(RecentFileService.class))` and this patch seems to make the `RecentFileService` clean up properly on dispose.