### PR TITLE
IOService recognizes a new 3rd state of loading data

### DIFF
--- a/src/main/java/org/scijava/io/IOService.java
+++ b/src/main/java/org/scijava/io/IOService.java
@@ -87,6 +87,15 @@ public interface IOService extends HandlerService<Location, IOPlugin<?>>,
 		return null;
 	}
 
+	/** A special type of "openned data" that can be returned by the
+	 * {@link #open(String)} and {@link #open(Location)} methods, and
+	 * that signals that data is opened outside the ImageJ2 data model.
+	 * Example is the opening of BigDataViewer's .xml files, in which case
+	 * no image is actually loaded into ImageJ2 per se, but an instance of
+	 * the BigDataViewer over the .xml file is opened/started instead.
+	 */
+	Object GOVERNING_APP_STARTED = new Object();
+
 	/**
 	 * Loads data from the given source. For extensibility, the nature of the
 	 * source is left intentionally general, but two common examples include file
@@ -95,11 +104,16 @@ public interface IOService extends HandlerService<Location, IOPlugin<?>>,
 	 * The opener to use is automatically determined based on available
 	 * {@link IOPlugin}s; see {@link #getOpener(String)}.
 	 * </p>
+	 * The opener may open the source in "external" application (e.g., in BigDataViewer)
+	 * in which case it must return {@link #GOVERNING_APP_STARTED} object (and not the
+	 * source data itself).
+	 * </p>
 	 *
 	 * @param source The source (e.g., file path) from which to data should be
 	 *          loaded.
-	 * @return An object representing the loaded data, or null if the source is
-	 *         not supported.
+	 * @return An object representing the loaded data, or {@link #GOVERNING_APP_STARTED}
+	 *         object signalling that the source was loaded into an external application,
+	 *         or null if the source is not supported.
 	 * @throws IOException if something goes wrong loading the data.
 	 */
 	Object open(String source) throws IOException;
@@ -110,10 +124,15 @@ public interface IOService extends HandlerService<Location, IOPlugin<?>>,
 	 * The opener to use is automatically determined based on available
 	 * {@link IOPlugin}s; see {@link #getOpener(Location)}.
 	 * </p>
+	 * The opener may open the source in "external" application (e.g., in BigDataViewer)
+	 * in which case it must return {@link #GOVERNING_APP_STARTED} object (and not the
+	 * source data itself).
+	 * </p>
 	 *
 	 * @param source The location from which to data should be loaded.
-	 * @return An object representing the loaded data, or null if the source is
-	 *         not supported.
+	 * @return An object representing the loaded data, or {@link #GOVERNING_APP_STARTED}
+	 *         object signalling that the source was loaded into an external application,
+	 *         or null if the source is not supported.
 	 * @throws IOException if something goes wrong loading the data.
 	 */
 	default Object open(Location source) throws IOException {


### PR DESCRIPTION
The `IOService` allows (likely among other functionalities) a client-code to be hooked into the drag&drop chain of openers. Each opener in this chain is asked if it `supportsOpen()` and `Object open(final Location source)` is called on the first opener supporting the given input.

However, the `open()` call expects data to be loaded that, in the drag&drop scenario, [is directly submitted to `uiService.show()`](https://github.com/fiji/IO/blob/3aa1c1a93abf199766c86384ab5cdb968981b841/src/main/java/HandleExtraFileTypes.java#L549-L552).

This PR attempts to solve the use case when the `open()` actually wants to use its own way of presenting the loaded data. The proposal defines a special, unique, signalling object `IOService.GOVERNING_APP_STARTED` that must be returned from the `open()` calls in such cases, that is, when 3rd party app is opened on the incoming (dropped-in) file.

This PR works in conjunction with https://github.com/fiji/IO/pull/18