### PR TITLE
Ignore empty Strings during String to FileArray conversion

### DIFF
--- a/src/main/java/org/scijava/convert/FileListConverters.java
+++ b/src/main/java/org/scijava/convert/FileListConverters.java
@@ -82,6 +82,8 @@ public class FileListConverters {
 			final String[] tokens = StringUtils.splitUnquoted((String) src, ",");
 			final List<File> fileList = new ArrayList<>();
 			for (final String filePath : tokens) {
+				if ( filePath.isEmpty() )
+					continue;
 				fileList.add(new File(filePath.replaceAll("^\"|\"$", "")));
 			}
 			return (T) fileList.toArray(new File[fileList.size()]);

--- a/src/test/java/org/scijava/convert/FileListConverterTest.java
+++ b/src/test/java/org/scijava/convert/FileListConverterTest.java
@@ -69,6 +69,7 @@ public class FileListConverterTest {
 				conv.convert(path, File[].class)[0]);
 		assertEquals("Wrong file name", new File("C:\\temp"),
 				conv.convert(path, File[].class)[1]);
+		assertEquals( 0, conv.convert( "", File[].class ).length );
 	}
 
 	@Test


### PR DESCRIPTION
* The current state of the code is that an empty String, is converted to a new File("") object initialized with an empty String
* A File object instantiated by this will be a File object with an absolute Path that is equivalent to the Path from which the application was started
* The result of this is a bit unpredictable
* This PR thus suggests that an empty String should not be converted to File object at all and not be added to the output