### PR TITLE
Always ignore commented script parameters

### DIFF
--- a/src/main/java/org/scijava/script/process/ParameterScriptProcessor.java
+++ b/src/main/java/org/scijava/script/process/ParameterScriptProcessor.java
@@ -129,7 +129,7 @@ public class ParameterScriptProcessor implements ScriptProcessor {
 
 	@Override
 	public String process(final String line) {
-		// parse new-style parameters starting with @# anywhere in the script.
+		// parse new-style parameters starting with #@ anywhere in the script.
 		if (line.matches("^#@.*")) {
 			final int at = line.indexOf('@');
 			return process(line, line.substring(at + 1));
@@ -140,7 +140,9 @@ public class ParameterScriptProcessor implements ScriptProcessor {
 			// NB: Check if line contains an '@' with no prior alphameric
 			// characters. This assumes that only non-alphanumeric characters can
 			// be used as comment line markers.
-			if (line.matches("^[^\\w]*@.*")) {
+			// NB: In addition, to allow for commented-out new-style parameters, we exclude
+			// lines that have the new-style #@ preceded by non-alphanumeric characters.
+			if (line.matches("^[^\\w]*[^\\w#]@.*")) {
 				final int at = line.indexOf('@');
 				return process(line, line.substring(at + 1));
 			}

--- a/src/test/java/org/scijava/script/process/ParameterScriptProcessorTest.java
+++ b/src/test/java/org/scijava/script/process/ParameterScriptProcessorTest.java
@@ -1,0 +1,54 @@
+package org.scijava.script.process;
+
+import static org.junit.Assert.*;
+
+import java.io.StringReader;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.script.ScriptInfo;
+
+public class ParameterScriptProcessorTest {
+
+	private Context context;
+
+	@Before
+	public void setUp() {
+		context = new Context();
+	}
+
+	@After
+	public void tearDown() {
+		context.dispose();
+	}
+
+	@Test
+	public void testScriptParameterParsing() {
+		String script = "" + //
+				"% @String legacyStyleParameter\n" +
+				"% #@ String commentedHeaderParameter\n" +
+				"% ############## Some Comment ###########\n" +
+				"#@ String implicitInputParameter\n" +
+				"#@input String explicitInputParameter\n" +
+				"\n" +
+				"% @String legacyStyleBodyParameter\n" +
+				"% #@ String commentedBodyParameter\n" +
+				"\n" +
+				"#@output implicitlyTypedOutputParameter\n" +
+				"#@output String explicitlyTypedOutputParameter\n";
+		final ScriptInfo info = new ScriptInfo(context, ".bsizes", new StringReader(script));
+		assertEquals("legacyStyleParameter", info.getInput("legacyStyleParameter").getName());
+		assertEquals("implicitInputParameter", info.getInput("implicitInputParameter").getName());
+		assertEquals("explicitInputParameter", info.getInput("explicitInputParameter").getName());
+
+		assertEquals("implicitlyTypedOutputParameter", info.getOutput("implicitlyTypedOutputParameter").getName());
+		assertEquals("explicitlyTypedOutputParameter", info.getOutput("explicitlyTypedOutputParameter").getName());
+
+		assertNull(info.getInput("commentedHeaderParameter"));
+		assertNull(info.getInput("legacyStyleBodyParameter"));
+		assertNull(info.getInput("commentedBodyParameter"));
+	}
+
+}


### PR DESCRIPTION
Closes #398.

Before this commit, commented-out new-style (`#@`) script parameters were ignored when in the script _body_, but parsed when in the script _header_, because they matched the pattern for old-style parameter syntax.
We now explicitly omit lines with _new-style syntax preceded by non-word characters_ from being matched, so the behavior is consistent, independent of the position of the parameter in the script.

Without this change in `ParameterScriptProcessor`, the test added in this commit would fail with:

```
[ERROR]   ParameterScriptProcessorTest.testScriptParameterParsing:49 expected null, but was:<commentedHeaderParameter: required=true, persisted=true>
```
