### PR TITLE
DefaultThreadService: allow faster JVM shutdown

### DIFF
--- a/src/main/java/org/scijava/thread/LifeCounter.java
+++ b/src/main/java/org/scijava/thread/LifeCounter.java
@@ -1,0 +1,80 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2020 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.thread;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Keeps the JVM alive, if and only if the life count is greater than zero.
+ * <p>
+ * This is achieved by adding a shutdown hook that waits for the life count to
+ * reach zero.
+ *
+ * @author Matthias Arzt
+ */
+class LifeCounter {
+
+	private final AtomicInteger counter = new AtomicInteger();
+
+	private CountDownLatch latch = null;
+
+	/**
+	 * Creates a {@link LifeCounter}, with life count initialized to 0.
+	 * The life counter, will keep the JVM alive as long as the life count
+	 * id greater than zero.
+	 */
+	public LifeCounter() {
+		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+			latch = new CountDownLatch(1);
+			if (counter.get() > 0) try {
+				latch.await();
+			}
+			catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}));
+	}
+
+	/**
+	 * Increases the life count by one.
+	 */
+	public void increase() {
+		counter.incrementAndGet();
+	}
+
+	/**
+	 * Decrease the life count by one.
+	 */
+	public void decrease() {
+		if (counter.decrementAndGet() <= 0)
+			if (latch != null) latch.countDown();
+	}
+}

--- a/src/test/java/org/scijava/thread/DefaultThreadServiceShutdownDemo.java
+++ b/src/test/java/org/scijava/thread/DefaultThreadServiceShutdownDemo.java
@@ -1,0 +1,86 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2020 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.thread;
+
+import org.scijava.Context;
+import org.scijava.command.Command;
+import org.scijava.command.CommandService;
+import org.scijava.plugin.Parameter;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Demonstrates that the {@link DefaultThreadService} keeps the JVM alive
+ * exactly as long as required.
+ * <p>
+ * This is done by using the CommandService which internally calls the
+ * ThreadService to executes commands. The command, used as an example,
+ * recursively calls itself, to perform a countdown.
+ * <p>
+ * The rather complicated countdown example demonstrates, that everything works
+ * correctly, even for complicated commands that call sub commands.
+ *
+ * @author Matthias Arzt
+ */
+public class DefaultThreadServiceShutdownDemo {
+
+	public static void main(String... args)
+			throws ExecutionException, InterruptedException
+	{
+		Context context = new Context();
+		CommandService command = context.service(CommandService.class);
+		command.run(CountDownCommand.class, true, "count", 10);
+	}
+
+	public static class CountDownCommand implements Command {
+
+		@Parameter
+		private int count;
+
+		@Parameter
+		private CommandService commandService;
+
+		@Override
+		public void run() {
+			try {
+				if(count > 0) {
+					System.out.println("Count down: " + count);
+					Thread.sleep(1000);
+					commandService.run(CountDownCommand.class, true, "count", count - 1);
+				} else {
+					System.out.println("Hurray!");
+				}
+			}
+			catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+}


### PR DESCRIPTION
I noticed that even a simple program as the following will keep the JVM alive for several seconds:
```java
public class Main {
     public static void main(String... args) {
           new Context();
     }
}
```
This is caused by threads created by the DefaultThreadService, which run for a view seconds even after all the tasks are completed.

This PR fixes the late JVM shutdown. The threads created by DefaultThreadService are made deamon threads and will no longer block the JVM shutdown. This unfortunately causes the JVM to shutdown before all tasks submitted to ThreadService are completed. This is fixed by adding a LifeCounter, that counts the tasks submitted to ThreadService and keeps the JVM alive until all tasks are completed.