### PR TITLE
DefaultWidgetModel: check for null choicesList

### DIFF
--- a/src/main/java/org/scijava/widget/DefaultWidgetModel.java
+++ b/src/main/java/org/scijava/widget/DefaultWidgetModel.java
@@ -221,6 +221,7 @@ public class DefaultWidgetModel extends AbstractContextual implements WidgetMode
 	@Override
 	public String[] getChoices() {
 		final List<?> choicesList = item.getChoices();
+		if (choicesList == null) return null;
 		final String[] choices = new String[choicesList.size()];
 		for (int i = 0; i < choices.length; i++) {
 			choices[i] = objectService.getName(choicesList.get(i));


### PR DESCRIPTION
Let's fail fast and return null when `item.getChoices()` returns null.