### PR TITLE
Only convert to array types when it is possible

### DIFF
--- a/src/main/java/org/scijava/convert/DefaultConverter.java
+++ b/src/main/java/org/scijava/convert/DefaultConverter.java
@@ -292,7 +292,17 @@ public class DefaultConverter extends AbstractConverter<Object, Object> {
 	public boolean canConvert(final Class<?> src, final Type dest) {
 
 		// Handle array types, including generic array types.
-		if (isArray(dest)) return true;
+		// The logic follows from the types that ArrayUtils.toCollection
+		// can convert
+		if (isArray(dest)){
+			// toCollection handles any type of Collection
+			if (Collection.class.isAssignableFrom(src)) return true;
+			// toCollection handles any type of array
+			if (src.isArray()) return true;
+			// toCollection can wrap objects into a Singleton list,
+			// but we only want to wrap up a T if the dest type is a T[].
+			return Types.isAssignable(src, Types.component(dest));
+		}
 
 		// Handle parameterized collection types.
 		if (dest instanceof ParameterizedType && isCollection(dest) &&

--- a/src/test/java/org/scijava/convert/ConvertServiceTest.java
+++ b/src/test/java/org/scijava/convert/ConvertServiceTest.java
@@ -457,7 +457,7 @@ public class ConvertServiceTest {
 	/**
 	 * Tests setting an incompatible element value for a primitive array.
 	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testBadPrimitiveArray() {
 		class Struct {
 
@@ -467,6 +467,7 @@ public class ConvertServiceTest {
 		final Struct struct = new Struct();
 
 		setFieldValue(struct, "intArray", "not an int array");
+		assertEquals(null, struct.intArray);
 	}
 
 	/**
@@ -486,7 +487,7 @@ public class ConvertServiceTest {
 
 		// Test abnormal behavior for an object array
 		setFieldValue(struct, "doubleArray", "not a double array");
-		assertEquals(null, struct.doubleArray[0]);
+		assertEquals(null, struct.doubleArray);
 
 		// Test abnormal behavior for a list
 		setFieldValue(struct, "nestedArray", "definitely not a set of char arrays");

--- a/src/test/java/org/scijava/util/ConversionUtilsTest.java
+++ b/src/test/java/org/scijava/util/ConversionUtilsTest.java
@@ -237,7 +237,6 @@ public class ConversionUtilsTest {
 	/**
 	 * Tests setting an incompatible element value for a primitive array.
 	 */
-	@Test(expected = IllegalArgumentException.class)
 	public void testBadPrimitiveArray() {
 		class Struct {
 
@@ -247,6 +246,7 @@ public class ConversionUtilsTest {
 		final Struct struct = new Struct();
 
 		setFieldValue(struct, "intArray", "not an int array");
+		assertEquals(null, struct.intArray);
 	}
 
 	/**
@@ -266,7 +266,7 @@ public class ConversionUtilsTest {
 
 		// Test abnormal behavior for an object array
 		setFieldValue(struct, "doubleArray", "not a double array");
-		assertEquals(null, struct.doubleArray[0]);
+		assertEquals(null, struct.doubleArray);
 
 		// Test abnormal behavior for a list
 		setFieldValue(struct, "nestedArray", "definitely not a set of char arrays");


### PR DESCRIPTION
This closes #448.

Instead of reporting that `DefaultConverter` can convert *anything* to an array, we only report that we can convert things that `ArrayUtils.toCollection` can actually convert into a `Collection`.

One other concern is whether the case logic might lead to action-at-a-distance errors.