### PR TITLE
Add a StringToNumberConverter

### DIFF
--- a/src/main/java/org/scijava/convert/StringToNumberConverter.java
+++ b/src/main/java/org/scijava/convert/StringToNumberConverter.java
@@ -1,0 +1,56 @@
+
+package org.scijava.convert;
+
+import org.scijava.plugin.Plugin;
+import org.scijava.util.Types;
+
+/**
+ * Converts a {@link String} to a {@link Number}. Currently handles all boxed
+ * and unboxed primitives, along with the Numbers. In particular,
+ * {@link String}s converted {@link Number}s are just {@link Double}s, as this
+ * features the broadest range of integers.
+ *
+ * @author Gabriel Selzer
+ */
+@Plugin(type = Converter.class)
+public class StringToNumberConverter extends AbstractConverter<String, Number> {
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T convert(Object src, Class<T> dest) {
+		// ensure type is well-behaved, rather than a primitive type
+		Class<T> saneDest = Types.box(dest);
+		if (!(src instanceof String)) throw new IllegalArgumentException(
+			"Expected src to be a String but got a " + src.getClass());
+		if (!(Number.class.isAssignableFrom(saneDest)))
+			throw new IllegalArgumentException(
+				"Expected dest to be Number.class (or a subclass of Number, or a numerical primitive), but got " +
+					saneDest);
+		String srcString = (String) src;
+		if (saneDest == Byte.class) return (T) new Byte(srcString);
+		if (saneDest == Short.class) return (T) new Short(srcString);
+		if (saneDest == Integer.class) return (T) new Integer(srcString);
+		if (saneDest == Long.class) return (T) new Long(srcString);
+		if (saneDest == Float.class) return (T) new Float(srcString);
+		if (saneDest == Double.class) return (T) new Double(srcString);
+		if (saneDest == Number.class) return (T) new Double(srcString);
+		else throw new IllegalArgumentException("Unknown destination type: " +
+			saneDest);
+	}
+
+	@Override
+	public Class<Number> getOutputType() {
+		return Number.class;
+	}
+
+	@Override
+	public Class<String> getInputType() {
+		return String.class;
+	}
+
+	@Override
+	public boolean canConvert(Object src, Class<?> dest) {
+		if (!Types.isAssignable(src.getClass(), String.class)) return false;
+		return Types.isAssignable(Types.box(dest), Number.class);
+	}
+}

--- a/src/main/java/org/scijava/convert/StringToNumberConverter.java
+++ b/src/main/java/org/scijava/convert/StringToNumberConverter.java
@@ -19,7 +19,7 @@ public class StringToNumberConverter extends AbstractConverter<String, Number> {
 	@SuppressWarnings("unchecked")
 	public <T> T convert(Object src, Class<T> dest) {
 		// ensure type is well-behaved, rather than a primitive type
-		Class<T> saneDest = Types.box(dest);
+		Class<T> saneDest = sane(dest);
 		if (!(src instanceof String)) throw new IllegalArgumentException(
 			"Expected src to be a String but got a " + src.getClass());
 		if (!(Number.class.isAssignableFrom(saneDest)))
@@ -33,7 +33,6 @@ public class StringToNumberConverter extends AbstractConverter<String, Number> {
 		if (saneDest == Long.class) return (T) new Long(srcString);
 		if (saneDest == Float.class) return (T) new Float(srcString);
 		if (saneDest == Double.class) return (T) new Double(srcString);
-		if (saneDest == Number.class) return (T) new Double(srcString);
 		else throw new IllegalArgumentException("Unknown destination type: " +
 			saneDest);
 	}
@@ -51,6 +50,22 @@ public class StringToNumberConverter extends AbstractConverter<String, Number> {
 	@Override
 	public boolean canConvert(Object src, Class<?> dest) {
 		if (!Types.isAssignable(src.getClass(), String.class)) return false;
-		return Types.isAssignable(Types.box(dest), Number.class);
+		// The only way to know if the conversion is valid is to actually do it.
+		try {
+			String srcString = (String) src;
+			sane(dest).getConstructor(String.class).newInstance(srcString);
+			return true;
+		}
+		catch (Exception e) {
+			return false;
+		}
+	}
+
+	// -- Helper functionality -- //
+
+	@SuppressWarnings("unchecked")
+	private <T> Class<T> sane(Class<T> c) {
+		if (c == Number.class) return (Class<T>) Double.class;
+		return Types.box(c);
 	}
 }

--- a/src/test/java/org/scijava/convert/StringToNumberConverterTest.java
+++ b/src/test/java/org/scijava/convert/StringToNumberConverterTest.java
@@ -1,0 +1,112 @@
+
+package org.scijava.convert;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests {@link StringToNumberConverter}
+ *
+ * @author Gabriel Selzer
+ */
+public class StringToNumberConverterTest {
+
+	Converter<String, Number> conv;
+
+	@Before
+	public void setUp() {
+		conv = new StringToNumberConverter();
+	}
+
+	@Test
+	public void stringToByteTest() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, Byte.class));
+		Assert.assertEquals(new Byte((byte) 0), conv.convert(s, Byte.class));
+	}
+
+	@Test
+	public void stringToPrimitiveByteTest() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, byte.class));
+		Assert.assertEquals(0, (int) conv.convert(s, byte.class));
+	}
+
+	@Test
+	public void stringToShortTest() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, Short.class));
+		Assert.assertEquals(new Short((short) 0), conv.convert(s, Short.class));
+	}
+
+	@Test
+	public void stringToPrimitiveShortTest() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, short.class));
+		Assert.assertEquals(0, (int) conv.convert(s, short.class));
+	}
+
+	@Test
+	public void stringToIntegerTest() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, Integer.class));
+		Assert.assertEquals(new Integer(0), conv.convert(s, Integer.class));
+	}
+
+	@Test
+	public void stringToPrimitiveIntegerTest() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, int.class));
+		Assert.assertEquals(0, (int) conv.convert(s, int.class));
+	}
+
+	@Test
+	public void stringToLongTest() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, Long.class));
+		Assert.assertEquals(new Long(0), conv.convert(s, Long.class));
+	}
+
+	@Test
+	public void stringToPrimitiveLongTest() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, long.class));
+		Assert.assertEquals(0L, (long) conv.convert(s, long.class));
+	}
+
+	@Test
+	public void stringToFloatTest() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, Float.class));
+		Assert.assertEquals(new Float(0), conv.convert(s, Float.class));
+	}
+
+	@Test
+	public void stringToPrimitiveFloat() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, float.class));
+		Assert.assertEquals(0f, conv.convert(s, float.class), 1e-6);
+	}
+
+	@Test
+	public void stringToDoubleTest() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, Double.class));
+		Assert.assertEquals(new Double(0), conv.convert(s, Double.class));
+	}
+
+	@Test
+	public void stringToPrimitiveDouble() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, double.class));
+		Assert.assertEquals(0d, conv.convert(s, double.class), 1e-6);
+	}
+
+	@Test
+	public void stringToNumberTest() {
+		String s = "0";
+		Assert.assertTrue(conv.canConvert(s, Number.class));
+		Assert.assertEquals(0d, conv.convert(s, Number.class));
+	}
+}

--- a/src/test/java/org/scijava/convert/StringToNumberConverterTest.java
+++ b/src/test/java/org/scijava/convert/StringToNumberConverterTest.java
@@ -109,4 +109,12 @@ public class StringToNumberConverterTest {
 		Assert.assertTrue(conv.canConvert(s, Number.class));
 		Assert.assertEquals(0d, conv.convert(s, Number.class));
 	}
+
+	@Test
+	public void invalidStringToNumberTest() {
+		String s = "invalid";
+		Assert.assertFalse(conv.canConvert(s, Number.class));
+		Assert.assertThrows(IllegalArgumentException.class, () -> conv.convert(s,
+			Number.class));
+	}
 }


### PR DESCRIPTION
This PR adds a `StringToNumberConverter`, a dedicated `Converter` that converts from `String`s to:
* numerical primitives
* `Number`
* `Number`'s subclasses

This is useful for imagej/imagej-ops#644