### PR TITLE
Improve error message for missing required inputs

### DIFF
--- a/src/main/java/org/scijava/object/DefaultObjectService.java
+++ b/src/main/java/org/scijava/object/DefaultObjectService.java
@@ -29,6 +29,9 @@
 
 package org.scijava.object;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.scijava.event.EventHandler;
 import org.scijava.event.EventService;
 import org.scijava.object.event.ObjectCreatedEvent;
@@ -56,12 +59,16 @@ import org.scijava.service.Service;
 public final class DefaultObjectService extends AbstractService implements
 	ObjectService
 {
+	private static String DEFAULT_OBJECT_NAME = "an object";
 
 	@Parameter
 	private EventService eventService;
 
 	/** Index of registered objects. */
 	private NamedObjectIndex<Object> objectIndex;
+
+	/** Map of human-friendly names */
+	private Map<Class<?>, String> aliasMap = new HashMap<>();
 
 	// -- ObjectService methods --
 
@@ -73,6 +80,16 @@ public final class DefaultObjectService extends AbstractService implements
 	@Override
 	public NamedObjectIndex<Object> getIndex() {
 		return objectIndex;
+	}
+
+	@Override
+	public String getHumanFriendlyName(Class<?> c) {
+		return aliasMap.getOrDefault(c, DEFAULT_OBJECT_NAME);
+	}
+
+	@Override
+	public void addHumanFriendlyName(Class<?> c, String name) {
+		aliasMap.put(c, name);
 	}
 
 	// -- Service methods --

--- a/src/main/java/org/scijava/object/ObjectService.java
+++ b/src/main/java/org/scijava/object/ObjectService.java
@@ -98,6 +98,10 @@ public interface ObjectService extends SciJavaService {
 		eventService().publish(new ObjectsRemovedEvent(obj));
 	}
 
+	String getHumanFriendlyName(Class<?> c);
+
+	void addHumanFriendlyName(Class<?> c, String name);
+
 	// -- Deprecated methods --
 
 	/** @deprecated Use {@link #eventService()} instead. */

--- a/src/main/java/org/scijava/widget/AbstractInputHarvester.java
+++ b/src/main/java/org/scijava/widget/AbstractInputHarvester.java
@@ -119,8 +119,8 @@ public abstract class AbstractInputHarvester<P, W> extends AbstractContextual
 		}
 
 		if (item.isRequired()) {
-			throw new ModuleException("A " + type.getSimpleName() +
-				" is required but none exist.");
+			throw new ModuleException("This operation requires " + objectService.getHumanFriendlyName(type)
+					+ " of type '" + type.getSimpleName() + "', but none was found.");
 		}
 
 		// item is not required; we can skip it


### PR DESCRIPTION
Human-friendly names can be registered at runtime by calling `ObjectService#addHumanFriendlyName(Class, String)`.

Closes #412.

I am not sure about the best naming, maybe we can find a better name than `{add|get}HumanFriendlyName`.
