### PR TITLE
Set the ScriptEngineManager to use Context's loader

### DIFF
--- a/src/main/java/org/scijava/script/AdaptedScriptLanguage.java
+++ b/src/main/java/org/scijava/script/AdaptedScriptLanguage.java
@@ -35,6 +35,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
 
+import org.scijava.Context;
 import org.scijava.plugin.PluginInfo;
 
 /**
@@ -140,7 +141,7 @@ public class AdaptedScriptLanguage extends AbstractScriptLanguage {
 	// -- Helper methods --
 
 	private static ScriptEngineFactory findFactory(final String factoryName) {
-		final ScriptEngineManager manager = new ScriptEngineManager();
+		final ScriptEngineManager manager = new ScriptEngineManager(Context.getClassLoader());
 		for (final ScriptEngineFactory factory : manager.getEngineFactories()) {
 			for (final String name : factory.getNames()) {
 				if (factoryName.equals(name)) return factory;


### PR DESCRIPTION
This change fixes the issue of `ScriptLanguage` plugin creation in imagej/napari-imagej#58.

The singular change changes the way in which `AdaptedScriptLanguage`'s `ScriptEngineManager` is constructed. Previously, the no-args constructor was called. **Now**, we call the constructor taking a `ClassLoader`, and pass a `Context.getClassLoader()`.

[`new ScriptEngineManager()`](https://docs.oracle.com/javase/8/docs/api/javax/script/ScriptEngineManager.html#ScriptEngineManager--) does nothing more than call `new ScriptEngineManager(Thread.currentThread().getContextClassLoader())`.

`Context.getClassLoader()` is nothing more than this call *with a fallback for a `null` `ClassLoader`*

Thus, this change does nothing more than ensure that `ScriptEngineManager` has a `ClassLoader`, avoiding the internal fallbacks.

The only functionality we *may* lose is within `ScriptEngineManager.getServiceLoader(ClassLoader c)`. Here is the method, decompiled in IntelliJ:
```java
  private ServiceLoader<ScriptEngineFactory> getServiceLoader(ClassLoader var1) {
    return var1 != null ? ServiceLoader.load(ScriptEngineFactory.class, var1) : ServiceLoader.loadInstalled(ScriptEngineFactory.class);
  }
```
This PR will ensure that `var1` is always non-null. Thus we lose any situations where we called `ServiceLoader.loadInstalled`. But, seeing as how this method [always ignores Service Providers in the application's classpath], I don't think we ever want that behavior here? When would we ever want to avoid loading a `ScriptLanguage` that is on the application's classpath?

Do you have any concerns @ctrueden?