### PR TITLE
Support widget groups to resolve #310

### DIFF
--- a/src/main/java/org/scijava/ItemVisibility.java
+++ b/src/main/java/org/scijava/ItemVisibility.java
@@ -61,6 +61,14 @@ public enum ItemVisibility {
 	 * intended as a message to the user (e.g., in the input harvester panel)
 	 * rather than an actual parameter to the module execution.
 	 */
-	MESSAGE
-
+	MESSAGE,
+	
+	/**
+	 * Indicates that the item's value defines the name of a widget group
+	 * (e.g., in the input harvester panel) rather than an actual parameter 
+	 * to the module execution. Widget groups organize related input widgets. 
+	 * Group members are added to a group by providing a group parameter annotation 
+	 * having the common group name.
+	 */
+	GROUP
 }

--- a/src/main/java/org/scijava/command/CommandModuleItem.java
+++ b/src/main/java/org/scijava/command/CommandModuleItem.java
@@ -134,6 +134,11 @@ public class CommandModuleItem<T> extends AbstractModuleItem<T> {
 	public String getWidgetStyle() {
 		return getParameter().style();
 	}
+	
+	@Override
+	public String getWidgetGroup() {
+		return getParameter().group();
+	}
 
 	@Override
 	public T getMinimumValue() {

--- a/src/main/java/org/scijava/command/CommandModuleItem.java
+++ b/src/main/java/org/scijava/command/CommandModuleItem.java
@@ -139,6 +139,11 @@ public class CommandModuleItem<T> extends AbstractModuleItem<T> {
 	public String getWidgetGroup() {
 		return getParameter().group();
 	}
+	
+	@Override
+	public boolean isExpanded() {
+		return getParameter().expanded();
+	}
 
 	@Override
 	public T getMinimumValue() {

--- a/src/main/java/org/scijava/module/AbstractModuleItem.java
+++ b/src/main/java/org/scijava/module/AbstractModuleItem.java
@@ -74,6 +74,7 @@ public abstract class AbstractModuleItem<T> extends AbstractBasicDetails
 		sm.append("persistKey", getPersistKey());
 		sm.append("callback", getCallback());
 		sm.append("widgetStyle", getWidgetStyle());
+		sm.append("widgetGroup", getWidgetGroup());
 		sm.append("default", getDefaultValue());
 		sm.append("min", getMinimumValue());
 		sm.append("max", getMaximumValue());
@@ -229,6 +230,11 @@ public abstract class AbstractModuleItem<T> extends AbstractBasicDetails
 
 	@Override
 	public String getWidgetStyle() {
+		return null;
+	}
+	
+	@Override
+	public String getWidgetGroup() {
 		return null;
 	}
 

--- a/src/main/java/org/scijava/module/AbstractModuleItem.java
+++ b/src/main/java/org/scijava/module/AbstractModuleItem.java
@@ -75,6 +75,7 @@ public abstract class AbstractModuleItem<T> extends AbstractBasicDetails
 		sm.append("callback", getCallback());
 		sm.append("widgetStyle", getWidgetStyle());
 		sm.append("widgetGroup", getWidgetGroup());
+		sm.append("expanded", isExpanded());
 		sm.append("default", getDefaultValue());
 		sm.append("min", getMinimumValue());
 		sm.append("max", getMaximumValue());
@@ -236,6 +237,11 @@ public abstract class AbstractModuleItem<T> extends AbstractBasicDetails
 	@Override
 	public String getWidgetGroup() {
 		return null;
+	}
+	
+	@Override
+	public boolean isExpanded() {
+		return true;
 	}
 
 	@Override

--- a/src/main/java/org/scijava/module/DefaultMutableModuleItem.java
+++ b/src/main/java/org/scijava/module/DefaultMutableModuleItem.java
@@ -60,6 +60,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	private String callback;
 	private String widgetStyle;
 	private String widgetGroup;
+	private boolean expanded;
 	private T defaultValue;
 	private T minimumValue;
 	private T maximumValue;
@@ -96,6 +97,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 		callback = super.getCallback();
 		widgetStyle = super.getWidgetStyle();
 		widgetGroup = super.getWidgetGroup();
+		expanded = super.isExpanded();
 		minimumValue = super.getMinimumValue();
 		maximumValue = super.getMaximumValue();
 		stepSize = super.getStepSize();
@@ -125,6 +127,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 		callback = item.getCallback();
 		widgetStyle = item.getWidgetStyle();
 		widgetGroup = item.getWidgetGroup();
+		expanded = item.isExpanded();
 		minimumValue = item.getMinimumValue();
 		maximumValue = item.getMaximumValue();
 		softMinimum = item.getSoftMinimum();
@@ -187,6 +190,16 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	@Override
 	public void setWidgetStyle(final String widgetStyle) {
 		this.widgetStyle = widgetStyle;
+	}
+	
+	@Override
+	public void setWidgetGroup(final String widgetGroup) {
+		this.widgetGroup = widgetGroup;
+	}
+	
+	@Override
+	public void setExpanded(final boolean expanded) {
+		this.expanded = expanded;
 	}
 
 	@Override
@@ -295,6 +308,11 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	@Override
 	public String getWidgetGroup() {
 		return widgetGroup;
+	}
+	
+	@Override
+	public boolean isExpanded() {
+		return expanded;
 	}
 
 	@Override

--- a/src/main/java/org/scijava/module/DefaultMutableModuleItem.java
+++ b/src/main/java/org/scijava/module/DefaultMutableModuleItem.java
@@ -59,6 +59,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	private String validater;
 	private String callback;
 	private String widgetStyle;
+	private String widgetGroup;
 	private T defaultValue;
 	private T minimumValue;
 	private T maximumValue;
@@ -94,6 +95,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 		validater = super.getValidater();
 		callback = super.getCallback();
 		widgetStyle = super.getWidgetStyle();
+		widgetGroup = super.getWidgetGroup();
 		minimumValue = super.getMinimumValue();
 		maximumValue = super.getMaximumValue();
 		stepSize = super.getStepSize();
@@ -122,6 +124,7 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 		validater = item.getValidater();
 		callback = item.getCallback();
 		widgetStyle = item.getWidgetStyle();
+		widgetGroup = item.getWidgetGroup();
 		minimumValue = item.getMinimumValue();
 		maximumValue = item.getMaximumValue();
 		softMinimum = item.getSoftMinimum();
@@ -287,6 +290,11 @@ public class DefaultMutableModuleItem<T> extends AbstractModuleItem<T>
 	@Override
 	public String getWidgetStyle() {
 		return widgetStyle;
+	}
+	
+	@Override
+	public String getWidgetGroup() {
+		return widgetGroup;
 	}
 
 	@Override

--- a/src/main/java/org/scijava/module/ModuleItem.java
+++ b/src/main/java/org/scijava/module/ModuleItem.java
@@ -159,6 +159,9 @@ public interface ModuleItem<T> extends BasicDetails {
 	 * the group.
 	 */
 	String getWidgetGroup();
+	
+	/** Returns the state of the widget group, expanded and visible or not expanded and hidden. */
+	boolean isExpanded();
 
 	/** Gets the default value. */
 	T getDefaultValue();

--- a/src/main/java/org/scijava/module/ModuleItem.java
+++ b/src/main/java/org/scijava/module/ModuleItem.java
@@ -153,6 +153,12 @@ public interface ModuleItem<T> extends BasicDetails {
 	 * interface.
 	 */
 	String getWidgetStyle();
+	
+	/**
+	 * Gets the name of the group the widget belongs to so it can be displayed within
+	 * the group.
+	 */
+	String getWidgetGroup();
 
 	/** Gets the default value. */
 	T getDefaultValue();

--- a/src/main/java/org/scijava/module/MutableModuleItem.java
+++ b/src/main/java/org/scijava/module/MutableModuleItem.java
@@ -61,6 +61,10 @@ public interface MutableModuleItem<T> extends ModuleItem<T> {
 	void setCallback(String callback);
 
 	void setWidgetStyle(String widgetStyle);
+	
+	void setWidgetGroup(String widgetGroup);
+	
+	void setExpanded(boolean expanded);
 
 	void setDefaultValue(T defaultValue);
 

--- a/src/main/java/org/scijava/plugin/Parameter.java
+++ b/src/main/java/org/scijava/plugin/Parameter.java
@@ -142,6 +142,9 @@ public @interface Parameter {
 	 * </p>
 	 */
 	String style() default "";
+	
+	/** Defines the widget group. */
+	String group() default "";
 
 	/** Defines the minimum allowed value (numeric parameters only). */
 	String min() default "";

--- a/src/main/java/org/scijava/plugin/Parameter.java
+++ b/src/main/java/org/scijava/plugin/Parameter.java
@@ -92,6 +92,9 @@ public @interface Parameter {
 	 * output, such as a "verbose" flag.</li>
 	 * <li>MESSAGE: parameter value is intended as a message only, not editable by
 	 * the user nor included as an input or output parameter.</li>
+	 * <li>GROUP: parameter value specifies a widget group, not editable by
+	 * the user nor included as an input or output parameter. Members are added
+	 * to the group using the group parameter annotation.</li>
 	 * </ul>
 	 */
 	ItemVisibility visibility() default ItemVisibility.NORMAL;
@@ -145,6 +148,12 @@ public @interface Parameter {
 	
 	/** Defines the widget group. */
 	String group() default "";
+	
+	/** 
+	 * Defines the state of the widget group. When true the group is expanded and visible. 
+	 * Otherwise, group members are hidden.
+	 * */
+	boolean expanded() default true;
 
 	/** Defines the minimum allowed value (numeric parameters only). */
 	String min() default "";

--- a/src/main/java/org/scijava/script/process/ParameterScriptProcessor.java
+++ b/src/main/java/org/scijava/script/process/ParameterScriptProcessor.java
@@ -277,6 +277,8 @@ public class ParameterScriptProcessor implements ScriptProcessor {
 		else if (is(k, "softMin")) item.setSoftMinimum(as(v, item.getType()));
 		else if (is(k, "stepSize")) item.setStepSize(as(v, double.class));
 		else if (is(k, "style")) item.setWidgetStyle(as(v, String.class));
+		else if (is(k, "group")) item.setWidgetGroup(as(v, String.class));
+		else if (is(k, "expanded")) item.setExpanded(as(v, boolean.class));
 		else if (is(k, "visibility")) item.setVisibility(as(v, ItemVisibility.class));
 		else if (is(k, "value")) item.setDefaultValue(as(v, item.getType()));
 		else item.set(k, v.toString());

--- a/src/main/java/org/scijava/widget/DefaultWidgetModel.java
+++ b/src/main/java/org/scijava/widget/DefaultWidgetModel.java
@@ -133,8 +133,8 @@ public class DefaultWidgetModel extends AbstractContextual implements WidgetMode
 	}
 	
 	@Override
-	public boolean isGroup(final String group) {
-		return getItem().getWidgetGroup().equals(group);
+	public String getGroup() {
+		return getItem().getWidgetGroup();
 	}
 
 	@Override

--- a/src/main/java/org/scijava/widget/DefaultWidgetModel.java
+++ b/src/main/java/org/scijava/widget/DefaultWidgetModel.java
@@ -131,6 +131,11 @@ public class DefaultWidgetModel extends AbstractContextual implements WidgetMode
 	public boolean isStyle(final String style) {
 		return WidgetStyle.isStyle(getItem(), style);
 	}
+	
+	@Override
+	public boolean isGroup(final String group) {
+		return getItem().getWidgetGroup().equals(group);
+	}
 
 	@Override
 	public Object getValue() {

--- a/src/main/java/org/scijava/widget/WidgetModel.java
+++ b/src/main/java/org/scijava/widget/WidgetModel.java
@@ -82,9 +82,11 @@ public interface WidgetModel extends Contextual {
 	boolean isStyle(String style);
 	
 	/**
-	 * Gets whether the widget is part of the group.
+	 * Gets group that the widget belongs to.
+	 * 
+	 * @return Group that the widget belongs to.
 	 */
-	boolean isGroup(String group);
+	String getGroup();
 
 	/**
 	 * Gets the current value of the module input.

--- a/src/main/java/org/scijava/widget/WidgetModel.java
+++ b/src/main/java/org/scijava/widget/WidgetModel.java
@@ -80,6 +80,11 @@ public interface WidgetModel extends Contextual {
 	 * {@code style.equals(getItem().getWidgetStyle())}.
 	 */
 	boolean isStyle(String style);
+	
+	/**
+	 * Gets whether the widget is part of the group.
+	 */
+	boolean isGroup(String group);
 
 	/**
 	 * Gets the current value of the module input.

--- a/src/test/java/org/scijava/script/ScriptInfoTest.java
+++ b/src/test/java/org/scijava/script/ScriptInfoTest.java
@@ -266,18 +266,18 @@ public class ScriptInfoTest {
 
 		final ModuleItem<?> log = info.getInput("log");
 		assertItem("log", LogService.class, null, ItemIO.INPUT, false, true, null,
-			null, null, null, null, null, null, null, noChoices, log);
+			null, null, null, null, null, null, null, null, noChoices, log);
 
 		final ModuleItem<?> sliderValue = info.getInput("sliderValue");
 		assertItem("sliderValue", int.class, "Slider Value", ItemIO.INPUT, true,
-			true, null, " slidEr,", 11, null, null, 5, 15, 3.0, noChoices, sliderValue);
+			true, null, " slidEr,", null, 11, null, null, 5, 15, 3.0, noChoices, sliderValue);
 		assertTrue("Case-insensitive trimmed style", WidgetStyle.isStyle(sliderValue, "slider"));
 
 		final ModuleItem<?> animal = info.getInput("animal");
 		final List<String> animalChoices = //
 			Arrays.asList("quick brown fox", "lazy dog");
 		assertItem("animal", String.class, null, ItemIO.INPUT, true, false,
-			null, null, null, null, null, null, null, null, animalChoices, animal);
+			null, null, null, null, null, null, null, null, null, animalChoices, animal);
 		assertEquals(animal.get("family"), "Carnivora"); // test custom attribute
 
 		final ModuleItem<?> notAutoFilled = info.getInput("notAutoFilled");
@@ -288,7 +288,7 @@ public class ScriptInfoTest {
 
 		final ModuleItem<?> buffer = info.getOutput("buffer");
 		assertItem("buffer", StringBuilder.class, null, ItemIO.BOTH, true, true,
-			null, null, null, null, null, null, null, null, noChoices, buffer);
+			null, null, null, null, null, null, null, null, null, noChoices, buffer);
 
 		int inputCount = 0;
 		final ModuleItem<?>[] inputs = { log, sliderValue, animal, notAutoFilled, msg, buffer };
@@ -367,7 +367,7 @@ public class ScriptInfoTest {
 	private void assertItem(final String name, final Class<?> type,
 		final String label, final ItemIO ioType, final boolean required,
 		final boolean persist, final String persistKey, final String style,
-		final Object value, final Object min, final Object max,
+		final String group, final Object value, final Object min, final Object max,
 		final Object softMin, final Object softMax, final Number stepSize,
 		final List<?> choices, final ModuleItem<?> item)
 	{
@@ -379,6 +379,7 @@ public class ScriptInfoTest {
 		assertEquals(persist, item.isPersisted());
 		assertEquals(persistKey, item.getPersistKey());
 		assertEquals(style, item.getWidgetStyle());
+		assertEquals(group, item.getWidgetGroup());
 		assertEquals(value, item.getDefaultValue());
 		assertEquals(min, item.getMinimumValue());
 		assertEquals(max, item.getMaximumValue());


### PR DESCRIPTION
This adds support for widget groups by adding ItemVisibility.GROUP and Parameter annotations group and expanded as well as all related implementations to interfaces and default classes.

Intended use is for the value of String Parameters with visibility GROUP to be used to create group labels. All Parameters with a matching group annotation to that value will be added to the widget group. The expanded annotation controls whether the parameters group are showing or not.
```java
@Parameter(visibility = ItemVisibility.GROUP)
private String basic = "basic";

@Parameter(group = "basic", label = "Number of ducks")
private int duckCount = 1;

@Parameter(visibility = ItemVisibility.GROUP, expanded = false)
private String advanced = "advanced";

@Parameter(group = "advanced", label = "Advanced duck typing")
private boolean advancedDuckTyping = true;

@Parameter(group = "advanced", label = "Starvation threshold")
private int starvationThreshold = 6;
```

and in scripts

```groovy
#@ String (visibility = GROUP,  value = "basic") basic
#@ Integer (label = "Number of ducks", group = "basic") duckCount
#@ String (visibility = GROUP, value = "advanced", expanded = false) advanced
#@ Boolean (label = "Advanced duck typing", value = true, group = "advanced") advancedDuckTyping
#@ Integer (label = "Starvation threshold", value = 6, group = "advanced") starvationThreshold
```
This PR supports a complete implementation of group labels that is realized in a corresponding PR in scijava-ui-swing - https://github.com/scijava/scijava-ui-swing/pull/60 and resolves issue https://github.com/scijava/scijava-common/issues/310