### PR TITLE
Add support for Number in NumberUtils

### DIFF
--- a/src/main/java/org/scijava/util/NumberUtils.java
+++ b/src/main/java/org/scijava/util/NumberUtils.java
@@ -78,6 +78,8 @@ public final class NumberUtils {
 		if (Types.isLong(type)) return Long.MIN_VALUE;
 		if (Types.isFloat(type)) return -Float.MAX_VALUE;
 		if (Types.isDouble(type)) return -Double.MAX_VALUE;
+		// Fallback for Number.class
+		if (Types.isNumber(type)) return -Double.MAX_VALUE;
 		return null;
 	}
 
@@ -88,6 +90,8 @@ public final class NumberUtils {
 		if (Types.isLong(type)) return Long.MAX_VALUE;
 		if (Types.isFloat(type)) return Float.MAX_VALUE;
 		if (Types.isDouble(type)) return Double.MAX_VALUE;
+		// Fallback for Number.class
+		if (Types.isNumber(type)) return Double.MAX_VALUE;
 		return null;
 	}
 

--- a/src/test/java/org/scijava/util/NumberUtilsTest.java
+++ b/src/test/java/org/scijava/util/NumberUtilsTest.java
@@ -1,0 +1,42 @@
+
+package org.scijava.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link NumberUtils} functionality
+ *
+ * @author Gabriel Selzer
+ */
+public class NumberUtilsTest {
+
+	/** Tests {@link NumberUtils#getMinimumNumber(Class)} */
+	@Test
+	public void testGetMinimumNumber() {
+		assertEquals(Byte.MIN_VALUE, NumberUtils.getMinimumNumber(Byte.class));
+		assertEquals(Short.MIN_VALUE, NumberUtils.getMinimumNumber(Short.class));
+		assertEquals(Integer.MIN_VALUE, NumberUtils.getMinimumNumber(
+			Integer.class));
+		assertEquals(Long.MIN_VALUE, NumberUtils.getMinimumNumber(Long.class));
+		assertEquals(-Float.MAX_VALUE, NumberUtils.getMinimumNumber(Float.class));
+		assertEquals(-Double.MAX_VALUE, NumberUtils.getMinimumNumber(Double.class));
+		// Number's minimum value should be the smallest of all the above -> Double
+		assertEquals(-Double.MAX_VALUE, NumberUtils.getMinimumNumber(Number.class));
+	}
+
+	/** Tests {@link NumberUtils#getMaximumNumber(Class)} */
+	@Test
+	public void testGetMaximumNumber() {
+		assertEquals(Byte.MAX_VALUE, NumberUtils.getMaximumNumber(Byte.class));
+		assertEquals(Short.MAX_VALUE, NumberUtils.getMaximumNumber(Short.class));
+		assertEquals(Integer.MAX_VALUE, NumberUtils.getMaximumNumber(
+			Integer.class));
+		assertEquals(Long.MAX_VALUE, NumberUtils.getMaximumNumber(Long.class));
+		assertEquals(Float.MAX_VALUE, NumberUtils.getMaximumNumber(Float.class));
+		assertEquals(Double.MAX_VALUE, NumberUtils.getMaximumNumber(Double.class));
+		// Number's minimum value should be the smallest of all the above -> Double
+		assertEquals(Double.MAX_VALUE, NumberUtils.getMaximumNumber(Number.class));
+	}
+}


### PR DESCRIPTION
This PR helps out imagej/imagej-ops#644.
It adds support for getting the minimum and maximum values of a `Number`, which will just be a `Double` because that is the largest (stock) `Number` subclass.

This PR also adds a regression test to ensure the correct behavior.