### PR TITLE
ADD: SelfShowableContent - a new kind of opening outcome

### DIFF
--- a/src/main/java/org/scijava/ui/SelfShowableContent.java
+++ b/src/main/java/org/scijava/ui/SelfShowableContent.java
@@ -1,0 +1,42 @@
+package org.scijava.ui;
+
+import java.util.function.Consumer;
+
+/**
+ * Representation of an outcome after opening some input, be it a file on a drive, URL,
+ * object from a drag-and-drop event or alike. The outcome is represented with an object
+ * with the data itself, and a method that knows how to present (that means read and display)
+ * this data. The class is primarily intended for opening inputs which ImageJ2 is not normally
+ * able to open. Example of such opening outcomes are opening of a specific/proprietary data file
+ * for GUI-based applications such as BigDataViewer or Mastodon.
+ *
+ * @param <T> The particular type for the particular data.
+ *
+ * @author Curtis Rueden, Vladimir Ulman
+ */
+public class SelfShowableContent<T> {
+	private T content;
+	private Consumer<T> showAction;
+
+	/**
+	 * Binds together a particular piece of data and a method that knows how to open it.
+	 * @param content
+	 * @param showAction
+	 */
+	public SelfShowableContent(T content, Consumer<T> showAction) {
+		this.content = content;
+		this.showAction = showAction;
+	}
+
+	/** Getter of the stored data. */
+	public T content() {
+		return content;
+	}
+
+	/**
+	 * This starts the actual opening/consuming of the stored data.
+	 */
+	public void show() {
+		showAction.accept(content());
+	}
+}


### PR DESCRIPTION
It is often used in conjuction with openers that do load-and-show on their own,
as opposed to load-only-and-have-Fiji-to-show pattern.

Requires a patch on the `imagej-legacy` side... will PR there too.

Example code
```java
package sc.fiji.ome.zarr.fiji.ui;

import net.imagej.ImageJ;
import org.scijava.io.AbstractIOPlugin;
import org.scijava.io.IOPlugin;
import org.scijava.io.location.Location;
import org.scijava.plugin.Attr;
import org.scijava.plugin.Plugin;
import org.scijava.ui.SelfShowableContent;

import java.io.IOException;
import java.nio.file.Files;
import java.nio.file.Path;
import java.nio.file.Paths;

@Plugin(type = IOPlugin.class, attrs = @Attr(name = "eager"))
public class MinimalFolderOpeningExample extends AbstractIOPlugin<Object> {
	@Override
	public boolean supportsOpen(Location source) {
		System.out.println(this.getClass().getName() + " is considering the file "+source);
		//
		final Path filePath = Paths.get(source.getURI());
		boolean canOpen = Files.isDirectory(filePath) && filePath.toString().endsWith(".xyz");
		System.out.println(this.getClass().getName() + " says canOpen = " + canOpen);
		return canOpen;
	}

	@Override
	public Object open(Location source) throws IOException {
		final String message = this.getClass().getName() + " is opening the file "+source;

		return new SelfShowableContent<>(
				source.toString(),
				m -> System.out.println("I just took care of the .xyz folder: "+m)
		);
	}

	@Override
	public Class<Object> getDataType() {
		return Object.class;
	}

	public static void main(String[] args) {
		ImageJ ij = new ImageJ();
		ij.ui().showUI();
	}
}
```