### PR TITLE
ScriptService: add getScript(String,String) signature

### DIFF
--- a/src/main/java/org/scijava/script/DefaultScriptService.java
+++ b/src/main/java/org/scijava/script/DefaultScriptService.java
@@ -30,6 +30,7 @@
 package org.scijava.script;
 
 import java.io.File;
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -157,6 +158,11 @@ public class DefaultScriptService extends
 	@Override
 	public ScriptInfo getScript(final File scriptFile) {
 		return getOrCreate(scriptFile);
+	}
+
+	@Override
+	public ScriptInfo getScript(final String path, final String script) {
+		return new ScriptInfo(getContext(), path, new StringReader(script));
 	}
 
 	@Override

--- a/src/main/java/org/scijava/script/ScriptService.java
+++ b/src/main/java/org/scijava/script/ScriptService.java
@@ -128,6 +128,18 @@ public interface ScriptService extends SingletonService<ScriptLanguage>,
 	ScriptInfo getScript(File scriptFile);
 
 	/**
+	 * Creates the {@link ScriptInfo} metadata for the provided script.
+	 * 
+	 * @param path
+	 *            Pseudo-path to the script file. This file does not actually need
+	 *            to exist, but rather provides a name for the script with file
+	 *            extension.
+	 * @param script
+	 *            The script contents.
+	 */
+	ScriptInfo getScript(String path, String script);
+
+	/**
 	 * Executes the script in the given file.
 	 * 
 	 * @param file File containing the script to execute.


### PR DESCRIPTION
This makes it easier to retrieve a `ScriptInfo` object from a script string (without going via `File`).

Closes #389.