### PR TITLE
Fix array types with generics

### DIFF
--- a/src/main/java/org/scijava/util/Types.java
+++ b/src/main/java/org/scijava/util/Types.java
@@ -365,6 +365,8 @@ public final class Types {
 	public static Class<?> raw(final Type type) {
 		if (type == null) return null;
 		if (type instanceof Class) return (Class<?>) type;
+		if (type instanceof GenericArrayType)
+			return array(raw(((GenericArrayType) type).getGenericComponentType()));
 		final List<Class<?>> c = raws(type);
 		if (c == null || c.size() == 0) return null;
 		return c.get(0);

--- a/src/test/java/org/scijava/command/CommandArrayConverterTest.java
+++ b/src/test/java/org/scijava/command/CommandArrayConverterTest.java
@@ -1,0 +1,162 @@
+package org.scijava.command;
+
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.ItemIO;
+import org.scijava.Priority;
+import org.scijava.convert.AbstractConverter;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.*;
+
+public class CommandArrayConverterTest {
+
+    @Test
+    public void testArrayCommandRaw() throws InterruptedException,
+            ExecutionException
+    {
+        final Context context = new Context(CommandService.class);
+        final CommandService commandService = context.service(CommandService.class);
+
+        UserClass[] userObjects = new UserClass[2];
+        userObjects[0] = new UserClass("User Object 0", new Object());
+        userObjects[1] = new UserClass("User Object 1", new Object());
+
+        final CommandModule module = //
+                commandService.run(CommandRawArrayInput.class, true, "userObjects", userObjects  ).get(); //
+        assertEquals("User Object 0;User Object 1;", module.getOutput("result"));
+    }
+
+    @Test
+    public void testArrayConvertFromStringCommandRaw() throws InterruptedException,
+            ExecutionException
+    {
+        final Context context = new Context(CommandService.class);
+        final CommandService commandService = context.service(CommandService.class);
+
+        final CommandModule module = //
+                commandService.run(CommandRawArrayInput.class, true, "userObjects", "User Object 0,User Object 1"  ).get(); //
+
+        assertEquals("User Object 0;User Object 1;", module.getOutput("result"));
+    }
+
+    @Test
+    public void testArrayCommandWildcardGenerics() throws InterruptedException,
+            ExecutionException
+    {
+        final Context context = new Context(CommandService.class);
+        final CommandService commandService = context.service(CommandService.class);
+
+        UserClass[] userObjects = new UserClass[2];
+        userObjects[0] = new UserClass("User Object 0", new Object());
+        userObjects[1] = new UserClass("User Object 1", new Object());
+
+        final CommandModule module = //
+                commandService.run(CommandGenericsWildcardArrayInput.class, true, "userObjects", userObjects  ).get(); //
+        assertEquals("User Object 0;User Object 1;", module.getOutput("result"));
+    }
+
+    @Test
+    public void testArrayConvertFromStringCommandWildcardGenerics() throws InterruptedException,
+            ExecutionException
+    {
+        final Context context = new Context(CommandService.class);
+        final CommandService commandService = context.service(CommandService.class);
+
+        final CommandModule module = //
+                commandService.run(CommandGenericsWildcardArrayInput.class, true, "userObjects", "User Object 0,User Object 1"  ).get(); //
+
+        assertEquals("User Object 0;User Object 1;", module.getOutput("result"));
+    }
+
+    /** A command which uses a UserClass Raw Array parameter. */
+    @Plugin(type = Command.class)
+    public static class CommandRawArrayInput implements Command {
+
+        @Parameter
+        private UserClass[] userObjects;
+
+        @Parameter(type = ItemIO.OUTPUT)
+        private String result = "default";
+
+        @Override
+        public void run() {
+            final StringBuilder sb = new StringBuilder();
+            System.out.println("userObjects length : "+userObjects.length);
+            System.out.println("class : "+userObjects.getClass());
+            for (UserClass obj : userObjects) {
+                System.out.println("\t"+obj);
+                sb.append(obj.toString()+";");
+            }
+            result = sb.toString();
+        }
+    }
+
+    /** A command which uses a UserClass Array with generics wildcard  */
+    @Plugin(type = Command.class)
+    public static class CommandGenericsWildcardArrayInput implements Command {
+
+        @Parameter
+        private UserClass<?>[] userObjects;
+
+        @Parameter(type = ItemIO.OUTPUT)
+        private String result = "default";
+
+        @Override
+        public void run() {
+            final StringBuilder sb = new StringBuilder();
+            System.out.println("userObjects length : "+userObjects.length);
+            System.out.println("class : "+userObjects.getClass());
+            for (UserClass obj : userObjects) {
+                System.out.println("\t"+obj);
+                sb.append(obj.toString()+";");
+            }
+            result = sb.toString();
+        }
+    }
+
+    @Plugin(type = org.scijava.convert.Converter.class, priority = Priority.LOW)
+    public static class StringToUserClassConverterNoGenerics extends AbstractConverter<String, UserClass[]> {
+
+        @Override
+        public <T> T convert(Object src, Class<T> dest) {
+            String str = (String) src;
+            String[] names = str.split(",");
+            UserClass[] userObjects = new UserClass[names.length];
+            for (int index = 0; index < names.length ; index++) {
+                userObjects[index] = new UserClass(names[index], new Object());
+            }
+            return (T) userObjects;
+        }
+
+        @Override
+        public Class<UserClass[]> getOutputType() {
+            return UserClass[].class;
+        }
+
+        @Override
+        public Class<String> getInputType() {
+            return String.class;
+        }
+    }
+
+    /**
+     * Simple class to test input arrays in command
+     */
+    public static class UserClass<T> {
+
+        String name;
+
+        public UserClass(String objectName, T generic_object) {
+            name = objectName;
+        }
+
+        public String toString() {
+            return  name;
+        }
+    }
+
+}

--- a/src/test/java/org/scijava/util/GenericArrayTypesTest.java
+++ b/src/test/java/org/scijava/util/GenericArrayTypesTest.java
@@ -1,0 +1,50 @@
+package org.scijava.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import org.junit.Test;
+
+public class GenericArrayTypesTest {
+
+	@Test
+	public void testArrayFields() throws NoSuchFieldException, SecurityException {
+		Field rawField = Types.field(ClassWithFields.class, "rawListArray");
+		Field genericWildcardField = Types.field(ClassWithFields.class, "wildcardListArray");
+		Field genericTypedField = Types.field(ClassWithFields.class, "integerListArray");
+
+		Type rawFieldType = Types.fieldType(rawField, ClassWithFields.class);
+		Type genericWildcardFieldType = Types.fieldType(genericWildcardField, ClassWithFields.class);
+		Type genericTypedFieldType = Types.fieldType(genericTypedField, ClassWithFields.class);
+
+		// raw type
+		assertFalse(rawFieldType instanceof GenericArrayType);
+		assertTrue(rawFieldType instanceof Class);
+
+		// generic array types
+		assertTrue(genericWildcardFieldType instanceof GenericArrayType);
+		assertTrue(genericTypedFieldType instanceof GenericArrayType);
+
+		assertEquals(rawField.getGenericType(), rawFieldType);
+		assertEquals(genericWildcardField.getGenericType(), genericWildcardFieldType);
+		assertEquals(genericTypedField.getGenericType(), genericTypedFieldType);
+
+		assertSame(List[].class, Types.raw(rawFieldType));
+		assertSame(List[].class, Types.raw(genericWildcardFieldType));
+		assertSame(List[].class, Types.raw(genericTypedFieldType));
+	}
+
+	@SuppressWarnings({ "rawtypes", "unused" })
+	private static class ClassWithFields {
+		public List[] rawListArray;
+		public List<?>[] wildcardListArray;
+		public List<Integer>[] integerListArray;
+	}
+}

--- a/src/test/java/org/scijava/util/TypesTest.java
+++ b/src/test/java/org/scijava/util/TypesTest.java
@@ -222,6 +222,7 @@ public class TypesTest {
 			private String[][] strings;
 			private Void v;
 			private List<String> list;
+			private List<String>[] listArray;
 			private HashMap<Integer, Float> map;
 		}
 		assertSame(int[].class, raw(Struct.class, "intArray"));
@@ -229,6 +230,7 @@ public class TypesTest {
 		assertSame(String[][].class, raw(Struct.class, "strings"));
 		assertSame(Void.class, raw(Struct.class, "v"));
 		assertSame(List.class, raw(Struct.class, "list"));
+		assertSame(List[].class, raw(Struct.class, "listArray"));
 		assertSame(HashMap.class, raw(Struct.class, "map"));
 	}
 


### PR DESCRIPTION
Adds a test that reproduces the issue https://github.com/scijava/scijava-common/issues/415

The test CommandArrayConverterTest#testArrayConvertFromStringCommandWildcardGenerics currently fails