### PR TITLE
AbstractInputHarvester: make getObjects() not return duplicates

### DIFF
--- a/src/main/java/org/scijava/widget/AbstractInputHarvester.java
+++ b/src/main/java/org/scijava/widget/AbstractInputHarvester.java
@@ -30,7 +30,9 @@
 package org.scijava.widget;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.scijava.AbstractContextual;
 import org.scijava.convert.ConvertService;
@@ -129,10 +131,10 @@ public abstract class AbstractInputHarvester<P, W> extends AbstractContextual
 	@SuppressWarnings("unchecked")
 	private List<?> getObjects(final Class<?> type) {
 		@SuppressWarnings("rawtypes")
-		List compatibleInputs =
-			new ArrayList(convertService.getCompatibleInputs(type));
+		Set compatibleInputs =
+				new HashSet(convertService.getCompatibleInputs(type));
 		compatibleInputs.addAll(objectService.getObjects(type));
-		return compatibleInputs;
+		return new ArrayList<>(compatibleInputs);
 	}
 
 }


### PR DESCRIPTION
* both the `convertService` and the `objectService` attach objects of a
given type to the result list of `AbstractInputHarvester:getObjects`
* this results into the same objects being in the list twice
* using a set avoids duplicates in the list

Example for testing:
```
@Plugin(type = Command.class)
public class TestCommand implements Command {

    @Parameter
    private Img input;

    @Parameter
    private Img input2;

    @Override
    public void run() {}

    public static void main(final String... args) throws Exception {
        final ImageJ ij = new ImageJ();
        ij.ui().showUI();
        Object img = ij.io().open("/home/random/blobs.tif");
        ij.ui().show(img);
        ij.command().run(TestCommand.class, true);
    }
}
```