### PR TITLE
Task interface and DefaultTask modifications - backward compatible

### DIFF
--- a/src/main/java/org/scijava/task/Task.java
+++ b/src/main/java/org/scijava/task/Task.java
@@ -37,25 +37,55 @@ import org.scijava.Named;
 /**
  * A self-aware job which reports its status and progress as it runs.
  *
- * @author Curtis Rueden
+ * There are two ways to use a Task object:
+ * - A job can be run asynchronously by using {@link Task#run(Runnable)}, and
+ * can report its progression from within the Runnable.
+ *
+ * - A {@link Task} object can simply be used to report in a synchronous manner
+ * the progression of a piece of code. In the case of synchronous reporting,
+ * the job is considered started when {@link Task#start()} is called and
+ * finished when {@link Task#finish()} is called. A finished job can be finished
+ * either because it is done or because it has been cancelled.
+ *
+ * A cancel callback can be set with {@link Task#setCancelCallBack(Runnable)}.
+ * The runnable argument will be executed in the case of an external event
+ * requesting a cancellation of the task - typically, if a user clicks
+ * a cancel button on the GUI, task.cancel("User cancellation requested") will
+ * be called. As a result, the task implementors should run the callback.
+ * This callback can be used to make the task aware that a cancellation
+ * has been requested, and should proceed to stop its execution.
+ *
+ * See also {@link TaskService}, {@link DefaultTask}
+ *
+ * @author Curtis Rueden, Nicolas Chiaruttini
  */
 public interface Task extends Cancelable, Named {
 
 	/**
-	 * Starts running the task.
+	 * Starts running the task - asynchronous job
 	 *
 	 * @throws IllegalStateException if the task was already started.
 	 */
 	void run(Runnable r);
 
 	/**
-	 * Waits for the task to complete.
+	 * Waits for the task to complete - asynchronous job
 	 *
 	 * @throws IllegalStateException if {@link #run} has not been called yet.
 	 * @throws InterruptedException if the task is interrupted.
 	 * @throws ExecutionException if the task throws an exception while running.
 	 */
 	void waitFor() throws InterruptedException, ExecutionException;
+
+	/**
+	 * reports that the task is started - synchronous job
+	 */
+	default void start() {}
+
+	/**
+	 * reports that the task is finished - synchronous job
+	 */
+	default void finish() {}
 
 	/** Checks whether the task has completed. */
 	boolean isDone();
@@ -102,4 +132,12 @@ public interface Task extends Cancelable, Named {
 	 * @see #getProgressMaximum()
 	 */
 	void setProgressMaximum(long max);
+
+	/**
+	 * If the task is cancelled (external call to {@link Task#cancel(String)}),
+	 * the input runnable argument should be executed by task implementors.
+	 *
+	 * @param runnable : should be executed if this task is cancelled through {@link Task#cancel(String)}
+	 */
+	default void setCancelCallBack(Runnable runnable) {}
 }

--- a/src/test/java/org/scijava/task/TaskEventTest.java
+++ b/src/test/java/org/scijava/task/TaskEventTest.java
@@ -1,0 +1,106 @@
+package org.scijava.task;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.event.EventHandler;
+import org.scijava.task.event.TaskEvent;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests whether many tasks run in parallel consistently trigger an Event
+ * when each task is started and when each task is ended.
+ *
+ * The test fails inconsistently, sometimes with a few tasks remaining, sometimes with almost all tasks remaining.
+ */
+
+public class TaskEventTest {
+
+    private TaskService taskService;
+    private TaskEventListener eventListener;
+
+    static int nTasks = 500; // Putting higher value can lead to issues because too many threads cannot be launched in parallel
+
+    @Before
+    public void setUp() {
+        final Context ctx = new Context(TaskService.class);
+        taskService = ctx.service(TaskService.class);
+        eventListener = new TaskEventListener();
+        ctx.inject(eventListener);
+    }
+
+    @After
+    public void tearDown() {
+        taskService.context().dispose();
+    }
+
+    @Test
+    public void testManyTasks() throws InterruptedException {
+        for (int i=0;i<nTasks;i++) {
+            createTask(taskService, "Task_"+i, 100, 10, 100);
+        }
+        Thread.sleep(5000);
+        assertEquals(0, eventListener.getLeftOvers().size());
+    }
+
+    public static void createTask(
+            TaskService taskService,
+            String taskName,
+            int msBeforeStart,
+            int msUpdate,
+            int msTaskDuration) {
+        Task task = taskService.createTask(taskName);
+
+        new Thread(
+                () -> {
+                    try {
+                        System.out.println("Waiting to start task "+taskName);
+                        Thread.sleep(msBeforeStart);
+
+                        // Task started
+                        task.setProgressMaximum(100);
+
+                        task.run(() -> {
+                            int totalMs = 0;
+                            while(totalMs<msTaskDuration) {
+                                try {
+                                    Thread.sleep(msUpdate);
+                                } catch (InterruptedException e) {
+                                    e.printStackTrace();
+                                }
+                                totalMs+=msUpdate;
+                                task.setProgressValue((int)(((double)totalMs/msTaskDuration)*100.0));
+                            }
+                            // Task ended
+                        });
+
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }).start();
+    }
+
+    public static class TaskEventListener {
+
+        Set<Task> tasks = new HashSet<>();
+
+        @EventHandler
+        private synchronized void onEvent(final TaskEvent evt) {
+            Task task = evt.getTask();
+            if (task.isDone()) {
+                tasks.remove(task);
+            } else {
+                tasks.add(task);
+            }
+        }
+
+        public synchronized Set<Task> getLeftOvers() {
+            return new HashSet<>(tasks);
+        }
+    }
+}


### PR DESCRIPTION
With this PR task events are published automatically when an asynchronous task (task.run(runnable)))
is started and finished. Additionally, task can be run in a synchronous manner and can trigger task events
with additional methods added to the Task interface.

This commit brings additional methods to the Task interface (empty default implementations provided):
* start and finish method: a job can notify when it is starting and ending in a synchronous manner
* setCancelCallback(runnable) method: Can be used to add a callback when a task is canceled

The DefaultTask implementation is modified:
* TaskEvent are published when start() and finish() are called (synchronous task)
* TaskEvent are published just before the runnable is started and after it is  finished
* A try finally statement is used in the async case to ensure a taskevent is sent even in the case of job execution failure
* And event is called when cancel is called, and:
  * Async job : future.cancel(true) is called, + the custom cancel callback is called, if set
  * Sync job : the custom cancel callback is called, if set

* adds a test to check whether many parallel tasks send an event when they are starting and when they are done
* documentation

See also : forum post describing the functionality: https://forum.image.sc/t/demo-and-proposal-new-progress-bars-for-fiji/64956

Draft PR for full functionality will be done in scijava-ui-swing, imagej-legacy and batch-processor