### PR TITLE
Fix ReadBufferDataHandle.globalToLocalOffset()

### DIFF
--- a/src/main/java/org/scijava/io/handle/ReadBufferDataHandle.java
+++ b/src/main/java/org/scijava/io/handle/ReadBufferDataHandle.java
@@ -182,7 +182,7 @@ public class ReadBufferDataHandle extends AbstractHigherOrderHandle<Location> {
 	 * Calculates the offset in the current page for the given global offset
 	 */
 	private int globalToLocalOffset(final long off) {
-		return (int) off % pageSize;
+		return (int) (off % pageSize);
 	}
 
 	@Override


### PR DESCRIPTION
Missing parantheses broke it for off > Integer.MAX_VALUE