### PR TITLE
Choose UserInterfaces smarter, ensure UIs shown when UI functionality called

### DIFF
--- a/src/main/java/org/scijava/ui/DefaultUIService.java
+++ b/src/main/java/org/scijava/ui/DefaultUIService.java
@@ -244,17 +244,17 @@ public final class DefaultUIService extends AbstractService implements
 
 	@Override
 	public void show(final Object o) {
-		getDefaultUI().show(o);
+		getVisibleUI(true).show(o);
 	}
 
 	@Override
 	public void show(final String name, final Object o) {
-		getDefaultUI().show(name, o);
+		getVisibleUI(true).show(name, o);
 	}
 
 	@Override
 	public void show(final Display<?> display) {
-		getDefaultUI().show(display);
+		getVisibleUI(true).show(display);
 	}
 
 	@Override
@@ -309,16 +309,15 @@ public final class DefaultUIService extends AbstractService implements
 		final String title, final DialogPrompt.MessageType messageType,
 		final DialogPrompt.OptionType optionType)
 	{
-		final UserInterface ui = getDefaultUI();
+		UserInterface ui = getVisibleUI(false);
 		if (ui == null) return null;
-		final DialogPrompt dialogPrompt =
-			ui.dialogPrompt(message, title, messageType, optionType);
+		final DialogPrompt dialogPrompt = ui.dialogPrompt(message, title, messageType, optionType);
 		return dialogPrompt == null ? null : dialogPrompt.prompt();
 	}
 
 	@Override
 	public File chooseFile(final File file, final String style) {
-		final UserInterface ui = getDefaultUI();
+		final UserInterface ui = getVisibleUI(true);
 		return ui == null ? null : ui.chooseFile(file, style);
 	}
 
@@ -326,19 +325,19 @@ public final class DefaultUIService extends AbstractService implements
 	public File
 		chooseFile(final String title, final File file, final String style)
 	{
-		final UserInterface ui = getDefaultUI();
+		final UserInterface ui = getVisibleUI(true);
 		return ui == null ? null : ui.chooseFile(title, file, style);
 	}
 
 	@Override
 	public File[] chooseFiles(File parent, File[] files, FileFilter filter, String style) {
-		final UserInterface ui = getDefaultUI();
+		final UserInterface ui = getVisibleUI(true);
 		return ui == null ? null : ui.chooseFiles(parent, files, filter, style);
 	}
 	
 	@Override
 	public List<File> chooseFiles(File parent, List<File> fileList, FileFilter filter, String style) {
-		final UserInterface ui = getDefaultUI();
+		final UserInterface ui = getVisibleUI(true);
 		return ui == null ? null : ui.chooseFiles(parent, fileList, filter, style);
 	}
 
@@ -346,7 +345,7 @@ public final class DefaultUIService extends AbstractService implements
 	public void showContextMenu(final String menuRoot, final Display<?> display,
 		final int x, final int y)
 	{
-		final UserInterface ui = getDefaultUI();
+		final UserInterface ui = getVisibleUI(true);
 		if (ui != null) ui.showContextMenu(menuRoot, display, x, y);
 	}
 
@@ -541,5 +540,22 @@ public final class DefaultUIService extends AbstractService implements
 
 	private String getTitle() {
 		return appService.getApp().getTitle();
+	}
+
+	private UserInterface getVisibleUI(final boolean forceShow) {
+		// finds the first (highest priority) VISIBLE UserInterface
+		// if none are visible, then we show default UI if the caller indicated so.
+		UserInterface defaultUI = getDefaultUI();
+		if (defaultUI == null) return null;
+		if (defaultUI.isVisible()) return defaultUI;
+		else if(getVisibleUIs().size() > 0) {
+			return getVisibleUIs().get(0);
+		}
+
+		if (forceShow) {
+			showUI(defaultUI);
+			return defaultUI;
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
Sometimes, user interface functionality is called on an invisble UI. This can be confusing, e.g. when modal dialogs are shown. This PR is designed to fix that, providing a new private method, `UserInterface DefaultUIService.getVisibleUI(final boolean forceShow)`, which does the following (this is what makes the most sense to me, but could be changed):
1. If the default UI is visible, return it
2. If there is *some other* UI visible, return it instead.
3. (If `foreceShow`) show the default UI and return it. Useful in e.g. `show`, where the calling functionality only makes sense with the UI open.
4. Return `null`.