### PR TITLE
DefaultIOService: Add concrete methods to resolve Location

### DIFF
--- a/src/main/java/org/scijava/io/DefaultIOService.java
+++ b/src/main/java/org/scijava/io/DefaultIOService.java
@@ -61,6 +61,24 @@ public final class DefaultIOService
 
 	@Parameter
 	private LocationService locationService;
+	
+	@Override
+	public IOPlugin<?> getOpener(final String source) throws IOException {
+		try {
+			return getOpener(locationService.resolve(source));
+		} catch (URISyntaxException e) {
+			throw new IOException(e);
+		}
+	}
+
+	@Override
+	public <D> IOPlugin<D> getSaver(D data, String destination) throws IOException {
+		try {
+			return getSaver(data, locationService.resolve(destination));
+		} catch (URISyntaxException e) {
+			throw new IOException(e);
+		}
+	}
 
 	@Override
 	public Object open(final String source) throws IOException {
@@ -112,4 +130,5 @@ public final class DefaultIOService
 			log.error("No Saver IOPlugin found for " + data.toString() + ".");
 		}
 	}
+	
 }

--- a/src/main/java/org/scijava/io/IOService.java
+++ b/src/main/java/org/scijava/io/IOService.java
@@ -31,7 +31,6 @@ package org.scijava.io;
 
 import java.io.IOException;
 
-import org.scijava.io.location.FileLocation;
 import org.scijava.io.location.Location;
 import org.scijava.plugin.HandlerService;
 import org.scijava.service.SciJavaService;
@@ -49,9 +48,7 @@ public interface IOService extends HandlerService<Location, IOPlugin<?>>,
 	 * Gets the most appropriate {@link IOPlugin} for opening data from the given
 	 * location.
 	 */
-	default IOPlugin<?> getOpener(final String source) {
-		return getOpener(new FileLocation(source));
-	}
+	IOPlugin<?> getOpener(final String source) throws IOException;
 
 	/**
 	 * Gets the most appropriate {@link IOPlugin} for opening data from the given
@@ -68,9 +65,7 @@ public interface IOService extends HandlerService<Location, IOPlugin<?>>,
 	 * Gets the most appropriate {@link IOPlugin} for saving data to the given
 	 * location.
 	 */
-	default <D> IOPlugin<D> getSaver(final D data, final String destination) {
-		return getSaver(data, new FileLocation(destination));
-	}
+	<D> IOPlugin<D> getSaver(final D data, final String destination) throws IOException;
 
 	/**
 	 * Gets the most appropriate {@link IOPlugin} for saving data to the given


### PR DESCRIPTION
Moved implementation of getOpener(String) and getSaver(String) to DefaultIOService so they can use LocationService, instead of forcing FileLocation.  

closes https://github.com/imagej/tutorials/issues/101.