### PR TITLE
Set jna.library.path to java.library.path if not otherwise set

### DIFF
--- a/src/main/java/org/scijava/platform/DefaultPlatformService.java
+++ b/src/main/java/org/scijava/platform/DefaultPlatformService.java
@@ -59,8 +59,8 @@ public final class DefaultPlatformService extends
 		//For ImageJ or Fiji, java.library.path = ".../Fiji.app/lib/win64:.../Fiji.app/mm/win64"
 		String java_library_path = System.getProperty("java.library.path");
 		
-		//Used by Java Native Access for JBlosc, sync with java.library.path
-		if(System.getProperty("jna.library.path") == null) {
+		//Allow Java Native Access to search java.library.path for versioned shared libraries on Linux
+		if(java_library_path != null && System.getProperty("jna.library.path") == null) {
 			System.setProperty("jna.library.path", java_library_path);
 		}
 	}

--- a/src/main/java/org/scijava/platform/DefaultPlatformService.java
+++ b/src/main/java/org/scijava/platform/DefaultPlatformService.java
@@ -54,6 +54,16 @@ import org.scijava.service.Service;
 public final class DefaultPlatformService extends
 	AbstractSingletonService<Platform> implements PlatformService
 {
+	
+	static {
+		//For ImageJ or Fiji, java.library.path = ".../Fiji.app/lib/win64:.../Fiji.app/mm/win64"
+		String java_library_path = System.getProperty("java.library.path");
+		
+		//Used by Java Native Access for JBlosc, sync with java.library.path
+		if(System.getProperty("jna.library.path") == null) {
+			System.setProperty("jna.library.path", java_library_path);
+		}
+	}
 
 	@Parameter
 	private LogService log;
@@ -154,6 +164,10 @@ public final class DefaultPlatformService extends
 	@Override
 	public void initialize() {
 		super.initialize();
+		
+		//report static configuration
+		log.debug("java.library.path = " + System.getProperty("java.library.path"));
+		log.debug("jna.library.path = " + System.getProperty("jna.library.path"));
 
 		// configure target platforms
 		final List<Platform> platforms = getInstances();


### PR DESCRIPTION
If `jna.library.path` is not set, set it to be the  same as `java.library.path`.

This should fix the issue with version libraries on Linux and macOS, allowing libblosc.so.1 to be dynamically linked by JBlosc.