### PR TITLE
CommandInfo: allow shadowed Service parameters

### DIFF
--- a/src/main/java/org/scijava/command/CommandInfo.java
+++ b/src/main/java/org/scijava/command/CommandInfo.java
@@ -52,6 +52,7 @@ import org.scijava.module.event.ModulesUpdatedEvent;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.plugin.PluginInfo;
+import org.scijava.service.Service;
 import org.scijava.util.ClassUtils;
 import org.scijava.util.StringMaker;
 import org.scijava.util.Types;
@@ -460,7 +461,8 @@ public class CommandInfo extends PluginInfo<Command> implements ModuleInfo {
 			}
 
 			final String name = f.getName();
-			if (inputMap.containsKey(name) || outputMap.containsKey(name)) {
+			if ((inputMap.containsKey(name) || outputMap.containsKey(name))
+					&& !Service.class.isAssignableFrom(f.getType())) {
 				// NB: Shadowed parameters are bad because they are ambiguous.
 				final String error = "Invalid duplicate parameter: " + f;
 				problems.add(new ValidityProblem(error));

--- a/src/test/java/org/scijava/command/CommandInfoTest.java
+++ b/src/test/java/org/scijava/command/CommandInfoTest.java
@@ -39,10 +39,12 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Iterator;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.command.CommandInfoTest.CommandWithEnumParam.Choice;
+import org.scijava.log.LogService;
 import org.scijava.module.ModuleItem;
 import org.scijava.plugin.Parameter;
 
@@ -53,12 +55,18 @@ import org.scijava.plugin.Parameter;
  */
 public class CommandInfoTest {
 
+	private Context ctx;
 	private CommandService commandService;
 
 	@Before
 	public void setUp() {
-		final Context ctx = new Context(CommandService.class);
+		ctx = new Context(CommandService.class);
 		commandService = ctx.getService(CommandService.class);
+	}
+
+	@After
+	public void tearDown() {
+		ctx.dispose();
 	}
 
 	@Test
@@ -88,6 +96,12 @@ public class CommandInfoTest {
 			choice.getChoices());
 	}
 
+	@Test
+	public void testDuplicateServiceParameters() {
+		CommandInfo commandInfo = new CommandInfo(ExtendedServiceCommand.class);
+		assertTrue(commandInfo.isValid());
+	}
+
 	// -- Helper classes --
 
 	/** A command with an enum parameter. */
@@ -110,6 +124,28 @@ public class CommandInfoTest {
 		@Override
 		public void run() {
 			// NB: No implementation needed.
+		}
+	}
+
+	private static class ServiceCommand implements Command {
+
+		@Parameter
+		private LogService logService;
+
+		@Override
+		public void run() {
+			// do nothing
+		}
+	}
+
+	private static class ExtendedServiceCommand extends ServiceCommand {
+
+		@Parameter
+		private LogService logService;
+
+		@Override
+		public void run() {
+			// do nothing
 		}
 	}
 }


### PR DESCRIPTION
When a `Command` extends another `Command`, we often have both classes use specific services.
It's better to be able to name these `Service` parameters consistently, than to avoid shadowing parameters at all costs. So let's exclude all `Service` parameters from the validity check.

Closes #408.