### PR TITLE
Add NameService and NameProvider

### DIFF
--- a/src/main/java/org/scijava/names/NameProvider.java
+++ b/src/main/java/org/scijava/names/NameProvider.java
@@ -1,0 +1,12 @@
+package org.scijava.names;
+
+import org.scijava.plugin.HandlerPlugin;
+
+public interface NameProvider extends HandlerPlugin<Object> {
+	public String getName(Object thing);
+
+	@Override
+	default Class<Object> getType() {
+		return Object.class;
+	}
+}

--- a/src/main/java/org/scijava/names/NameService.java
+++ b/src/main/java/org/scijava/names/NameService.java
@@ -1,0 +1,27 @@
+package org.scijava.names;
+
+import org.scijava.plugin.AbstractHandlerService;
+import org.scijava.plugin.HandlerService;
+import org.scijava.plugin.Plugin;
+import org.scijava.service.SciJavaService;
+import org.scijava.service.Service;
+
+@Plugin(type=Service.class)
+public class NameService extends AbstractHandlerService<Object, NameProvider> implements HandlerService<Object, NameProvider>, SciJavaService {
+
+	@Override
+	public Class<NameProvider> getPluginType() {
+		return NameProvider.class;
+	}
+
+	@Override
+	public Class<Object> getType() {
+		return Object.class;
+	}
+
+	public String getName(Object thing) {
+		NameProvider handler = getHandler(thing);
+		if (handler == null) return null;
+		return handler.getName(thing);
+	}
+}

--- a/src/main/java/org/scijava/object/ObjectService.java
+++ b/src/main/java/org/scijava/object/ObjectService.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import org.scijava.Named;
 import org.scijava.event.EventService;
+import org.scijava.names.NameService;
 import org.scijava.object.event.ObjectsAddedEvent;
 import org.scijava.object.event.ObjectsRemovedEvent;
 import org.scijava.service.SciJavaService;
@@ -72,10 +73,15 @@ public interface ObjectService extends SciJavaService {
 		if (obj == null) throw new NullPointerException();
 		final String name = getIndex().getName(obj);
 		if (name != null) return name;
+		// Instances of Named
 		if (obj instanceof Named) {
 			final String n = ((Named) obj).getName();
 			if (n != null) return n;
 		}
+		// Objects for which a NameProvider exists
+		final String name2 = context().service(NameService.class).getName(obj);
+		if (name2 != null) return name2;
+		// Fallback
 		final String s = obj.toString();
 		if (s != null) return s;
 		return obj.getClass().getName() + "@" + Integer.toHexString(obj.hashCode());

--- a/src/test/java/org/scijava/ContextCreationTest.java
+++ b/src/test/java/org/scijava/ContextCreationTest.java
@@ -101,6 +101,7 @@ public class ContextCreationTest {
 				org.scijava.main.DefaultMainService.class,
 				org.scijava.menu.DefaultMenuService.class,
 				org.scijava.module.DefaultModuleService.class,
+				org.scijava.names.NameService.class,
 				org.scijava.object.DefaultObjectService.class,
 				org.scijava.options.DefaultOptionsService.class,
 				org.scijava.parse.DefaultParseService.class,

--- a/src/test/java/org/scijava/names/NameProviderTest.java
+++ b/src/test/java/org/scijava/names/NameProviderTest.java
@@ -1,0 +1,70 @@
+package org.scijava.names;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.plugin.AbstractHandlerPlugin;
+import org.scijava.plugin.Plugin;
+import org.scijava.plugin.PluginInfo;
+import org.scijava.plugin.PluginService;
+
+public class NameProviderTest {
+
+	private Context context;
+
+	@Before
+	public void setUp() throws Exception {
+		context = new Context();
+		context.service(PluginService.class).addPlugin(PluginInfo.create(ThirdPartyObjectNameProvider.class, NameProvider.class));
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		context.dispose();
+	}
+
+	@Test
+	public void test() {
+		String expected = "foo";
+		ThirdPartyObject foo = new ThirdPartyObject(expected);
+		NameProvider handler = context.service(NameService.class).getHandler(foo);
+		assertNotNull(handler);
+		assertEquals(expected, handler.getName(foo));
+	}
+
+	public static class ThirdPartyObjectNameProvider extends AbstractHandlerPlugin<Object> implements NameProvider {
+
+		@Override
+		public String getName(Object thing) {
+			return ((ThirdPartyObject) thing).someNonStandardMethod();
+		}
+
+		@Override
+		public boolean supports(Object thing) {
+			//System.err.println("NameProvider queried with " + thing + " of class " + thing.getClass());
+			return ThirdPartyObject.class.isAssignableFrom(thing.getClass());
+		}
+		
+	}
+
+	public static class ThirdPartyObject {
+		private String name;
+
+		public ThirdPartyObject (String name) {
+			this.name = name;
+		}
+
+		public String someNonStandardMethod() {
+			return name;
+		}
+
+		@Override
+		public String toString() {
+			return null;
+		}
+	}
+}

--- a/src/test/java/org/scijava/object/ObjectServiceTest.java
+++ b/src/test/java/org/scijava/object/ObjectServiceTest.java
@@ -37,7 +37,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.scijava.Context;
+import org.scijava.names.NameProviderTest.ThirdPartyObject;
+import org.scijava.names.NameProviderTest.ThirdPartyObjectNameProvider;
+import org.scijava.names.NameProvider;
+import org.scijava.names.NameService;
 import org.scijava.plugin.PluginInfo;
+import org.scijava.plugin.PluginService;
 import org.scijava.plugin.SciJavaPlugin;
 
 public class ObjectServiceTest {
@@ -47,7 +52,7 @@ public class ObjectServiceTest {
 
 	@Before
 	public void setUp() {
-		context = new Context(ObjectService.class);
+		context = new Context(ObjectService.class, NameService.class, PluginService.class);
 		objectService = context.getService(ObjectService.class);
 	}
 
@@ -64,6 +69,8 @@ public class ObjectServiceTest {
 		Object obj3 = new Double(0.3);
 		PluginInfo<SciJavaPlugin> obj4 = PluginInfo.create(TestPlugin.class, SciJavaPlugin.class);
 		obj4.setName("TestPlugin name");
+		String name5 = "Third-party object";
+		ThirdPartyObject obj5 = new ThirdPartyObject(name5);
 
 		objectService.addObject(obj1, name1);
 		assertEquals("Name of object 1", name1, objectService.getName(obj1));
@@ -74,6 +81,10 @@ public class ObjectServiceTest {
 		objectService.addObject(obj4);
 		assertNotNull(objectService.getName(obj4));
 		assertEquals("Name of object 4", obj4.getName(), objectService.getName(obj4));
+		assertNotNull(objectService.getName(obj5));
+		assertEquals("Name of object 5 before adding NameProvider", obj5.getClass().getName() + "@" + Integer.toHexString(obj5.hashCode()), objectService.getName(obj5));
+		context.service(PluginService.class).addPlugin(PluginInfo.create(ThirdPartyObjectNameProvider.class, NameProvider.class));
+		assertEquals("Name of object 5 after adding NameProvider", obj5.someNonStandardMethod(), objectService.getName(obj5));
 
 		assertTrue("Object 1 registered", objectService.getObjects(Object.class).contains(obj1));
 		assertTrue("Object 2 registered", objectService.getObjects(Object.class).contains(obj2));


### PR DESCRIPTION
This allows to define a way to derive names from objects of third party libraries, e.g. for use in `ObjectService`, where objects are registered with a name and can be provided e.g. in a drop-down choice in the UI.

This pull request, together with https://github.com/imagej/imagej-legacy/pull/263, will resolve [this forum discussion](https://forum.image.sc/t/can-parameter-choices-annotation-be-filled-automatically/53753/5?u=imagejan) about being able to automatically populate `ij.measure.ResultsTable` inputs, provided we implement the following `ResultsTableNameProvider` in a follow-up pull request to `imagej-legacy`:

```java
package net.imagej.legacy.plugin;

import org.scijava.names.NameProvider;
import org.scijava.plugin.AbstractHandlerPlugin;
import org.scijava.plugin.Plugin;

import ij.measure.ResultsTable;

@Plugin(type=NameProvider.class)
public class ResultsTableNameProvider extends AbstractHandlerPlugin<Object> implements NameProvider {

	@Override
	public String getName(Object thing) {
		return ((ResultsTable) thing).getTitle();
	}

	@Override
	public boolean supports(Object thing) {
		return ResultsTable.class.isAssignableFrom(thing.getClass());
	}
}
```

(Suggestions welcome to make this even more concise!)

<img width="303" alt="image" src="https://user-images.githubusercontent.com/2033938/122983264-18d67980-d39c-11eb-830f-177db79684d9.png">
