### PR TITLE
Prevent TextFormat plugins from claiming support for unknown / unsupported files

### DIFF
--- a/src/main/java/org/scijava/text/AbstractTextFormat.java
+++ b/src/main/java/org/scijava/text/AbstractTextFormat.java
@@ -32,6 +32,7 @@ package org.scijava.text;
 import java.io.File;
 
 import org.scijava.plugin.AbstractHandlerPlugin;
+import org.scijava.util.FileUtils;
 
 /**
  * Abstract superclass of {@link TextFormat} implementations.
@@ -41,5 +42,16 @@ import org.scijava.plugin.AbstractHandlerPlugin;
 public abstract class AbstractTextFormat extends AbstractHandlerPlugin<File>
 	implements TextFormat
 {
-	// NB: No implementation needed.
+        @Override
+	public boolean supports(final File file) {
+                for (final String ext : getExtensions()) {
+			if (FileUtils.getExtension(file).equalsIgnoreCase(ext)) return true;
+		}
+		return false;
+	}
+
+        @Override
+	public Class<File> getType() {
+		return File.class;
+	}
 }

--- a/src/main/java/org/scijava/text/TextFormat.java
+++ b/src/main/java/org/scijava/text/TextFormat.java
@@ -34,7 +34,6 @@ import java.util.List;
 
 import org.scijava.plugin.HandlerPlugin;
 import org.scijava.plugin.Plugin;
-import org.scijava.util.FileUtils;
 
 /**
  * {@code TextFormat} is a plugin that provides handling for a text markup
@@ -58,20 +57,4 @@ public interface TextFormat extends HandlerPlugin<File> {
 
 	/** Expresses the given text string in HTML format. */
 	String asHTML(String text);
-
-	// -- Typed methods --
-
-	@Override
-	default boolean supports(final File file) {
-		for (final String ext : getExtensions()) {
-			if (FileUtils.getExtension(file).equalsIgnoreCase(ext)) return true;
-		}
-		return false;
-	}
-
-	@Override
-	default Class<File> getType() {
-		return File.class;
-	}
-
 }

--- a/src/test/java/org/scijava/io/IOServiceTest.java
+++ b/src/test/java/org/scijava/io/IOServiceTest.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -63,6 +64,23 @@ public class IOServiceTest {
 		obj = io.open(new FileLocation(localFile));
 		assertNotNull(obj);
 		assertEquals(content, obj.toString());
+	}
+
+	@Test
+	public void testUnsupportedFile() throws IOException {
+		// create context, add dummy text format
+		final Context ctx = new Context();
+		ctx.getPluginIndex().add(new PluginInfo<>(DummyTextFormat.class, TextFormat.class));
+		final IOService io = ctx.getService(IOService.class);
+
+		// open unsupported file from resources as String
+		String localFile = getClass().getResource("test.foobar").getPath();
+		Object obj = io.open(localFile);
+		assertNull(obj);
+
+		// open unsupported file from resources as FileLocation
+		obj = io.open(new FileLocation(localFile));
+		assertNull(obj);
 	}
 
 

--- a/src/test/resources/org/scijava/io/test.foobar
+++ b/src/test/resources/org/scijava/io/test.foobar
@@ -1,0 +1,1 @@
+content


### PR DESCRIPTION
This is meant to fix one of the issues I found in fiji/fiji#303.
Without this change SCIFIO ends up using the `TextIOPlugin` for otherwise unsupported binary files.
I tried extending the existing test to cover the change and document the intend but I am not familiar with the general architecture and don't do a lot of Java so I might be missing if this has unintended consequences or might be unacceptable for other reasons.