### PR TITLE
Add ModuleErroredEvent for callbacks on exceptions thrown by Modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>scijava-common</artifactId>
-	<version>2.92.1-SNAPSHOT</version>
+	<version>2.93.0-SNAPSHOT</version>
 
 	<name>SciJava Common</name>
 	<description>SciJava Common is a shared library for SciJava software. It provides a plugin framework, with an extensible mechanism for service discovery, backed by its own annotation processor, so that plugins can be loaded dynamically. It is used by downstream projects in the SciJava ecosystem, such as ImageJ and SCIFIO.</description>

--- a/src/main/java/org/scijava/module/event/ModuleErroredEvent.java
+++ b/src/main/java/org/scijava/module/event/ModuleErroredEvent.java
@@ -1,0 +1,52 @@
+/*
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2023 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.module.event;
+
+import org.scijava.module.Module;
+
+/**
+ * An event indicating a module execution has thrown an exception.
+ *
+ * @author Gabriel Selzer
+ */
+public class ModuleErroredEvent extends ModuleExecutionEvent {
+
+	private final Throwable exc;
+
+	public ModuleErroredEvent(final Module module, final Throwable exc) {
+		super(module);
+		this.exc = exc;
+	}
+
+	public Throwable getException() {
+		return exc;
+	}
+
+}

--- a/src/test/java/org/scijava/module/event/ModuleErroredEventTest.java
+++ b/src/test/java/org/scijava/module/event/ModuleErroredEventTest.java
@@ -29,8 +29,9 @@
 
 package org.scijava.module.event;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -48,6 +49,7 @@ import org.scijava.module.ModuleService;
  * Tests {@link ModuleErroredEvent} behavior.
  *
  * @author Gabriel Selzer
+ * @author Curtis Rueden
  */
 public class ModuleErroredEventTest {
 
@@ -65,14 +67,14 @@ public class ModuleErroredEventTest {
 	public void testModuleErroredEvent() {
 
 		// Must be a final boolean array to be included in the below closure
-		final boolean[] caughtException = { false };
+		final Throwable[] caughtException = { null };
 
 		// Add a new EventHandler to change our state
 		final Object interestedParty = new Object() {
 
 			@EventHandler
 			void onEvent(final ModuleErroredEvent e) {
-				caughtException[0] = true;
+				caughtException[0] = e.getException();
 			}
 		};
 		es.subscribe(interestedParty);
@@ -80,7 +82,8 @@ public class ModuleErroredEventTest {
 		// Run the module, ensure we get the exception
 		assertThrows(Exception.class, //
 			() -> module.run(new TestModuleInfo(), false).get());
-		assertTrue(caughtException[0]);
+		assertNotNull(caughtException[0]);
+		assertEquals("Yay!", caughtException[0].getMessage());
 	}
 
 	static class TestModuleInfo extends AbstractModuleInfo {

--- a/src/test/java/org/scijava/module/event/ModuleErroredEventTest.java
+++ b/src/test/java/org/scijava/module/event/ModuleErroredEventTest.java
@@ -1,0 +1,114 @@
+/*-
+ * #%L
+ * SciJava Common shared library for SciJava software.
+ * %%
+ * Copyright (C) 2009 - 2023 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.module.event;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.event.EventHandler;
+import org.scijava.event.EventService;
+import org.scijava.module.AbstractModule;
+import org.scijava.module.AbstractModuleInfo;
+import org.scijava.module.Module;
+import org.scijava.module.ModuleException;
+import org.scijava.module.ModuleInfo;
+import org.scijava.module.ModuleService;
+
+/**
+ * Tests {@link ModuleErroredEvent} behavior.
+ *
+ * @author Gabriel Selzer
+ */
+public class ModuleErroredEventTest {
+
+	private EventService es;
+	private ModuleService module;
+
+	@Before
+	public void setUp() {
+		Context ctx = new Context();
+		es = ctx.getService(EventService.class);
+		module = ctx.getService(ModuleService.class);
+	}
+
+	@Test
+	public void testModuleErroredEvent() {
+
+		// Must be a final boolean array to be included in the below closure
+		final boolean[] caughtException = { false };
+
+		// Add a new EventHandler to change our state
+		es.subscribe(new Object() {
+
+			@EventHandler
+			void onEvent(final ModuleErroredEvent e) {
+				caughtException[0] = true;
+			}
+		});
+
+		// Run the module, ensure we get the exception
+		assertThrows(Exception.class, //
+			() -> module.run(new TestModuleInfo(), false).get());
+		assertTrue(caughtException[0]);
+	}
+
+	static class TestModuleInfo extends AbstractModuleInfo {
+
+		@Override
+		public String getDelegateClassName() {
+			return this.getClass().getName();
+		}
+
+		@Override
+		public Class<?> loadDelegateClass() throws ClassNotFoundException {
+			return this.getClass();
+		}
+
+		@Override
+		public Module createModule() throws ModuleException {
+			ModuleInfo thisInfo = this;
+			return new AbstractModule() {
+
+				@Override
+				public ModuleInfo getInfo() {
+					return thisInfo;
+				}
+
+				@Override
+				public void run() {
+					throw new RuntimeException("Yay!");
+				}
+			};
+		}
+	}
+}

--- a/src/test/java/org/scijava/module/event/ModuleErroredEventTest.java
+++ b/src/test/java/org/scijava/module/event/ModuleErroredEventTest.java
@@ -68,13 +68,14 @@ public class ModuleErroredEventTest {
 		final boolean[] caughtException = { false };
 
 		// Add a new EventHandler to change our state
-		es.subscribe(new Object() {
+		final Object interestedParty = new Object() {
 
 			@EventHandler
 			void onEvent(final ModuleErroredEvent e) {
 				caughtException[0] = true;
 			}
-		});
+		};
+		es.subscribe(interestedParty);
 
 		// Run the module, ensure we get the exception
 		assertThrows(Exception.class, //


### PR DESCRIPTION
This PR adds a new `ModuleEvent` subclass that is published whenever a `Module` throws an `Exception` within `ModuleRunner`.

TODO:
* [ ] Should we be subscribing to this event anywhere within SciJava Common?
* [ ] What should the bounds of the `try` be? Should they be limited to `Module.run()`, or should they stay where they are? I feel like we'd also want to know if a `Module` throws an exception within pre/post-processing, but is that failure from the `Module` or from the pre/post-processor?

Closes #452